### PR TITLE
made the strategy enum an argument in the factory

### DIFF
--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/BasicCegarLoop.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/BasicCegarLoop.java
@@ -279,7 +279,7 @@ public class BasicCegarLoop<LETTER extends IIcfgTransition<?>> extends AbstractC
 	@Override
 	protected LBool isCounterexampleFeasible() throws AutomataOperationCanceledException {
 
-		final IRefinementStrategy<LETTER> strategy = mRefinementStrategyFactory.createStrategy(mCounterexample,
+		final IRefinementStrategy<LETTER> strategy = mRefinementStrategyFactory.createStrategy(mPref.getRefinementStrategy(), mCounterexample,
 				mAbstraction, getIteration(), getCegarLoopBenchmark());
 		try {
 			mTraceCheckAndRefinementEngine = new TraceAbstractionRefinementEngine<>(mLogger, strategy);

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/RefinementStrategyFactory.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/RefinementStrategyFactory.java
@@ -45,6 +45,7 @@ import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.Ce
 import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.CegarLoopStatisticsGenerator;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.predicates.PredicateFactory;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.preferences.TAPreferences;
+import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.preferences.TraceAbstractionPreferenceInitializer.RefinementStrategy;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.traceabstraction.singletracecheck.PredicateUnifier;
 
 /**
@@ -110,14 +111,14 @@ public class RefinementStrategyFactory<LETTER extends IIcfgTransition<?>> {
 	 *            benchmark
 	 * @return refinement strategy
 	 */
-	public IRefinementStrategy<LETTER> createStrategy(final IRun<LETTER, IPredicate, ?> counterexample,
-			final IAutomaton<LETTER, IPredicate> abstraction, final int iteration,
-			final CegarLoopStatisticsGenerator benchmark) {
+	public IRefinementStrategy<LETTER> createStrategy(final RefinementStrategy strategy,
+			final IRun<LETTER, IPredicate, ?> counterexample, final IAutomaton<LETTER, IPredicate> abstraction,
+			final int iteration, final CegarLoopStatisticsGenerator benchmark) {
 		final PredicateUnifier predicateUnifier = new PredicateUnifier(mServices,
 				mPrefs.getCfgSmtToolkit().getManagedScript(), mPredicateFactory, mInitialIcfg.getSymboltable(),
 				mPrefsConsolidation.getSimplificationTechnique(), mPrefsConsolidation.getXnfConversionTechnique());
 
-		switch (mPrefs.getRefinementStrategy()) {
+		switch (strategy) {
 		case FIXED_PREFERENCES:
 			final ManagedScript managedScript =
 					setupManagedScriptFromPreferences(mServices, mInitialIcfg, mStorage, iteration, mPrefs);


### PR DESCRIPTION
I would like to have the option to give the parrot strategy a "fallback". The user should be able to use a strategy of his choice, until some criterion is met (for example: iteration == 38) that lets the user jump in.
For the quickest implementation, it will at least be required to allow the parrot strategy to construct its fallback.

Also, appart from my requirement, I think it only makes sense to give the Factory the enum directly instead of reading it from preferences.