### PR TITLE
Simplified Refinement Engine

### DIFF
--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/TraceAbstractionRefinementEngine.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/TraceAbstractionRefinementEngine.java
@@ -127,31 +127,21 @@ public final class TraceAbstractionRefinementEngine<LETTER>
 	private LBool executeStrategy(final IRefinementStrategy<LETTER> strategy) {
 		final List<InterpolantsPreconditionPostcondition> perfectIpps = new LinkedList<>();
 		final List<InterpolantsPreconditionPostcondition> imperfectIpps = new LinkedList<>();
-		while (true) {
-			/*
-			 * check feasibility using the strategy
-			 *
-			 * NOTE: Logically, this method should be called outside the loop. However, since the result is cached,
-			 * asking the same trace checker several times does not cost much. On the plus side, the strategy does not
-			 * have to take care of exception handling if it decides to exchange the backing trace checker.
-			 */
-			final LBool feasibility = checkFeasibility(strategy);
 
-			switch (feasibility) {
-			case SAT:
-				// feasible counterexample, nothing more to do here
-				return handleFeasibleCase(strategy);
-			case UNKNOWN:
-				return handleUnknownCase(strategy, perfectIpps, imperfectIpps);
-			case UNSAT:
-				final boolean doContinue = handleInfeasibleCase(strategy, perfectIpps, imperfectIpps);
-				if (doContinue) {
-					continue;
-				}
-				return constructAutomatonFromIpps(strategy, perfectIpps, imperfectIpps);
-			default:
-				throw new IllegalArgumentException("Unknown case: " + feasibility);
+		final LBool feasibility = checkFeasibility(strategy);
+
+		switch (feasibility) {
+		case SAT:
+			// feasible counterexample, nothing more to do here
+			return handleFeasibleCase(strategy);
+		case UNKNOWN:
+			return handleUnknownCase(strategy, perfectIpps, imperfectIpps);
+		case UNSAT:
+			while (handleInfeasibleCase(strategy, perfectIpps, imperfectIpps)) {
 			}
+			return constructAutomatonFromIpps(strategy, perfectIpps, imperfectIpps);
+		default:
+			throw new IllegalArgumentException("Unknown case: " + feasibility);
 		}
 	}
 


### PR DESCRIPTION
Um eine Strategie besser verstehen zu können habe ich folgendes Bild gemalt:
![refinementengine1](https://cloud.githubusercontent.com/assets/1053417/23332165/816a08da-fb75-11e6-97af-d07b7b36bb94.jpg)


Es enthält eine Darstellung der Ausführung einer Strategie - so wie sie aktuell in der Engine implementiert ist - als state Machine.

Dabei ist mir Direkt folgendes aufgefallen:

Sobald ein TraceChecker ein mal **UNSAT** liefert, kommt man eigentlich gar nicht mehr wirklich aus dem rechten Ast zurück, denn

- Wenn die Strategie den Vertrag der im IRefinementStrategy in den Kommentaren festgehalten ist einhält, dann bleibt der TraceChecker immer der selbe (da es zu einem Aufruf von hasNextTraceChecker nur genau dann kommt, wenn der TraceChecker **UNKNOWN** geliefert hat).
- Der TraceChecker berechnet das Ergebnis (**UNSAT**) im Konstruktur nur ein mal (Matthias-Style Immutable Objekt) und der Aufruf .isCorrect() wird daher immer **UNSAT** liefern.

Dieses Verhalten ist natürlich - so wie ich die Strategien verstehe - völlig beabsichtigt:
Sobald einmal ein counterexample feasible ist, muss man nicht mehr unbedingt teure trace checker anwerfen, sondern es reicht (evtl mehrere) Sequenzen von Interpolanten zu generieren.

In der TraceAbstractionRefinementEngine.executeStrategy Methode wird das ganze mit folgendem Kommentar gerechtfertigt:

```java
         /*
          * check feasibility using the strategy
          *
          * NOTE: Logically, this method should be called outside the loop. However, since the result is cached, asking
          * the same trace checker several times does not cost much. On the plus side, the strategy does not have to take
          * care of exception handling if it decides to exchange the backing trace checker.
          */
```
Mir erschließt sich der Sinn das zu tun nicht wirklich.

Mir scheint, dass die Implementierung an der Stelle vereinfacht werden kann (und sollte) wie in folgendem Bild:
![refinementengine2](https://cloud.githubusercontent.com/assets/1053417/23332193/ddbd2f4a-fb75-11e6-8cc4-dae3a402bc52.jpg)

Dieser Pull-Request Realisiert diese Vereinfachung.
