### PR TITLE
instead of setting variable directly, call nextTraceChecker in constructor

### DIFF
--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/MultiTrackTraceAbstractionRefinementStrategy.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/MultiTrackTraceAbstractionRefinementStrategy.java
@@ -174,7 +174,7 @@ public abstract class MultiTrackTraceAbstractionRefinementStrategy<LETTER extend
 		mTaPrefsForInterpolantConsolidation = taPrefsForInterpolantConsolidation;
 
 		mInterpolationTechniques = initializeInterpolationTechniquesList();
-		mNextTechnique = mInterpolationTechniques.next();
+		nextTraceChecker();
 	}
 
 	@Override


### PR DESCRIPTION
As has been noticed before (see https://github.com/ultimate-pa/ultimate/pull/126), strategies (sadly) do not behave like iterators.

The strategies are expected to have at least one trace checker and interpolant generator.

Even worse:
This isn't even implemented consistently by an initial call of nextTraceChecker or something like that - each strategy individually does it - and not by calling the next- methods but by setting states manually.

Now I sadly don't have time to fix this right now, and also having it be reviewed would consume lots of time - but it is a problem for me right now.

So i suggest this quick-fix for now - just for the abstract MultiTrack strategy - which will allow me to customize behaviour in subclass for now.