### PR TITLE
Fix thread IDs in C translation

### DIFF
--- a/trunk/examples/concurrent/pthreads/regression/join_correct.c
+++ b/trunk/examples/concurrent/pthreads/regression/join_correct.c
@@ -1,0 +1,37 @@
+// #Safe
+/*
+ * Author: Dominik Klumpp
+ * Date: April 17 2021
+ *
+ * Test that a pthread_join actually joins the correct thread instance, even if multiple thread instances were created by the same pthread_create statement.
+ * A bug in ULTIMATE allowed the wrong instance to be joined, leading to unsoundness.
+ *
+ * The reason was that the ID of the created thread was always the same for all executions of a pthread_create statement.
+ * The solution is to instead maintain and increment a global counter.
+ */
+#include <pthread.h>
+
+typedef unsigned long int pthread_t;
+int ret[2];
+
+void* thread0(void *arg)
+{
+  int in = *((int*)arg);
+  ret[in] = in - 1;
+  return (void*) &ret[in];
+}
+
+void main(void)
+{
+  pthread_t threads[2];
+  int x = 0;
+
+  while (x < 2) {
+    pthread_create(&threads[x], NULL, thread0, &x);
+    x++;
+  }
+  pthread_join(threads[0], &x);
+
+  //@ assert x == -1;
+}
+

--- a/trunk/examples/concurrent/pthreads/regression/join_correct.c
+++ b/trunk/examples/concurrent/pthreads/regression/join_correct.c
@@ -12,13 +12,10 @@
 #include <pthread.h>
 
 typedef unsigned long int pthread_t;
-int ret[2];
 
-void* thread0(void *arg)
+void* increment(void *arg)
 {
-  int in = *((int*)arg);
-  ret[in] = in - 1;
-  return (void*) &ret[in];
+  return (void*) (((int)arg) + 42);
 }
 
 void main(void)
@@ -27,11 +24,12 @@ void main(void)
   int x = 0;
 
   while (x < 2) {
-    pthread_create(&threads[x], NULL, thread0, &x);
+    pthread_create(&threads[x], NULL, increment, (void*)x);
     x++;
   }
-  pthread_join(threads[0], &x);
 
-  //@ assert x == -1;
+  void* result;
+  pthread_join(threads[0], &result);
+  //@ assert result == 42;
 }
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -1080,7 +1080,8 @@ public class MemoryHandler {
 	}
 
 	public IdentifierExpression getPthreadForkCount(final ILocation loc) {
-		return ExpressionFactory.constructIdentifierExpression(loc, BoogieType.TYPE_INT, SFO.ULTIMATE_FORK_COUNT,
+		final BoogieType counterType = mTypeHandler.getBoogieTypeForCType(getThreadIdType());
+		return ExpressionFactory.constructIdentifierExpression(loc, counterType, SFO.ULTIMATE_FORK_COUNT,
 				new DeclarationInformation(StorageClass.GLOBAL, null));
 	}
 
@@ -1847,9 +1848,13 @@ public class MemoryHandler {
 	}
 
 	private VariableDeclaration declarePthreadsForkCount(final ILocation loc) {
-		final ASTType counterType = mTypeHandler.cType2AstType(loc, new CPrimitive(CPrimitives.ULONG));
+		final ASTType counterType = mTypeHandler.cType2AstType(loc, getThreadIdType());
 		final VarList varList = new VarList(loc, new String[] { SFO.ULTIMATE_FORK_COUNT }, counterType);
 		return new VariableDeclaration(loc, new Attribute[0], new VarList[] { varList });
+	}
+
+	public CPrimitive getThreadIdType() {
+		return new CPrimitive(CPrimitives.INT);
 	}
 
 	private VariableDeclaration declarePThreadsMutexArray(final ILocation loc) {
@@ -2810,7 +2815,7 @@ public class MemoryHandler {
 		case ULTIMATE_MEMINIT:
 			break;
 		case ULTIMATE_PTHREADS_FORK_COUNT:
-			return new MemoryModelDeclarationInfo(mmd, BoogieType.TYPE_INT);
+			return new MemoryModelDeclarationInfo(mmd, mTypeHandler.getBoogieTypeForCType(getThreadIdType()));
 		case ULTIMATE_PTHREADS_MUTEX:
 			return new MemoryModelDeclarationInfo(mmd,
 					BoogieType.createArrayType(0, new BoogieType[] { mTypeHandler.getBoogiePointerType() }, mTypeHandler

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -163,6 +163,8 @@ public class MemoryHandler {
 
 		ULTIMATE_LENGTH(SFO.LENGTH),
 
+		ULTIMATE_PTHREADS_FORK_COUNT("#PthreadsForkCount"),
+
 		ULTIMATE_PTHREADS_MUTEX("#PthreadsMutex"),
 
 		ULTIMATE_PTHREADS_MUTEX_LOCK("#PthreadsMutexLock"),
@@ -536,6 +538,11 @@ public class MemoryHandler {
 			final ConstructRealloc cr = new ConstructRealloc(this, mProcedureManager, (TypeHandler) mTypeHandler,
 					mTypeSizeAndOffsetComputer, mExpressionTranslation, mAuxVarInfoBuilder, mTypeSizes);
 			decl.addAll(cr.declareRealloc(main, heapDataArrays, hook));
+		}
+
+		if (mRequiredMemoryModelFeatures.getRequiredMemoryModelDeclarations()
+				.contains(MemoryModelDeclarations.ULTIMATE_PTHREADS_FORK_COUNT)) {
+			decl.add(declarePthreadsForkCount(tuLoc));
 		}
 
 		if (mRequiredMemoryModelFeatures.getRequiredMemoryModelDeclarations()
@@ -1070,6 +1077,11 @@ public class MemoryHandler {
 	public void endScope() {
 		mVariablesToBeMalloced.endScope();
 		mVariablesToBeFreed.endScope();
+	}
+
+	public IdentifierExpression getPthreadForkCount(final ILocation loc) {
+		return ExpressionFactory.constructIdentifierExpression(loc, BoogieType.TYPE_INT, SFO.ULTIMATE_FORK_COUNT,
+				new DeclarationInformation(StorageClass.GLOBAL, null));
 	}
 
 	public Expression constructMutexArrayIdentifierExpression(final ILocation loc) {
@@ -1832,6 +1844,12 @@ public class MemoryHandler {
 			result.addAll(constructSingleReadProcedure(main, loc, heapDataArray, rda, false, hook));
 		}
 		return result;
+	}
+
+	private static VariableDeclaration declarePthreadsForkCount(final ILocation loc) {
+		final ASTType counterType = new PrimitiveType(loc, BoogieType.TYPE_INT, SFO.INT);
+		final VarList varList = new VarList(loc, new String[] { SFO.ULTIMATE_FORK_COUNT }, counterType);
+		return new VariableDeclaration(loc, new Attribute[0], new VarList[] { varList });
 	}
 
 	private VariableDeclaration declarePThreadsMutexArray(final ILocation loc) {
@@ -2791,6 +2809,8 @@ public class MemoryHandler {
 					new BoogieType[] { mTypeHandler.getBoogieTypeForPointerComponents() }, BoogieType.TYPE_INT));
 		case ULTIMATE_MEMINIT:
 			break;
+		case ULTIMATE_PTHREADS_FORK_COUNT:
+			return new MemoryModelDeclarationInfo(mmd, BoogieType.TYPE_INT);
 		case ULTIMATE_PTHREADS_MUTEX:
 			return new MemoryModelDeclarationInfo(mmd,
 					BoogieType.createArrayType(0, new BoogieType[] { mTypeHandler.getBoogiePointerType() }, mTypeHandler

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -1846,8 +1846,8 @@ public class MemoryHandler {
 		return result;
 	}
 
-	private static VariableDeclaration declarePthreadsForkCount(final ILocation loc) {
-		final ASTType counterType = new PrimitiveType(loc, BoogieType.TYPE_INT, SFO.INT);
+	private VariableDeclaration declarePthreadsForkCount(final ILocation loc) {
+		final ASTType counterType = mTypeHandler.cType2AstType(loc, new CPrimitive(CPrimitives.ULONG));
 		final VarList varList = new VarList(loc, new String[] { SFO.ULTIMATE_FORK_COUNT }, counterType);
 		return new VariableDeclaration(loc, new Attribute[0], new VarList[] { varList });
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -163,8 +163,6 @@ public class StandardFunctionHandler {
 
 	private final ITypeHandler mTypeHandler;
 
-	private int mPthreadCreateCounter = 0;
-
 	private final CExpressionTranslator mCEpressionTranslator;
 
 	private final ILogger mLogger;
@@ -991,6 +989,7 @@ public class StandardFunctionHandler {
 	 */
 	private Result handlePthread_create(final IDispatcher main, final IASTFunctionCallExpression node,
 			final ILocation loc, final String name) {
+		mMemoryHandler.requireMemoryModelFeature(MemoryModelDeclarations.ULTIMATE_PTHREADS_FORK_COUNT);
 
 		final IASTInitializerClause[] arguments = node.getArguments();
 		checkArguments(loc, 4, name, arguments);
@@ -1064,8 +1063,29 @@ public class StandardFunctionHandler {
 					argThreadIdPointer.getLrValue().getCType(), false, null);
 		}
 
-		final Expression threadId = mTypeSizes.constructLiteralForIntegerType(loc, new CPrimitive(CPrimitives.ULONG),
-				BigInteger.valueOf(mPthreadCreateCounter++));
+		final ExpressionResultBuilder builder = new ExpressionResultBuilder();
+		final IdentifierExpression forkCount = mMemoryHandler.getPthreadForkCount(loc);
+		// set temporary ID variable to value of global fork count
+		final AuxVarInfo tmpThreadId =
+				mAuxVarInfoBuilder.constructAuxVarInfo(loc, new CPrimitive(CPrimitives.ULONG), SFO.AUXVAR.PRE_MOD);
+		builder.addDeclaration(tmpThreadId.getVarDec());
+		builder.addAuxVar(tmpThreadId);
+		final AssignmentStatement counterStore = new AssignmentStatement(loc,
+				new LeftHandSide[] { tmpThreadId.getLhs() }, new Expression[] { forkCount });
+		builder.addStatement(counterStore);
+		// increment the global variable fork count
+		final var counterLhs = new VariableLHS(loc, forkCount.getType(), forkCount.getIdentifier(),
+				forkCount.getDeclarationInformation());
+		final Expression sum = mExpressionTranslation.constructArithmeticExpression(
+				loc, IASTBinaryExpression.op_plus, forkCount, new CPrimitive(CPrimitives.ULONG), mTypeSizes
+						.constructLiteralForIntegerType(loc, new CPrimitive(CPrimitives.ULONG), BigInteger.valueOf(1L)),
+				new CPrimitive(CPrimitives.ULONG));
+		final AssignmentStatement counterIncrement =
+				new AssignmentStatement(loc, new VariableLHS[] { counterLhs }, new Expression[] { sum });
+		builder.addStatement(counterIncrement);
+		// use temporary variable as ID for forked thread
+		final Expression threadId = tmpThreadId.getExp();
+
 		final List<Statement> writeCall =
 				mMemoryHandler.getWriteCall(loc, heapLValue, threadId, new CPrimitive(CPrimitives.ULONG), false, node);
 
@@ -1082,7 +1102,6 @@ public class StandardFunctionHandler {
 		final ForkStatement fs = new ForkStatement(loc, new Expression[] { threadId }, methodName, forkArguments);
 		mProcedureManager.registerForkStatement(fs);
 
-		final ExpressionResultBuilder builder = new ExpressionResultBuilder();
 		builder.addAllExceptLrValue(argThreadIdPointer, argThreadAttributes, argStartRoutine, startRoutineArguments);
 		builder.addStatements(writeCall);
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
@@ -208,6 +208,8 @@ public final class SFO {
 	public static final String REALLOC_PTR = "ptr";
 	public static final String REALLOC_SIZE = "size";
 
+	public static final String ULTIMATE_FORK_COUNT = "#pthreadsForks";
+
 	public static final String ULTIMATE_PTHREADS_MUTEX = "#pthreadsMutex";
 
 	public static final String INIT_TO_ZERO_AT_ADDRESS = "initToZeroAtPointerBaseAddress~";


### PR DESCRIPTION
Previously, each `pthread_create()` call was translated to a Boogie statement `fork X ...` for a fixed constant `X` (e.g. `fork 0 ... `). This is unsound if the statement can be executed multiple times, as several threads end up with the same thread ID and `pthread_join()` calls then become ambiguous.

Instead, we now maintain a global counter that is used as thread ID and then incremented.