### PR TITLE
Add typechecking for attributes on Boogie assume and assert statements

### DIFF
--- a/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/TypeChecker.java
+++ b/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/TypeChecker.java
@@ -400,6 +400,9 @@ public class TypeChecker extends BaseObserver {
 	}
 
 	private void typecheckAttributes(final Attribute[] attributes) {
+		if (attributes == null) {
+			return;
+		}
 		for (final Attribute attr : attributes) {
 			Expression[] exprs;
 			if (attr instanceof Trigger) {
@@ -666,11 +669,13 @@ public class TypeChecker extends BaseObserver {
 			if (!t.equals(BoogieType.TYPE_BOOL) && !t.equals(BoogieType.TYPE_ERROR)) {
 				typeError(statement, "Assume is not boolean: " + statement);
 			}
+			typecheckAttributes(((AssumeStatement) statement).getAttributes());
 		} else if (statement instanceof AssertStatement) {
 			final BoogieType t = typecheckExpression(((AssertStatement) statement).getFormula());
 			if (!t.equals(BoogieType.TYPE_BOOL) && !t.equals(BoogieType.TYPE_ERROR)) {
 				typeError(statement, "Assert is not boolean: " + statement);
 			}
+			typecheckAttributes(((AssertStatement) statement).getAttributes());
 		} else if (statement instanceof BreakStatement) {
 			final String label = ((BreakStatement) statement).getLabel();
 			if (!outer.contains(label == null ? "*" : label)) {


### PR DESCRIPTION
Boogie assume and assert statements may have attributes. However, these attributes
are not type-checked. In case the attributes contain expressions, this results in
a null value in their type field and causes a null-pointer dereference during
Boogie preprocessing.