### PR TITLE
Refactor IcfgPetrifier

### DIFF
--- a/trunk/source/IcfgToChc/src/de/uni_freiburg/informatik/ultimate/plugins/icfgtochc/concurrent/ChcProviderConcurrentWithLbe.java
+++ b/trunk/source/IcfgToChc/src/de/uni_freiburg/informatik/ultimate/plugins/icfgtochc/concurrent/ChcProviderConcurrentWithLbe.java
@@ -58,9 +58,7 @@ public class ChcProviderConcurrentWithLbe implements IChcProvider {
 
 	@Override
 	public Collection<HornClause> getHornClauses(final IIcfg<IcfgLocation> icfg) {
-		final IIcfg<IcfgLocation> petrified =
-				new IcfgPetrifier(mServices, icfg, 2)
-						.getPetrifiedIcfg();
+		final IIcfg<IcfgLocation> petrified = new IcfgPetrifier(mServices, icfg, 2).getPetrifiedIcfg();
 		final Map<String, Integer> numberOfThreads =
 				petrified.getInitialNodes().stream().collect(Collectors.toMap(IcfgLocation::getProcedure, x -> 1));
 		final Set<String> unboundedThreads = new HashSet<>();

--- a/trunk/source/IcfgToChc/src/de/uni_freiburg/informatik/ultimate/plugins/icfgtochc/concurrent/ChcProviderConcurrentWithLbe.java
+++ b/trunk/source/IcfgToChc/src/de/uni_freiburg/informatik/ultimate/plugins/icfgtochc/concurrent/ChcProviderConcurrentWithLbe.java
@@ -21,7 +21,6 @@ import de.uni_freiburg.informatik.ultimate.lib.chc.HcSymbolTable;
 import de.uni_freiburg.informatik.ultimate.lib.chc.HornClause;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.CfgSmtToolkit;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier.IcfgConstructionMode;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgUtils;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfg;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdge;
@@ -60,7 +59,7 @@ public class ChcProviderConcurrentWithLbe implements IChcProvider {
 	@Override
 	public Collection<HornClause> getHornClauses(final IIcfg<IcfgLocation> icfg) {
 		final IIcfg<IcfgLocation> petrified =
-				new IcfgPetrifier(mServices, icfg, IcfgConstructionMode.ASSUME_THREAD_INSTANCE_SUFFICIENCY, 2)
+				new IcfgPetrifier(mServices, icfg, 2)
 						.getPetrifiedIcfg();
 		final Map<String, Integer> numberOfThreads =
 				petrified.getInitialNodes().stream().collect(Collectors.toMap(IcfgLocation::getProcedure, x -> 1));

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -113,10 +112,7 @@ public class IcfgPetrifier {
 		ProcedureMultiplier.duplicateProcedures(mServices, mPetrifiedIcfg, instances, backtranslator, threadInstanceMap,
 				newForkCurrentThreads, newJoinCurrentThreads);
 		fillErrorNodeMap(threadInstanceMap.keySet(), inUseErrorNodeMap);
-		for (final Entry<IIcfgForkTransitionThreadCurrent<IcfgLocation>, IcfgLocation> entry : inUseErrorNodeMap
-				.entrySet()) {
-			mPetrifiedIcfg.addLocation(entry.getValue(), false, true, false, false, false);
-		}
+		inUseErrorNodeMap.values().forEach(x -> mPetrifiedIcfg.addLocation(x, false, true, false, false, false));
 		adder.connectThreadInstances(mPetrifiedIcfg, newForkCurrentThreads, newJoinCurrentThreads, threadInstanceMap,
 				inUseErrorNodeMap, backtranslator);
 

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
@@ -111,7 +111,7 @@ public class IcfgPetrifier {
 		// IcfgForkThreadCurrentTransitions, namely in the case where
 		// a forked transition contains a fork.
 		ProcedureMultiplier.duplicateProcedures(mServices, mPetrifiedIcfg, instances, backtranslator, threadInstanceMap,
-				newForkCurrentThreads, newJoinCurrentThreads, this);
+				newForkCurrentThreads, newJoinCurrentThreads);
 		fillErrorNodeMap(threadInstanceMap.keySet(), inUseErrorNodeMap);
 		for (final Entry<IIcfgForkTransitionThreadCurrent<IcfgLocation>, IcfgLocation> entry : inUseErrorNodeMap
 				.entrySet()) {

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
@@ -27,9 +27,9 @@
  */
 package de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -50,7 +50,7 @@ import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.I
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocation;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.transformations.BlockEncodingBacktranslator;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.transformations.IcfgDuplicator;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.variables.IProgramNonOldVar;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.variables.IProgramVar;
 import de.uni_freiburg.informatik.ultimate.logic.Term;
 
 /**
@@ -121,7 +121,9 @@ public class IcfgPetrifier {
 		adder.connectThreadInstances(mPetrifiedIcfg, newForkCurrentThreads, newJoinCurrentThreads, threadInstanceMap,
 				inUseErrorNodeMap, backtranslator, addThreadInUseViolationEdges);
 
-		backtranslator.setVariableBlacklist(collectAxiliaryThreadVariables(instances, addThreadInUseViolationEdges));
+		final Set<Term> idVars = instances.stream().flatMap(x -> Arrays.stream(x.getIdVars())).map(IProgramVar::getTerm)
+				.collect(Collectors.toSet());
+		backtranslator.setVariableBlacklist(idVars);
 		mBacktranslator = backtranslator;
 	}
 
@@ -133,17 +135,6 @@ public class IcfgPetrifier {
 			inUseErrorNodeMap.put(fork, errNode);
 			errorNodeId++;
 		}
-	}
-
-	private static Set<Term> collectAxiliaryThreadVariables(final Collection<ThreadInstance> values,
-			final boolean addThreadInUseViolationEdges) {
-		final Set<Term> result = new HashSet<>();
-		for (final ThreadInstance ti : values) {
-			for (final IProgramNonOldVar idVar : ti.getIdVars()) {
-				result.add(idVar.getTerm());
-			}
-		}
-		return result;
 	}
 
 	public IIcfg<IcfgLocation> getPetrifiedIcfg() {

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgPetrifier.java
@@ -117,9 +117,8 @@ public class IcfgPetrifier {
 				.entrySet()) {
 			mPetrifiedIcfg.addLocation(entry.getValue(), false, true, false, false, false);
 		}
-		final boolean addThreadInUseViolationEdges = true;
 		adder.connectThreadInstances(mPetrifiedIcfg, newForkCurrentThreads, newJoinCurrentThreads, threadInstanceMap,
-				inUseErrorNodeMap, backtranslator, addThreadInUseViolationEdges);
+				inUseErrorNodeMap, backtranslator);
 
 		final Set<Term> idVars = instances.stream().flatMap(x -> Arrays.stream(x.getIdVars())).map(IProgramVar::getTerm)
 				.collect(Collectors.toSet());

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
@@ -130,7 +130,7 @@ public class ProcedureMultiplier {
 				}
 				outParams.put(copyIdentifier, outParamsOfCopy);
 				for (final ILocalProgramVar localVar : cfgSmtToolkit.getSymbolTable().getLocals(proc)) {
-					if (procOldVar2NewVar.containsKey(localVar)) {
+					if (!procOldVar2NewVar.containsKey(localVar)) {
 						constructVariableCopy(localVar, copyIdentifier, managedScript, procOldVar2NewVar,
 								variableBacktranslationMapping, symbolTable, lockOwner);
 					}

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
@@ -91,7 +91,8 @@ public class ProcedureMultiplier {
 			final List<ThreadInstance> instances, final BlockEncodingBacktranslator backtranslator,
 			final Map<IIcfgForkTransitionThreadCurrent<IcfgLocation>, List<ThreadInstance>> threadInstanceMap,
 			final List<IIcfgForkTransitionThreadCurrent<IcfgLocation>> forkCurrentThreads,
-			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads, final Object lockOwner) {
+			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads) {
+		final Object lockOwner = ProcedureMultiplier.class;
 		final HashRelation<String, String> copyDirectives = generateCopyDirectives(instances);
 		final CfgSmtToolkit cfgSmtToolkit = icfg.getCfgSmtToolkit();
 		final IcfgEdgeFactory icfgEdgeFactory = cfgSmtToolkit.getIcfgEdgeFactory();

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
@@ -266,7 +266,7 @@ public class ProcedureMultiplier {
 		final MultiTermResult newThreadIdArguments =
 				copyMultiTermResult(joinSmtArguments.getThreadIdArguments(), defaultVariableMapping, managedScript);
 		final List<IProgramVar> newAssignmentLhs = joinSmtArguments.getAssignmentLhs().stream()
-				.map(x -> x instanceof ILocalProgramVar ? map.get(x) : x).collect(Collectors.toList());
+				.map(x -> x.isGlobal() ? x : map.get(x)).collect(Collectors.toList());
 		return new JoinSmtArguments(newThreadIdArguments, newAssignmentLhs);
 	}
 

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
@@ -71,8 +71,8 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.HashRela
 /**
  * Modifies a given {@link IIcfg} by adding copies of existing procedures.
  * <p>
- * Copies are constructed according to the {@link HashRelation} argument "copyDirectives". If the relation contains the
- * pair (foo, bar) we construct a copy of the procedure "foo" and the identifier of the copy is "bar".
+ * Copies are constructed according to the {@link List} argument "instances". For each instance with the name "foo" and
+ * the template "bar" we construct a copy of the procedure "foo" and the identifier of the copy is "bar".
  * <p />
  * <p>
  * A {@link ProcedureMultiplier} replaces also all local variables accordingly and replaces the {@link CfgSmtToolkit}.

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ProcedureMultiplier.java
@@ -34,13 +34,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.core.model.models.IPayload;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.boogie.Expression2Term.MultiTermResult;
@@ -52,11 +50,11 @@ import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.I
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgCallTransition;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdge;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdgeFactory;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdgeIterator;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgForkThreadCurrentTransition;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgInternalTransition;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgJoinThreadCurrentTransition;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocation;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocationIterator;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.transformations.BlockEncodingBacktranslator;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.transitions.TransFormulaBuilder;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.transitions.UnmodifiableTransFormula;
@@ -86,31 +84,33 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.HashRela
  *
  *
  * @author Matthias Heizmann (heizmann@informatik.uni-freiburg.de)
+ * @author Frank Schüssele (schuessf@informatik.uni-freiburg.de)
  */
 public class ProcedureMultiplier {
-
-	public ProcedureMultiplier(final IUltimateServiceProvider services, final BasicIcfg<IcfgLocation> icfg,
-			final HashRelation<String, String> copyDirectives, final BlockEncodingBacktranslator backtranslator,
+	public static void duplicateProcedures(final IUltimateServiceProvider services, final BasicIcfg<IcfgLocation> icfg,
+			final List<ThreadInstance> instances, final BlockEncodingBacktranslator backtranslator,
 			final Map<IIcfgForkTransitionThreadCurrent<IcfgLocation>, List<ThreadInstance>> threadInstanceMap,
 			final List<IIcfgForkTransitionThreadCurrent<IcfgLocation>> forkCurrentThreads,
-			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads) {
-		final IcfgEdgeFactory icfgEdgeFactory = icfg.getCfgSmtToolkit().getIcfgEdgeFactory();
-		final Map<String, List<ILocalProgramVar>> inParams = new HashMap<>(icfg.getCfgSmtToolkit().getInParams());
-		final Map<String, List<ILocalProgramVar>> outParams = new HashMap<>(icfg.getCfgSmtToolkit().getOutParams());
-		final Set<String> procedures = new HashSet<>(icfg.getCfgSmtToolkit().getProcedures());
-		final SmtFunctionsAndAxioms smtSymbols = icfg.getCfgSmtToolkit().getSmtFunctionsAndAxioms();
+			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads, final Object lockOwner) {
+		final HashRelation<String, String> copyDirectives = generateCopyDirectives(instances);
+		final CfgSmtToolkit cfgSmtToolkit = icfg.getCfgSmtToolkit();
+		final IcfgEdgeFactory icfgEdgeFactory = cfgSmtToolkit.getIcfgEdgeFactory();
+		final Map<String, List<ILocalProgramVar>> inParams = new HashMap<>(cfgSmtToolkit.getInParams());
+		final Map<String, List<ILocalProgramVar>> outParams = new HashMap<>(cfgSmtToolkit.getOutParams());
+		final Set<String> procedures = new HashSet<>(cfgSmtToolkit.getProcedures());
+		final SmtFunctionsAndAxioms smtSymbols = cfgSmtToolkit.getSmtFunctionsAndAxioms();
 		final DefaultIcfgSymbolTable symbolTable =
-				new DefaultIcfgSymbolTable(icfg.getCfgSmtToolkit().getSymbolTable(), procedures);
-		final ManagedScript managedScript = icfg.getCfgSmtToolkit().getManagedScript();
+				new DefaultIcfgSymbolTable(cfgSmtToolkit.getSymbolTable(), procedures);
+		final ManagedScript managedScript = cfgSmtToolkit.getManagedScript();
 		final HashRelation<String, IProgramNonOldVar> proc2globals =
-				new HashRelation<>(icfg.getCfgSmtToolkit().getModifiableGlobalsTable().getProcToGlobals());
+				new HashRelation<>(cfgSmtToolkit.getModifiableGlobalsTable().getProcToGlobals());
 
-		final Map<ILocalProgramVar, ILocalProgramVar> newVar2OldVar = new HashMap<>();
+		// Add variables
 		final Map<String, Map<ILocalProgramVar, ILocalProgramVar>> oldVar2newVar = new HashMap<>();
 		final Map<Term, Term> variableBacktranslationMapping = new HashMap<>();
-		managedScript.lock(this);
+		managedScript.lock(lockOwner);
 		for (final String proc : copyDirectives.getDomain()) {
-			assert icfg.getCfgSmtToolkit().getProcedures().contains(proc) : "procedure " + proc + " missing";
+			assert cfgSmtToolkit.getProcedures().contains(proc) : "procedure " + proc + " missing";
 			for (final String copyIdentifier : copyDirectives.getImage(proc)) {
 				icfg.addProcedure(copyIdentifier);
 				final Map<ILocalProgramVar, ILocalProgramVar> procOldVar2NewVar = new HashMap<>();
@@ -118,150 +118,139 @@ public class ProcedureMultiplier {
 				final List<ILocalProgramVar> inParamsOfCopy = new ArrayList<>();
 				for (final ILocalProgramVar inParam : inParams.get(proc)) {
 					final ILocalProgramVar inParamCopy = constructVariableCopy(inParam, copyIdentifier, managedScript,
-							procOldVar2NewVar, variableBacktranslationMapping, symbolTable);
+							procOldVar2NewVar, variableBacktranslationMapping, symbolTable, lockOwner);
 					inParamsOfCopy.add(inParamCopy);
-					newVar2OldVar.put(inParamCopy, inParam);
 				}
 				inParams.put(copyIdentifier, inParamsOfCopy);
 				final List<ILocalProgramVar> outParamsOfCopy = new ArrayList<>();
 				for (final ILocalProgramVar outParam : outParams.get(proc)) {
 					final ILocalProgramVar outParamCopy = constructVariableCopy(outParam, copyIdentifier, managedScript,
-							procOldVar2NewVar, variableBacktranslationMapping, symbolTable);
+							procOldVar2NewVar, variableBacktranslationMapping, symbolTable, lockOwner);
 					outParamsOfCopy.add(outParamCopy);
-					newVar2OldVar.put(outParamCopy, outParam);
 				}
 				outParams.put(copyIdentifier, outParamsOfCopy);
-				for (final ILocalProgramVar localVar : icfg.getCfgSmtToolkit().getSymbolTable().getLocals(proc)) {
-					if (!procOldVar2NewVar.containsKey(localVar)) {
+				for (final ILocalProgramVar localVar : cfgSmtToolkit.getSymbolTable().getLocals(proc)) {
+					if (procOldVar2NewVar.containsKey(localVar)) {
 						constructVariableCopy(localVar, copyIdentifier, managedScript, procOldVar2NewVar,
-								variableBacktranslationMapping, symbolTable);
+								variableBacktranslationMapping, symbolTable, lockOwner);
 					}
 				}
-				final List<IProgramNonOldVar> modifiableGlobals = new ArrayList<>();
-				modifiableGlobals.addAll(proc2globals.getImage(proc));
-				for (final IProgramNonOldVar modifiableGlobal : modifiableGlobals) {
-					proc2globals.addPair(copyIdentifier, modifiableGlobal);
-				}
 				oldVar2newVar.put(copyIdentifier, procOldVar2NewVar);
+				proc2globals.getImage(proc).forEach(g -> proc2globals.addPair(copyIdentifier, g));
 			}
 		}
 		backtranslator.setTermTranslator(x -> Substitution.apply(managedScript, variableBacktranslationMapping, x));
-		managedScript.unlock(this);
+		managedScript.unlock(lockOwner);
 
-		final ModifiableGlobalsTable modifiableGlobalsTable = new ModifiableGlobalsTable(proc2globals);
 		final CfgSmtToolkit newCfgSmtToolkit =
-				new CfgSmtToolkit(modifiableGlobalsTable, managedScript, symbolTable, procedures, inParams, outParams,
-						icfgEdgeFactory, icfg.getCfgSmtToolkit().getConcurrencyInformation(), smtSymbols);
-		final Map<IcfgLocation, IcfgLocation> newLoc2OldLoc = new HashMap<>();
+				new CfgSmtToolkit(new ModifiableGlobalsTable(proc2globals), managedScript, symbolTable, procedures,
+						inParams, outParams, icfgEdgeFactory, cfgSmtToolkit.getConcurrencyInformation(), smtSymbols);
+		icfg.setCfgSmtToolkit(newCfgSmtToolkit);
+
+		// Add locations and edges
 		for (final String proc : copyDirectives.getDomain()) {
 			final IcfgLocation procEntry = icfg.getProcedureEntryNodes().get(proc);
-			final List<IcfgLocation> procLocs =
-					new IcfgLocationIterator<>(procEntry).asStream().collect(Collectors.toList());
+			final List<IcfgEdge> edges =
+					new IcfgEdgeIterator(procEntry.getOutgoingEdges()).asStream().collect(Collectors.toList());
 			for (final String copyIdentifier : copyDirectives.getImage(proc)) {
-				final Map<IcfgLocation, IcfgLocation> procOldLoc2NewLoc = new HashMap<>();
-				// add locations
-				for (final IcfgLocation oldLoc : procLocs) {
-					final IcfgLocation newLoc = constructCopy(oldLoc, copyIdentifier, backtranslator);
-					newLoc2OldLoc.put(newLoc, oldLoc);
-					procOldLoc2NewLoc.put(oldLoc, newLoc);
-					final boolean isInitial = icfg.getInitialNodes().contains(oldLoc);
-					final boolean isError = icfg.getProcedureErrorNodes().get(proc).contains(oldLoc);
-					final boolean isProcEntry = icfg.getProcedureEntryNodes().get(proc).equals(oldLoc);
-					final boolean isProcExit = icfg.getProcedureExitNodes().get(proc).equals(oldLoc);
-					final boolean isLoopLocation = icfg.getLoopLocations().contains(oldLoc);
-					icfg.addLocation(newLoc, isInitial, isError, isProcEntry, isProcExit, isLoopLocation);
-				}
-				// add edges
-				for (final IcfgLocation oldLoc : procLocs) {
-					for (final IcfgEdge outEdge : oldLoc.getOutgoingEdges()) {
-						if (outEdge instanceof IcfgInternalTransition) {
-							final IcfgInternalTransition oldInternalEdge = (IcfgInternalTransition) outEdge;
-							final IcfgLocation source = procOldLoc2NewLoc.get(oldInternalEdge.getSource());
-							final IcfgLocation target = procOldLoc2NewLoc.get(oldInternalEdge.getTarget());
-							final IPayload payload = null;
-							final UnmodifiableTransFormula transFormula = TransFormulaBuilder.constructCopy(
-									managedScript, outEdge.getTransformula(), oldVar2newVar.get(copyIdentifier));
-							final UnmodifiableTransFormula transFormulaWithBE = TransFormulaBuilder.constructCopy(
-									managedScript, oldInternalEdge.getTransitionFormulaWithBranchEncoders(),
-									oldVar2newVar.get(copyIdentifier));
-							final IcfgInternalTransition newInternalEdge = icfgEdgeFactory.createInternalTransition(
-									source, target, payload, transFormula, transFormulaWithBE);
-							backtranslator.mapEdges(newInternalEdge, oldInternalEdge);
-							ModelUtils.copyAnnotations(oldInternalEdge, newInternalEdge);
-							source.addOutgoing(newInternalEdge);
-							target.addIncoming(newInternalEdge);
-						} else if (outEdge instanceof IcfgForkThreadCurrentTransition) {
-							// mainly copy and paste form IcfgInternalTransition
-							final IcfgForkThreadCurrentTransition oldForkEdge =
-									(IcfgForkThreadCurrentTransition) outEdge;
-							final IcfgLocation source = procOldLoc2NewLoc.get(oldForkEdge.getSource());
-							final IcfgLocation target = procOldLoc2NewLoc.get(oldForkEdge.getTarget());
-							final IPayload payload = null;
-							final UnmodifiableTransFormula transFormula = TransFormulaBuilder.constructCopy(
-									managedScript, outEdge.getTransformula(), oldVar2newVar.get(copyIdentifier));
-							final ForkSmtArguments newForkSmtArguments =
-									copyForkSmtArguments(oldForkEdge.getForkSmtArguments(),
-											oldVar2newVar.get(copyIdentifier), managedScript);
-							final IcfgForkThreadCurrentTransition newForkEdge =
-									icfgEdgeFactory.createForkThreadCurrentTransition(source, target, payload,
-											transFormula, newForkSmtArguments, oldForkEdge.getNameOfForkedProcedure());
-							backtranslator.mapEdges(newForkEdge, oldForkEdge);
-							ModelUtils.copyAnnotations(oldForkEdge, newForkEdge);
-							source.addOutgoing(newForkEdge);
-							target.addIncoming(newForkEdge);
-							// add to thread instance mapping
-							forkCurrentThreads.add(newForkEdge);
-							final List<ThreadInstance> threadInstances = threadInstanceMap.get(oldForkEdge);
-							assert threadInstances != null;
-							threadInstanceMap.put(newForkEdge, threadInstances);
-						} else if (outEdge instanceof IcfgJoinThreadCurrentTransition) {
-							// mainly copy and paste form IcfgInternalTransition
-							final IcfgJoinThreadCurrentTransition oldJoinEdge =
-									(IcfgJoinThreadCurrentTransition) outEdge;
-							final IcfgLocation source = procOldLoc2NewLoc.get(oldJoinEdge.getSource());
-							final IcfgLocation target = procOldLoc2NewLoc.get(oldJoinEdge.getTarget());
-							final IPayload payload = null;
-							final UnmodifiableTransFormula transFormula = TransFormulaBuilder.constructCopy(
-									managedScript, outEdge.getTransformula(), oldVar2newVar.get(copyIdentifier));
-							final JoinSmtArguments newForkSmtArguments =
-									copyJoinSmtArguments(oldJoinEdge.getJoinSmtArguments(),
-											oldVar2newVar.get(copyIdentifier), managedScript);
-							final IcfgJoinThreadCurrentTransition newJoinEdge =
-									icfgEdgeFactory.createJoinThreadCurrentTransition(source, target, payload,
-											transFormula, newForkSmtArguments);
-							backtranslator.mapEdges(newJoinEdge, oldJoinEdge);
-							ModelUtils.copyAnnotations(oldJoinEdge, newJoinEdge);
-							source.addOutgoing(newJoinEdge);
-							target.addIncoming(newJoinEdge);
-							// add to join list
-							joinCurrentThreads.add(newJoinEdge);
-						} else if (outEdge instanceof IcfgCallTransition) {
-							throw new UnsupportedOperationException(String.format(
-									"%s does not support %s. Calls and returns should habe been removed by inlining. (Did the inlining fail because this program is recursive.)",
-									this.getClass().getSimpleName(), outEdge.getClass().getSimpleName()));
-						} else {
-							throw new UnsupportedOperationException(this.getClass().getSimpleName()
-									+ " does not support " + outEdge.getClass().getSimpleName());
-						}
-					}
+				final Map<IcfgLocation, IcfgLocation> old2NewLoc = new HashMap<>();
+				for (final IcfgEdge edge : edges) {
+					final IcfgLocation source = getOrConstructLocationCopy(edge.getSource(), old2NewLoc, icfg,
+							copyIdentifier, backtranslator);
+					final IcfgLocation target = getOrConstructLocationCopy(edge.getTarget(), old2NewLoc, icfg,
+							copyIdentifier, backtranslator);
+					final IcfgEdge newEdge = constructEdgeCopy(edge, source, target, oldVar2newVar.get(copyIdentifier),
+							icfgEdgeFactory, managedScript, threadInstanceMap, forkCurrentThreads, joinCurrentThreads);
+					backtranslator.mapEdges(newEdge, edge);
+					ModelUtils.copyAnnotations(edge, newEdge);
+					source.addOutgoing(newEdge);
+					target.addIncoming(newEdge);
 				}
 			}
 		}
-		icfg.setCfgSmtToolkit(newCfgSmtToolkit);
 	}
 
-	private ILocalProgramVar constructVariableCopy(final ILocalProgramVar localVar, final String procedureCopy,
+	private static IcfgEdge constructEdgeCopy(final IcfgEdge edge, final IcfgLocation source, final IcfgLocation target,
+			final Map<ILocalProgramVar, ILocalProgramVar> varReplacement, final IcfgEdgeFactory icfgEdgeFactory,
+			final ManagedScript managedScript,
+			final Map<IIcfgForkTransitionThreadCurrent<IcfgLocation>, List<ThreadInstance>> threadInstanceMap,
+			final List<IIcfgForkTransitionThreadCurrent<IcfgLocation>> forkCurrentThreads,
+			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads) {
+		final UnmodifiableTransFormula transFormula =
+				TransFormulaBuilder.constructCopy(managedScript, edge.getTransformula(), varReplacement);
+		if (edge instanceof IcfgInternalTransition) {
+			final UnmodifiableTransFormula transFormulaWithBE = TransFormulaBuilder.constructCopy(managedScript,
+					((IcfgInternalTransition) edge).getTransitionFormulaWithBranchEncoders(), varReplacement);
+			return icfgEdgeFactory.createInternalTransition(source, target, null, transFormula, transFormulaWithBE);
+		}
+		if (edge instanceof IcfgForkThreadCurrentTransition) {
+			final IcfgForkThreadCurrentTransition oldForkEdge = (IcfgForkThreadCurrentTransition) edge;
+			final ForkSmtArguments newForkSmtArguments =
+					copyForkSmtArguments(oldForkEdge.getForkSmtArguments(), varReplacement, managedScript);
+			final IcfgForkThreadCurrentTransition newForkEdge = icfgEdgeFactory.createForkThreadCurrentTransition(
+					source, target, null, transFormula, newForkSmtArguments, oldForkEdge.getNameOfForkedProcedure());
+			// add to thread instance mapping
+			forkCurrentThreads.add(newForkEdge);
+			final List<ThreadInstance> threadInstances = threadInstanceMap.get(oldForkEdge);
+			assert threadInstances != null;
+			threadInstanceMap.put(newForkEdge, threadInstances);
+			return newForkEdge;
+		}
+		if (edge instanceof IcfgJoinThreadCurrentTransition) {
+			final JoinSmtArguments newForkSmtArguments = copyJoinSmtArguments(
+					((IcfgJoinThreadCurrentTransition) edge).getJoinSmtArguments(), varReplacement, managedScript);
+			final IcfgJoinThreadCurrentTransition newJoinEdge = icfgEdgeFactory
+					.createJoinThreadCurrentTransition(source, target, null, transFormula, newForkSmtArguments);
+			// add to join list
+			joinCurrentThreads.add(newJoinEdge);
+			return newJoinEdge;
+		}
+		if (edge instanceof IcfgCallTransition) {
+			throw new UnsupportedOperationException(String.format(
+					"%s does not support %s. Calls and returns should habe been removed by inlining. "
+							+ "(Did the inlining fail because this program is recursive.)",
+					ProcedureMultiplier.class.getSimpleName(), edge.getClass().getSimpleName()));
+		}
+		throw new UnsupportedOperationException(
+				ProcedureMultiplier.class.getSimpleName() + " does not support " + edge.getClass().getSimpleName());
+	}
+
+	private static IcfgLocation getOrConstructLocationCopy(final IcfgLocation originalLocation,
+			final Map<IcfgLocation, IcfgLocation> old2newLoc, final BasicIcfg<IcfgLocation> icfg, final String newProc,
+			final BlockEncodingBacktranslator backtranslator) {
+		return old2newLoc.computeIfAbsent(originalLocation,
+				x -> constructLocationCopy(x, icfg, newProc, backtranslator));
+	}
+
+	private static IcfgLocation constructLocationCopy(final IcfgLocation originalLocation,
+			final BasicIcfg<IcfgLocation> icfg, final String newProc,
+			final BlockEncodingBacktranslator backtranslator) {
+		final String proc = originalLocation.getProcedure();
+		final IcfgLocation newLoc = new IcfgLocation(originalLocation.getDebugIdentifier(), newProc);
+		ModelUtils.copyAnnotations(originalLocation, newLoc);
+		backtranslator.mapLocations(newLoc, originalLocation);
+		final boolean isInitial = icfg.getInitialNodes().contains(originalLocation);
+		final boolean isError = icfg.getProcedureErrorNodes().get(proc).contains(originalLocation);
+		final boolean isProcEntry = icfg.getProcedureEntryNodes().get(proc).equals(originalLocation);
+		final boolean isProcExit = icfg.getProcedureExitNodes().get(proc).equals(originalLocation);
+		final boolean isLoopLocation = icfg.getLoopLocations().contains(originalLocation);
+		icfg.addLocation(newLoc, isInitial, isError, isProcEntry, isProcExit, isLoopLocation);
+		return newLoc;
+	}
+
+	private static ILocalProgramVar constructVariableCopy(final ILocalProgramVar localVar, final String procedureCopy,
 			final ManagedScript managedScript, final Map<ILocalProgramVar, ILocalProgramVar> procOldVar2NewVar,
-			final Map<Term, Term> variableBacktranslationMapping, final DefaultIcfgSymbolTable symbolTable) {
+			final Map<Term, Term> variableBacktranslationMapping, final DefaultIcfgSymbolTable symbolTable,
+			final Object lockOwner) {
 		final ILocalProgramVar localVarCopy = ProgramVarUtils.constructLocalProgramVar(localVar.getIdentifier(),
-				procedureCopy, localVar.getSort(), managedScript, this);
+				procedureCopy, localVar.getSort(), managedScript, lockOwner);
 		procOldVar2NewVar.put(localVar, localVarCopy);
 		variableBacktranslationMapping.put(localVarCopy.getTermVariable(), localVar.getTermVariable());
 		symbolTable.add(localVarCopy);
 		return localVarCopy;
 	}
 
-	private ForkSmtArguments copyForkSmtArguments(final ForkSmtArguments forkSmtArguments,
+	private static ForkSmtArguments copyForkSmtArguments(final ForkSmtArguments forkSmtArguments,
 			final Map<ILocalProgramVar, ILocalProgramVar> map, final ManagedScript managedScript) {
 		final Map<Term, Term> defaultVariableMapping = constructDefaultVariableMapping(map);
 		final MultiTermResult newThreadIdArguments =
@@ -271,28 +260,19 @@ public class ProcedureMultiplier {
 		return new ForkSmtArguments(newThreadIdArguments, newProcedureArguments);
 	}
 
-	private JoinSmtArguments copyJoinSmtArguments(final JoinSmtArguments joinSmtArguments,
+	private static JoinSmtArguments copyJoinSmtArguments(final JoinSmtArguments joinSmtArguments,
 			final Map<ILocalProgramVar, ILocalProgramVar> map, final ManagedScript managedScript) {
 		final Map<Term, Term> defaultVariableMapping = constructDefaultVariableMapping(map);
 		final MultiTermResult newThreadIdArguments =
 				copyMultiTermResult(joinSmtArguments.getThreadIdArguments(), defaultVariableMapping, managedScript);
-		final List<IProgramVar> newAssignmentLhs =
-				joinSmtArguments.getAssignmentLhs().stream().map(x -> getNew(map, x)).collect(Collectors.toList());
+		final List<IProgramVar> newAssignmentLhs = joinSmtArguments.getAssignmentLhs().stream()
+				.map(x -> x instanceof ILocalProgramVar ? map.get(x) : x).collect(Collectors.toList());
 		return new JoinSmtArguments(newThreadIdArguments, newAssignmentLhs);
 	}
 
-	private static IProgramVar getNew(final Map<ILocalProgramVar, ILocalProgramVar> mapOld2New,
-			final IProgramVar variable) {
-		if (variable instanceof ILocalProgramVar) {
-			return mapOld2New.get(variable);
-		}
-		assert variable.isGlobal() : "Variable is neither local nor global";
-		return variable;
-	}
-
-	private MultiTermResult copyMultiTermResult(final MultiTermResult oldProcedureArguments,
+	private static MultiTermResult copyMultiTermResult(final MultiTermResult oldProcedureArguments,
 			final Map<Term, Term> defaultVariableMadefaultVariableMappingpping2, final ManagedScript managedScript) {
-		final Function<Term, Term> subst =
+		final UnaryOperator<Term> subst =
 				(x -> Substitution.apply(managedScript, defaultVariableMadefaultVariableMappingpping2, x));
 		final Term[] terms = Arrays.stream(oldProcedureArguments.getTerms()).map(subst).toArray(Term[]::new);
 		final Collection<TermVariable> auxiliaryVars = oldProcedureArguments.getAuxiliaryVars();
@@ -302,22 +282,11 @@ public class ProcedureMultiplier {
 	}
 
 	private static Map<Term, Term> constructDefaultVariableMapping(final Map<ILocalProgramVar, ILocalProgramVar> map) {
-		final Map<Term, Term> result = new HashMap<>();
-		for (final Entry<ILocalProgramVar, ILocalProgramVar> entry : map.entrySet()) {
-			result.put(entry.getKey().getTermVariable(), entry.getValue().getTermVariable());
-		}
-		return result;
+		return map.entrySet().stream()
+				.collect(Collectors.toMap(x -> x.getKey().getTermVariable(), x -> x.getValue().getTermVariable()));
 	}
 
-	private static IcfgLocation constructCopy(final IcfgLocation oldLoc, final String copy,
-			final BlockEncodingBacktranslator backtranslator) {
-		final IcfgLocation newLoc = new IcfgLocation(oldLoc.getDebugIdentifier(), copy);
-		ModelUtils.copyAnnotations(oldLoc, newLoc);
-		backtranslator.mapLocations(newLoc, oldLoc);
-		return newLoc;
-	}
-
-	public static HashRelation<String, String>
+	private static HashRelation<String, String>
 			generateCopyDirectives(final Collection<ThreadInstance> threadInstances) {
 		final HashRelation<String, String> result = new HashRelation<>();
 		for (final ThreadInstance ti : threadInstances) {
@@ -325,5 +294,4 @@ public class ProcedureMultiplier {
 		}
 		return result;
 	}
-
 }

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstance.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstance.java
@@ -41,15 +41,13 @@ public class ThreadInstance {
 	private final String mThreadTemplateName;
 
 	private final IProgramNonOldVar[] mIdVars;
-	private final IProgramNonOldVar mInUseVar;
 
 	public ThreadInstance(final String threadInstanceName, final String threadTemplateName,
-			final IProgramNonOldVar[] idVars, final IProgramNonOldVar inUseVar) {
+			final IProgramNonOldVar[] idVars) {
 		super();
 		mThreadInstanceName = threadInstanceName;
 		mThreadTemplateName = threadTemplateName;
 		mIdVars = idVars;
-		mInUseVar = inUseVar;
 	}
 
 	public String getThreadInstanceName() {

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstanceAdder.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstanceAdder.java
@@ -341,8 +341,7 @@ public class ThreadInstanceAdder {
 			for (int j = 1; j <= numberOfThreadInstances; j++) {
 				final String procedureName = fork.getNameOfForkedProcedure();
 				final String threadInstanceId = generateThreadInstanceId(i, procedureName, j, numberOfThreadInstances);
-				final ThreadInstance ti = constructThreadInstance(mgdScript,
-						fork, procedureName, threadInstanceId);
+				final ThreadInstance ti = constructThreadInstance(mgdScript, fork, procedureName, threadInstanceId);
 				threadInstances.add(ti);
 			}
 			result.put(fork, threadInstances);
@@ -362,14 +361,12 @@ public class ThreadInstanceAdder {
 		return errorLocation;
 	}
 
-	private static ThreadInstance constructThreadInstance(
-			final ManagedScript mgdScript, final IIcfgForkTransitionThreadCurrent<IcfgLocation> fork,
-			final String procedureName, final String threadInstanceId) {
+	private static ThreadInstance constructThreadInstance(final ManagedScript mgdScript,
+			final IIcfgForkTransitionThreadCurrent<IcfgLocation> fork, final String procedureName,
+			final String threadInstanceId) {
 		final ProgramNonOldVar[] threadIdVars = constructThreadIdVariable(threadInstanceId, mgdScript,
 				fork.getForkSmtArguments().getThreadIdArguments().getTerms());
-
-		final ThreadInstance ti = new ThreadInstance(threadInstanceId, procedureName, threadIdVars);
-		return ti;
+		return new ThreadInstance(threadInstanceId, procedureName, threadIdVars);
 	}
 
 	private static String generateThreadInstanceId(final int forkNumber, final String procedureName,

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstanceAdder.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/ThreadInstanceAdder.java
@@ -99,21 +99,18 @@ public class ThreadInstanceAdder {
 			final List<IIcfgJoinTransitionThreadCurrent<IcfgLocation>> joinCurrentThreads,
 			final Map<IIcfgForkTransitionThreadCurrent<IcfgLocation>, List<ThreadInstance>> threadInstanceMap,
 			final Map<IIcfgForkTransitionThreadCurrent<IcfgLocation>, IcfgLocation> inUseErrorNodeMap,
-			final BlockEncodingBacktranslator backtranslator, final boolean addThreadInUseViolationEdges) {
+			final BlockEncodingBacktranslator backtranslator) {
 		for (final IIcfgForkTransitionThreadCurrent<IcfgLocation> fct : forkCurrentThreads) {
-			if (addThreadInUseViolationEdges) {
-				final IcfgLocation callerNode = fct.getSource();
-				final IcfgLocation errorNode = inUseErrorNodeMap.get(fct);
-				final IcfgEdgeFactory ef = icfg.getCfgSmtToolkit().getIcfgEdgeFactory();
-				final UnmodifiableTransFormula errorTransformula =
-						TransFormulaBuilder.getTrivialTransFormula(icfg.getCfgSmtToolkit().getManagedScript());
-				final IcfgInternalTransition errorTransition = ef.createInternalTransition(callerNode, errorNode,
-						new Payload(), errorTransformula, errorTransformula);
-				integrateForkEdge(fct, backtranslator, callerNode, errorNode, errorTransition);
-			}
+			final IcfgLocation callerNode = fct.getSource();
+			final IcfgLocation errorNode = inUseErrorNodeMap.get(fct);
+			final IcfgEdgeFactory ef = icfg.getCfgSmtToolkit().getIcfgEdgeFactory();
+			final UnmodifiableTransFormula errorTransformula =
+					TransFormulaBuilder.getTrivialTransFormula(icfg.getCfgSmtToolkit().getManagedScript());
+			final IcfgInternalTransition errorTransition = ef.createInternalTransition(callerNode, errorNode,
+					new Payload(), errorTransformula, errorTransformula);
+			integrateForkEdge(fct, backtranslator, callerNode, errorNode, errorTransition);
 			for (final ThreadInstance ti : threadInstanceMap.get(fct)) {
-				addForkOtherThreadTransition(fct, ti.getIdVars(), icfg, ti.getThreadInstanceName(), backtranslator,
-						addThreadInUseViolationEdges);
+				addForkOtherThreadTransition(fct, ti.getIdVars(), icfg, ti.getThreadInstanceName(), backtranslator);
 			}
 		}
 
@@ -129,8 +126,7 @@ public class ThreadInstanceAdder {
 						isReturnValueCompatible(jot.getJoinSmtArguments().getAssignmentLhs(),
 								icfg.getCfgSmtToolkit().getOutParams().get(ti.getThreadInstanceName()));
 				if (threadIdCompatible && returnValueCompatible) {
-					addJoinOtherThreadTransition(jot, ti.getThreadInstanceName(), ti.getIdVars(), icfg, backtranslator,
-							addThreadInUseViolationEdges);
+					addJoinOtherThreadTransition(jot, ti.getThreadInstanceName(), ti.getIdVars(), icfg, backtranslator);
 					joinOtherThreadTransitions++;
 				}
 			}
@@ -186,7 +182,6 @@ public class ThreadInstanceAdder {
 	 * Add ForkOtherThreadEdge from the ForkCurrentThreadEdge source to the entry location of the forked procedure.
 	 *
 	 * @param backtranslator
-	 * @param addThreadInUseViolationEdges
 	 * @param string
 	 *
 	 * @param edge
@@ -194,8 +189,7 @@ public class ThreadInstanceAdder {
 	 */
 	private void addForkOtherThreadTransition(final IIcfgForkTransitionThreadCurrent<IcfgLocation> fct,
 			final IProgramNonOldVar[] threadIdVars, final IIcfg<? extends IcfgLocation> icfg,
-			final String threadInstanceName, final BlockEncodingBacktranslator backtranslator,
-			final boolean addThreadInUseViolationEdges) {
+			final String threadInstanceName, final BlockEncodingBacktranslator backtranslator) {
 		// FIXME Matthias 2018-08-17: check method, especially for terminology and
 		// overapproximation flags
 
@@ -283,8 +277,7 @@ public class ThreadInstanceAdder {
 	 */
 	private void addJoinOtherThreadTransition(final IIcfgJoinTransitionThreadCurrent<IcfgLocation> jot,
 			final String threadInstanceName, final IProgramNonOldVar[] threadIdVars,
-			final IIcfg<? extends IcfgLocation> icfg, final BlockEncodingBacktranslator backtranslator,
-			final boolean addThreadInUseViolationEdges) {
+			final IIcfg<? extends IcfgLocation> icfg, final BlockEncodingBacktranslator backtranslator) {
 		// FIXME Matthias 2018-08-17: check method, especially for terminology and
 		// overapproximation flags
 		final IcfgLocation exitNode = icfg.getProcedureExitNodes().get(threadInstanceName);

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/TraceAbstractionStarter.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/TraceAbstractionStarter.java
@@ -502,8 +502,7 @@ public class TraceAbstractionStarter<L extends IIcfgTransition<?>> {
 		assert IcfgUtils.isConcurrent(icfg) : "Petrification unnecessary for sequential programs";
 
 		mLogger.info("Constructing petrified ICFG for " + numberOfThreadInstances + " thread instances.");
-		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, icfg,
-				numberOfThreadInstances);
+		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, icfg, numberOfThreadInstances);
 		final IIcfg<IcfgLocation> petrifiedIcfg = icfgPetrifier.getPetrifiedIcfg();
 		mLocationMap = ((BlockEncodingBacktranslator) icfgPetrifier.getBacktranslator()).getLocationMapping();
 		mServices.getBacktranslationService().addTranslator(icfgPetrifier.getBacktranslator());

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/TraceAbstractionStarter.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/TraceAbstractionStarter.java
@@ -60,7 +60,6 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.IProgressMonitorS
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.CfgSmtToolkit;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier.IcfgConstructionMode;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgUtils;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfg;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfgElement;
@@ -504,7 +503,7 @@ public class TraceAbstractionStarter<L extends IIcfgTransition<?>> {
 
 		mLogger.info("Constructing petrified ICFG for " + numberOfThreadInstances + " thread instances.");
 		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, icfg,
-				IcfgConstructionMode.ASSUME_THREAD_INSTANCE_SUFFICIENCY, numberOfThreadInstances);
+				numberOfThreadInstances);
 		final IIcfg<IcfgLocation> petrifiedIcfg = icfgPetrifier.getPetrifiedIcfg();
 		mLocationMap = ((BlockEncodingBacktranslator) icfgPetrifier.getBacktranslator()).getLocationMapping();
 		mServices.getBacktranslationService().addTranslator(icfgPetrifier.getBacktranslator());

--- a/trunk/source/TraceAbstractionConcurrent/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstractionconcurrent/TraceAbstractionConcurrentObserver.java
+++ b/trunk/source/TraceAbstractionConcurrent/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstractionconcurrent/TraceAbstractionConcurrentObserver.java
@@ -43,7 +43,6 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceP
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.CfgSmtToolkit;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgPetrifier.IcfgConstructionMode;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgUtils;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfg;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfgTransition;
@@ -87,7 +86,7 @@ public class TraceAbstractionConcurrentObserver implements IUnmanagedObserver {
 		final IIcfg<? extends IcfgLocation> inputIcfg = (IIcfg<?>) root;
 		final int numberOfThreadInstances = 3;
 		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, inputIcfg,
-				IcfgConstructionMode.ASSUME_THREAD_INSTANCE_SUFFICIENCY, numberOfThreadInstances);
+				numberOfThreadInstances);
 		final IIcfg<? extends IcfgLocation> petrifiedIcfg = icfgPetrifier.getPetrifiedIcfg();
 		mServices.getBacktranslationService().addTranslator(icfgPetrifier.getBacktranslator());
 		final TAPreferences taPrefs = new TAPreferences(mServices);

--- a/trunk/source/TraceAbstractionConcurrent/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstractionconcurrent/TraceAbstractionConcurrentObserver.java
+++ b/trunk/source/TraceAbstractionConcurrent/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstractionconcurrent/TraceAbstractionConcurrentObserver.java
@@ -85,8 +85,7 @@ public class TraceAbstractionConcurrentObserver implements IUnmanagedObserver {
 	public boolean process(final IElement root) {
 		final IIcfg<? extends IcfgLocation> inputIcfg = (IIcfg<?>) root;
 		final int numberOfThreadInstances = 3;
-		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, inputIcfg,
-				numberOfThreadInstances);
+		final IcfgPetrifier icfgPetrifier = new IcfgPetrifier(mServices, inputIcfg, numberOfThreadInstances);
 		final IIcfg<? extends IcfgLocation> petrifiedIcfg = icfgPetrifier.getPetrifiedIcfg();
 		mServices.getBacktranslationService().addTranslator(icfgPetrifier.getBacktranslator());
 		final TAPreferences taPrefs = new TAPreferences(mServices);


### PR DESCRIPTION
Refactor `IcfgPetrifier` (and callees). This includes:
* Use static method for `ProcedureMultiplier` instead of constructor
* Extract code from this (very long!) method into helper methods
* Slightly simplified `ProcedureMultiplier`
* Minor changes on IcfgPetrifier (e.g. make mPetrifiedIcfg of type BasicIcfg instead of always casting it)
* Remove deprecated and unused methods of `ThreadInstanceAdder`
* Remove unused setting `IcfgConstructionMode` in `IcfgPetrifier`
*  Remove InUseVars (they were passed to `ThreadInstance`, but could not be used) 