### PR TITLE
Feature: Add LTL time step specifications to Boogie input files

### DIFF
--- a/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/BoogiePreprocessor.java
+++ b/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/BoogiePreprocessor.java
@@ -113,6 +113,7 @@ public class BoogiePreprocessor implements IAnalysis {
 		observers.add(new StructExpander(backTranslator, logger));
 		observers.add(new UnstructureCode(backTranslator));
 		observers.add(new FunctionInliner(logger));
+		observers.add(new LTLStepAnnotator());
 		if (useSimplifier) {
 			observers.add(new Simplifier(backTranslator));
 		}

--- a/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/LTLStepAnnotator.java
+++ b/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/LTLStepAnnotator.java
@@ -1,0 +1,84 @@
+package de.uni_freiburg.informatik.ultimate.boogie.preprocessor;
+
+import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
+
+import de.uni_freiburg.informatik.ultimate.boogie.ast.GeneratedBoogieAstTransformer;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedAttribute;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.Unit;
+import de.uni_freiburg.informatik.ultimate.core.lib.observers.BaseObserver;
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LTLStepAnnotation;
+
+/**
+ * Transform Boogie annotations of the form {: ltl_step } into corresponding
+ * step specifications.
+ *
+ * @author Martin Neuhäußer (post@marneu.com)
+ */
+public class LTLStepAnnotator extends BaseObserver {
+
+	protected LTLStepAnnotator() {
+	}
+
+	/**
+	 * The process function. Called by the tool-chain and gets a node of the graph as parameter.
+	 * The function traverses the graph and attached LTL step specifications to each assume,
+	 * assert and call statement that has an "ltl_step" attribute attached to it.
+	 */
+	@Override
+	public boolean process(final IElement root) {
+		if (root instanceof Unit) {
+			final Unit unit = (Unit) root;
+			processUnit(unit);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Searches for all procedures in the Boogie file and visits each statement.
+	 * @param unit The root of the abstract syntax tree
+	 */
+	private void processUnit(final Unit unit) {
+		final BoogieLTLStepAnnotator ltlAnnotator = new BoogieLTLStepAnnotator();
+		unit.accept(ltlAnnotator);
+	}
+
+	/**
+	 * Attach LTL step specifications to all assume, assert and call statements that have
+	 * a Boogie attribute "ltl_step" attached to them.
+	 * @author Martin Neuhäußer
+	 */
+	private final class BoogieLTLStepAnnotator extends GeneratedBoogieAstTransformer {
+		private Statement attachLTLSpecification(final Statement stmt, final NamedAttribute[] attrs) {
+			if (attrs != null) {
+				for (final NamedAttribute attr : attrs) {
+					if (attr.getName() == "ltl_step") {
+						LTLStepAnnotation stepAnnotation = new LTLStepAnnotation();
+						stepAnnotation.annotate(stmt);
+					}
+				}
+			}
+			return stmt;
+		}
+
+		@Override
+		public Statement transform(final AssumeStatement node) {
+			return attachLTLSpecification(node, node.getAttributes());
+		}
+
+		@Override
+		public Statement transform(final AssertStatement node) {
+			return attachLTLSpecification(node, node.getAttributes());
+		}
+
+		@Override
+		public Statement transform(final CallStatement node) {
+			return attachLTLSpecification(node, node.getAttributes());
+		}
+
+	}
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -2075,9 +2075,10 @@ public class StandardFunctionHandler {
 
 	private static Result handleLtlStep(final IDispatcher main, final IASTFunctionCallExpression node,
 			final ILocation loc) {
-		final LTLStepAnnotation ltlStep = new LTLStepAnnotation();
-		final AssumeStatement assumeStmt = new AssumeStatement(loc, ExpressionFactory.createBooleanLiteral(loc, true));
-		ltlStep.annotate(assumeStmt);
+		final NamedAttribute ltlAttribute = new NamedAttribute(loc, "ltl_step", new Expression[]{ });
+		final AssumeStatement assumeStmt = new AssumeStatement(loc, 
+				new NamedAttribute[] { ltlAttribute }, 
+				ExpressionFactory.createBooleanLiteral(loc, true))  ;
 		return new ExpressionResult(Collections.singletonList(assumeStmt), null);
 	}
 


### PR DESCRIPTION
While the C front end does support the definition of LTL time steps by calling the special function `__VERIFIER_ltl_step()`, similar functionality seems to be missing for bare Boogie input files.

With this patch, one can label `assume`, `assert`, and `call` statements in Boogie input files with a parameterless attribute `ltl_step`. The Boogie preprocessor then attaches internal LTLStepAnnotation labels to the respective nodes, thereby making the step specification available to the Büchi product generator.

Goal of this PR is to support LTL time step boundaries via inserting `assume {: ltl_step } true` statements at the appropriate control flow locations.