### PR TITLE
Fix handling of LTLStepAnnotations in Büchi program product construction and RCFGBuilder

### DIFF
--- a/trunk/source/BuchiProgramProduct/src/de/uni_freiburg/informatik/ultimate/buchiprogramproduct/productgenerator/ProductGenerator.java
+++ b/trunk/source/BuchiProgramProduct/src/de/uni_freiburg/informatik/ultimate/buchiprogramproduct/productgenerator/ProductGenerator.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import de.uni_freiburg.informatik.ultimate.automata.nestedword.INestedWordAutomaton;
 import de.uni_freiburg.informatik.ultimate.automata.nestedword.transitions.OutgoingInternalTransition;
@@ -52,6 +53,8 @@ import de.uni_freiburg.informatik.ultimate.buchiprogramproduct.ProductBacktransl
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.BuchiProgramAcceptingStateAnnotation;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LTLStepAnnotation;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IActionWithBranchEncoders;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdge;
@@ -765,8 +768,13 @@ public final class ProductGenerator {
 
 	private BoogieIcfgLocation createProductProgramPoint(final DebugIdentifier debugIdentifier,
 			final BoogieIcfgLocation originalState) {
-		final BoogieIcfgLocation rtr = new BoogieIcfgLocation(debugIdentifier, originalState.getProcedure(), false,
-				originalState.getBoogieASTNode());
+		final Predicate<IAnnotations> omitLTLStepAnnotations = (a -> !(a instanceof LTLStepAnnotation));
+
+		final BoogieIcfgLocation rtr = new BoogieIcfgLocation(debugIdentifier,
+				originalState.getProcedure(),
+				false,
+				originalState.getBoogieASTNode(),
+				omitLTLStepAnnotations);
 
 		// update metadata
 		Map<DebugIdentifier, BoogieIcfgLocation> prog2programPoints = mProductRoot.getProgramPoints()

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/BoogieIcfgLocation.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/BoogieIcfgLocation.java
@@ -27,6 +27,8 @@
  */
 package de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder.cfg;
 
+import java.util.function.Predicate;
+
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BoogieASTNode;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
@@ -36,6 +38,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
 import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Visualizable;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocation;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.debugidentifiers.DebugIdentifier;
@@ -69,10 +72,25 @@ public class BoogieIcfgLocation extends IcfgLocation {
 	 */
 	public BoogieIcfgLocation(final DebugIdentifier debugIdentifier, final String procedure, final boolean isErrorLoc,
 			final BoogieASTNode boogieASTNode) {
+		this(debugIdentifier, procedure, isErrorLoc, boogieASTNode, a -> true);
+	}
+
+	/**
+	 *
+	 * @param debugIdentifier
+	 *            see {@link IcfgLocation} (must be unique inside its procedure among all the nodes!)
+	 * @param procedure
+	 * @param isErrorLoc
+	 * @param boogieASTNode
+	 * @param annotationFilter Predicate to determine which annotations to copy over from boogieAstNode
+	 */
+	public BoogieIcfgLocation(final DebugIdentifier debugIdentifier, final String procedure, final boolean isErrorLoc,
+			final BoogieASTNode boogieASTNode,
+			final Predicate<IAnnotations> annotationFilter) {
 		super(debugIdentifier, procedure);
 		mIsErrorLocation = isErrorLoc;
 		mBoogieASTNode = boogieASTNode;
-		ModelUtils.copyAnnotations(boogieASTNode, this);
+		ModelUtils.copyAnnotationsFiltered(boogieASTNode, this, annotationFilter);
 		final ILocation loc = getLocationFromASTNode(boogieASTNode);
 		if (loc != null) {
 			loc.annotate(this);

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
@@ -75,6 +75,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.core.lib.exceptions.ToolchainCanceledException;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.AtomicBlockInfo;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Check;
+import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LTLStepAnnotation;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LoopEntryAnnotation;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LoopEntryAnnotation.LoopEntryType;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.LoopExitAnnotation;
@@ -491,13 +492,17 @@ public class CfgBuilder {
 	}
 
 	/**
-	 * Check it this statement is an <code>assume true</ code> and has an empty list of attributes (or no attributes at
-	 * all).
+	 * Check it this statement is a plain <code>assume true</code> statement, i.e. whether
+	 * * it has an empty list of attributes or no attributes at all, and
+	 * * it is not annotated with an LTLStepAnnotation. 
 	 */
-	private static boolean isAssumeTrueStatementWithoutAttributes(final Statement st) {
+	private static boolean isPlainAssumeTrueStatement(final Statement st) {
 		if (st instanceof AssumeStatement) {
 			final AssumeStatement as = (AssumeStatement) st;
 			if (as.getAttributes() != null && as.getAttributes().length > 0) {
+				return false;
+			}
+			if (LTLStepAnnotation.getAnnotation(as) != null) {
 				return false;
 			}
 			if (as.getFormula() instanceof BooleanLiteral) {
@@ -683,7 +688,7 @@ public class CfgBuilder {
 
 				// Rationale: <code>assume true</ code> statements can be omitted, unless they
 				// carry attributes or indicate an overapproximation.
-				if (mRemoveAssumeTrueStmt && isAssumeTrueStatementWithoutAttributes(st) && !isOverapproximation(st)) {
+				if (mRemoveAssumeTrueStmt && isPlainAssumeTrueStatement(st) && !isOverapproximation(st)) {
 					mRemovedAssumeTrueStatements++;
 					continue;
 				}


### PR DESCRIPTION
This PR includes two patches:
* 2e35eee: With this patch, the Büchi program product construction does no longer preserve LTLStepAnnotations in the resulting interprocedural CFG. This allows us to use all variants of large block encodings on the product automaton.
If LTLStepAnnotations were present, LBE would generally run into problems whenever two successive edges that both bear LTLStepAnnotations are merged. The LTL step annotations will not convey much information in the Büchi program product after LBE is complete, anyways. 
So I assume it is safe to discard them at his stage.
*  0dce1c2: This patch adds a condition to the RCFGBuilder's code that removes `assume(true)` statements so that such statements are preserved if they bear an LTL step annotation (and therefore are semantically relevant). So far, only `assume(true)` statements with attributes were preserved but annotations weren't taken into account.