### PR TITLE
Fix backtranslation bug for Büchi program products

### DIFF
--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslator.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslator.java
@@ -608,7 +608,7 @@ public class CACSL2BoogieBacktranslator
 		for (; j < programExecution.getLength(); ++j) {
 			// search for other nodes that have the same location in order to merge them all into one new statement
 			final AtomicTraceElement<BoogieASTNode> lookahead = programExecution.getTraceElement(j);
-			if (!lookahead.getTraceElement().getLocation().equals(loc)) {
+			if (!loc.equals(lookahead.getTraceElement().getLocation())) {
 				j--;
 				break;
 			}


### PR DESCRIPTION
This patch addresses a NullPointerException bug that occurs in the CACSL backtranslator for counterexample traces that stem from LTL model checking. Some nodes in the counterexample trace may have no CLocation attached to them (e.g. transitions introduced by product construction). That is not taken into account in the backtranslation code.

An example C program that triggers the bug is the following:
```C
//#Unsafe
//@ ltl invariant positive: [](AP(a==1) ==> X(AP(a==2)));

extern void __VERIFIER_ltl_step() __attribute__ ((__noreturn__));

int a, x = 5;

int main()
{
	x = 99;
	a = 1;
	__VERIFIER_ltl_step();
	a = 1;
	a = 2;
	__VERIFIER_ltl_step();
	a = 6;
	__VERIFIER_ltl_step();
	x = 0;
        a = 1;
	__VERIFIER_ltl_step();
        a = 2;
        a = 9;
}
```

I used the following toolchain definition and preferences (essentially not using lbe):
```
<rundefinition>
	<name>Ultimate Toolchain</name>
	<toolchain>
	<plugin id="de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator" />
	<plugin id="de.uni_freiburg.informatik.ultimate.boogie.preprocessor" />
	<plugin id="de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder" />
	<plugin id="de.uni_freiburg.informatik.ultimate.ltl2aut" />
	<plugin id="de.uni_freiburg.informatik.ultimate.buchiprogramproduct" /> 
	<plugin id="de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer" /> 
	</toolchain>
</rundefinition>
```

```
#Fri Apr 29 16:11:45 CEST 2022
\!/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder=
/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder/Remove\ assume\ true\ statements=false
/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder/Size\ of\ a\ code\ block=SingleStatement
/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder/SMT\ solver=Internal_SMTInterpol
@de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder=0.2.2
file_export_version=3.0
#Fri Apr 29 16:11:45 CEST 2022
\!/instance/de.uni_freiburg.informatik.ultimate.ltl2aut=
/instance/de.uni_freiburg.informatik.ultimate.ltl2aut/Read\ property\ from\ file=true
/instance/de.uni_freiburg.informatik.ultimate.ltl2aut/Rewrite\ not\ equals\ during\ small\ block\ encoding=true
/instance/de.uni_freiburg.informatik.ultimate.ltl2aut/Use\ small\ block\ encoding=false
@de.uni_freiburg.informatik.ultimate.ltl2aut=0.2.2
file_export_version=3.0
```

The output is as follows (only end of log file):
```
[2022-05-10 09:33:07,699 INFO  L425         BuchiCegarLoop]: ======== Iteration 4============
[2022-05-10 09:33:07,699 INFO  L72            BuchiIsEmpty]: Start buchiIsEmpty. Operand 22 states and 22 transitions.
[2022-05-10 09:33:07,699 INFO  L131   ngComponentsAnalysis]: Automaton has 1 accepting balls. 1
[2022-05-10 09:33:07,699 INFO  L87            BuchiIsEmpty]: Finished buchiIsEmpty Result is false
[2022-05-10 09:33:07,699 INFO  L119           BuchiIsEmpty]: Starting construction of run
[2022-05-10 09:33:07,700 INFO  L842         BuchiCegarLoop]: Counterexample stem histogram [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
[2022-05-10 09:33:07,700 INFO  L843         BuchiCegarLoop]: Counterexample loop histogram [1]
[2022-05-10 09:33:07,700 INFO  L786   eck$LassoCheckResult]: Stem: 417#ULTIMATE.startENTRY_NONWA call ULTIMATE.init();< 426#ULTIMATE.initENTRY_NONWA ~a~0 := 0; 418#L6_NONWA ~x~0 := 5; 419#ULTIMATE.initFINAL_NONWA assume true; 416#ULTIMATE.initEXIT_NONWA >#89#return; 410#L-1_NONWA call #t~ret0 := main();< 424#mainENTRY_T0_init ~x~0 := 99; 425#L11_T0_init ~a~0 := 1; 429#L12_T0_init assume true;assume true; 430#L13_T0_init ~a~0 := 1; 409#L14_T0_init ~a~0 := 2; 411#L15_T0_init assume true;assume true; 412#L16_T0_init ~a~0 := 6; 413#L17_T0_init assume true;assume true; 423#L18_T0_init ~x~0 := 0; 422#L19_T0_init ~a~0 := 1; 414#L20_T0_init assume true;assume 1 == ~a~0; 415#L21_accept_S2 ~a~0 := 2; 420#L22_accept_S2 ~a~0 := 9; 421#mainFINAL_accept_S2 assume true; 428#mainEXIT_accept_S2 assume true;assume !(2 == ~a~0); 427#mainEXIT_accept_all 
[2022-05-10 09:33:07,700 INFO  L788   eck$LassoCheckResult]: Loop: 427#mainEXIT_accept_all assume true;assume true; 427#mainEXIT_accept_all 
[2022-05-10 09:33:07,700 INFO  L144       PredicateUnifier]: Initialized classic predicate unifier
[2022-05-10 09:33:07,700 INFO  L85        PathProgramCache]: Analyzing trace with hash -688463312, now seen corresponding path program 1 times
[2022-05-10 09:33:07,700 INFO  L118   FreeRefinementEngine]: Executing refinement strategy FIXED_PREFERENCES
[2022-05-10 09:33:07,701 INFO  L333   FreeRefinementEngine]: Using trace check IpTcStrategyModulePreferences [552751167]
[2022-05-10 09:33:07,701 INFO  L95    rtionOrderModulation]: Keeping assertion order NOT_INCREMENTALLY
[2022-05-10 09:33:07,701 INFO  L127          SolverBuilder]: Constructing new instance of SMTInterpol with explicit timeout -1 ms and remaining time -1 ms
[2022-05-10 09:33:07,710 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,710 INFO  L352             TraceCheck]: Trace is feasible, we will do another trace check, this time with branch encoders.
[2022-05-10 09:33:07,714 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,718 INFO  L130   FreeRefinementEngine]: Strategy FIXED_PREFERENCES found a feasible trace
[2022-05-10 09:33:07,718 INFO  L144       PredicateUnifier]: Initialized classic predicate unifier
[2022-05-10 09:33:07,718 INFO  L85        PathProgramCache]: Analyzing trace with hash 94, now seen corresponding path program 4 times
[2022-05-10 09:33:07,719 INFO  L118   FreeRefinementEngine]: Executing refinement strategy FIXED_PREFERENCES
[2022-05-10 09:33:07,719 INFO  L333   FreeRefinementEngine]: Using trace check IpTcStrategyModulePreferences [712413136]
[2022-05-10 09:33:07,719 INFO  L95    rtionOrderModulation]: Keeping assertion order NOT_INCREMENTALLY
[2022-05-10 09:33:07,719 INFO  L127          SolverBuilder]: Constructing new instance of SMTInterpol with explicit timeout -1 ms and remaining time -1 ms
[2022-05-10 09:33:07,721 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,721 INFO  L352             TraceCheck]: Trace is feasible, we will do another trace check, this time with branch encoders.
[2022-05-10 09:33:07,722 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,723 INFO  L130   FreeRefinementEngine]: Strategy FIXED_PREFERENCES found a feasible trace
[2022-05-10 09:33:07,723 INFO  L144       PredicateUnifier]: Initialized classic predicate unifier
[2022-05-10 09:33:07,723 INFO  L85        PathProgramCache]: Analyzing trace with hash 132473871, now seen corresponding path program 1 times
[2022-05-10 09:33:07,723 INFO  L118   FreeRefinementEngine]: Executing refinement strategy FIXED_PREFERENCES
[2022-05-10 09:33:07,724 INFO  L333   FreeRefinementEngine]: Using trace check IpTcStrategyModulePreferences [1452482666]
[2022-05-10 09:33:07,724 INFO  L95    rtionOrderModulation]: Keeping assertion order NOT_INCREMENTALLY
[2022-05-10 09:33:07,724 INFO  L127          SolverBuilder]: Constructing new instance of SMTInterpol with explicit timeout -1 ms and remaining time -1 ms
[2022-05-10 09:33:07,735 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,735 INFO  L352             TraceCheck]: Trace is feasible, we will do another trace check, this time with branch encoders.
[2022-05-10 09:33:07,740 INFO  L136    AnnotateAndAsserter]: Conjunction of SSA is sat
[2022-05-10 09:33:07,743 INFO  L130   FreeRefinementEngine]: Strategy FIXED_PREFERENCES found a feasible trace
[2022-05-10 09:33:07,856 FATAL L?                        ?]: The Plugin de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer has thrown an exception:
java.lang.NullPointerException
	at de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.CACSL2BoogieBacktranslator.findMergeSequence(CACSL2BoogieBacktranslator.java:611)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.CACSL2BoogieBacktranslator.translateProgramExecution(CACSL2BoogieBacktranslator.java:278)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ModelTranslationContainer.translateProgramExecution(ModelTranslationContainer.java:216)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ModelTranslationContainer.translateProgramExecution(ModelTranslationContainer.java:225)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ModelTranslationContainer.translateProgramExecution(ModelTranslationContainer.java:225)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ModelTranslationContainer.translateProgramExecution(ModelTranslationContainer.java:225)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ModelTranslationContainer.translateProgramExecution(ModelTranslationContainer.java:206)
	at de.uni_freiburg.informatik.ultimate.core.lib.results.LTLInfiniteCounterExampleResult.getLongDescription(LTLInfiniteCounterExampleResult.java:67)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.services.ResultService.reportResult(ResultService.java:86)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer.BuchiAutomizerObserver.reportResult(BuchiAutomizerObserver.java:374)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer.BuchiAutomizerObserver.reportLTLPropertyIsViolated(BuchiAutomizerObserver.java:342)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer.BuchiAutomizerObserver.interpretAndReportResult(BuchiAutomizerObserver.java:214)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer.BuchiAutomizerObserver.doTerminationAnalysis(BuchiAutomizerObserver.java:162)
	at de.uni_freiburg.informatik.ultimate.plugins.generator.buchiautomizer.BuchiAutomizerObserver.finish(BuchiAutomizerObserver.java:397)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.PluginConnector.runObserver(PluginConnector.java:168)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.PluginConnector.runTool(PluginConnector.java:151)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.PluginConnector.run(PluginConnector.java:128)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.ToolchainWalker.executePluginConnector(ToolchainWalker.java:232)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.ToolchainWalker.processPlugin(ToolchainWalker.java:226)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.ToolchainWalker.walkUnprotected(ToolchainWalker.java:142)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.ToolchainWalker.walk(ToolchainWalker.java:104)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.ToolchainManager$Toolchain.processToolchain(ToolchainManager.java:320)
	at de.uni_freiburg.informatik.ultimate.core.coreplugin.toolchain.DefaultToolchainJob.run(DefaultToolchainJob.java:145)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```