### PR TITLE
remove LETTER type parameter from Marking

### DIFF
--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/partialorder/Petri2AutomatonCoveringRelation.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/partialorder/Petri2AutomatonCoveringRelation.java
@@ -57,18 +57,17 @@ import de.uni_freiburg.informatik.ultimate.automata.petrinet.Marking;
  */
 public class Petri2AutomatonCoveringRelation<L, S, P> implements ICoveringRelation<S> {
 	private final IPetriNet<L, P> mPetriNet;
-	private final Function<S, Marking<L, P>> mGetMarking;
+	private final Function<S, Marking<P>> mGetMarking;
 
-	public Petri2AutomatonCoveringRelation(final IPetriNet<L, P> petriNet,
-			final Function<S, Marking<L, P>> getMarking) {
+	public Petri2AutomatonCoveringRelation(final IPetriNet<L, P> petriNet, final Function<S, Marking<P>> getMarking) {
 		mPetriNet = petriNet;
 		mGetMarking = Objects.requireNonNull(getMarking);
 	}
 
 	@Override
 	public boolean covers(final S oldState, final S newState) {
-		final Marking<L, P> oldMarking = mGetMarking.apply(oldState);
-		final Marking<L, P> newMarking = mGetMarking.apply(newState);
+		final Marking<P> oldMarking = mGetMarking.apply(oldState);
+		final Marking<P> newMarking = mGetMarking.apply(newState);
 
 		// TODO In the future, the second disjunct below could be replaced by a strictly weaker condition:
 		// A (cached) check whether any accepting place can be reached from p.

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/IPetriNetSuccessorProvider.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/IPetriNetSuccessorProvider.java
@@ -36,12 +36,13 @@ public interface IPetriNetSuccessorProvider<LETTER, PLACE> extends IAutomaton<LE
 	Collection<ISuccessorTransitionProvider<LETTER, PLACE>> getSuccessorTransitionProviders(
 			final Set<PLACE> mustPlaces,
 			final Set<PLACE> mayPlaces);
+
 	/**
 	 * @param marking
 	 *            A marking.
 	 * @return {@code true} iff the marking is accepting.
 	 */
-	boolean isAccepting(Marking<LETTER, PLACE> marking);
+	boolean isAccepting(Marking<PLACE> marking);
 
 	boolean isAccepting(PLACE place);
 

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/Marking.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/Marking.java
@@ -44,12 +44,11 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.ImmutableSet;
  *
  * @author Matthias Heizmann (heizmann@informatik.uni-freiburg.de)
  * @author Julian Jarecki (jareckij@informatik.uni-freiburg.de)
- * @param <LETTER>
- *            symbols type
+ *
  * @param <PLACE>
  *            place content type
  */
-public class Marking<LETTER, PLACE> implements Iterable<PLACE>, Serializable {
+public class Marking<PLACE> implements Iterable<PLACE>, Serializable {
 	private static final long serialVersionUID = -357669345268897194L;
 
 	private final ImmutableSet<PLACE> mPlaces;
@@ -127,7 +126,7 @@ public class Marking<LETTER, PLACE> implements Iterable<PLACE>, Serializable {
 		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
-		final Marking<LETTER, PLACE> other = (Marking<LETTER, PLACE>) obj;
+		final Marking<PLACE> other = (Marking<PLACE>) obj;
 		if (mPlaces == null) {
 			if (other.mPlaces != null) {
 				return false;
@@ -148,7 +147,7 @@ public class Marking<LETTER, PLACE> implements Iterable<PLACE>, Serializable {
 	 *            The transition.
 	 * @return true, if the marking enables the specified transition.
 	 */
-	public boolean isTransitionEnabled(final ITransition<LETTER, PLACE> transition,
+	public <LETTER> boolean isTransitionEnabled(final ITransition<LETTER, PLACE> transition,
 			final IPetriNet<LETTER, PLACE> net) {
 		return mPlaces.containsAll(net.getPredecessors(transition));
 	}
@@ -159,7 +158,7 @@ public class Marking<LETTER, PLACE> implements Iterable<PLACE>, Serializable {
 	 * @return The marking to which the occurrence of the specified transition leads.
 	 * @throws PetriNetNot1SafeException
 	 */
-	public Marking<LETTER, PLACE> fireTransition(final ITransition<LETTER, PLACE> transition,
+	public <LETTER> Marking<PLACE> fireTransition(final ITransition<LETTER, PLACE> transition,
 			final IPetriNet<LETTER, PLACE> net) throws PetriNetNot1SafeException {
 		final Set<PLACE> predecessors = net.getPredecessors(transition);
 		final Set<PLACE> successors = net.getSuccessors(transition);

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/PetriNetRun.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/PetriNetRun.java
@@ -42,10 +42,10 @@ import de.uni_freiburg.informatik.ultimate.automata.nestedword.NestedWord;
  * @param <PLACE>
  *            place content type
  */
-public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, PLACE>> {
+public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<PLACE>> {
 
 	private final Word<LETTER> mWord;
-	private final ArrayList<Marking<LETTER, PLACE>> mMarkingSequence;
+	private final ArrayList<Marking<PLACE>> mMarkingSequence;
 
 	/**
 	 * Construct Petri net run of length 0.
@@ -53,7 +53,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	 * @param m0
 	 *            initial marking
 	 */
-	public PetriNetRun(final Marking<LETTER, PLACE> m0) {
+	public PetriNetRun(final Marking<PLACE> m0) {
 		mWord = new NestedWord<>();
 		mMarkingSequence = new ArrayList<>();
 		mMarkingSequence.add(m0);
@@ -69,7 +69,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	 * @param m1
 	 *            next marking
 	 */
-	public PetriNetRun(final Marking<LETTER, PLACE> m0, final LETTER symbol, final Marking<LETTER, PLACE> m1) {
+	public PetriNetRun(final Marking<PLACE> m0, final LETTER symbol, final Marking<PLACE> m1) {
 		mWord = new NestedWord<>(symbol, NestedWord.INTERNAL_POSITION);
 		mMarkingSequence = new ArrayList<>();
 		mMarkingSequence.add(m0);
@@ -84,7 +84,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	 * @param word
 	 *            corresponding word
 	 */
-	public PetriNetRun(final ArrayList<Marking<LETTER, PLACE>> sequenceOfMarkings, final Word<LETTER> word) {
+	public PetriNetRun(final ArrayList<Marking<PLACE>> sequenceOfMarkings, final Word<LETTER> word) {
 		if (sequenceOfMarkings.size() - 1 != word.length()) {
 			throw new IllegalArgumentException("run consists of word length +1 markings");
 		}
@@ -107,7 +107,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	 *            Position.
 	 * @return marking at the given position
 	 */
-	public Marking<LETTER, PLACE> getMarking(final int pos) {
+	public Marking<PLACE> getMarking(final int pos) {
 		return mMarkingSequence.get(pos);
 	}
 
@@ -122,7 +122,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	 * @return A new run which is the concatenation of this and run2. This is not changed.
 	 */
 	public PetriNetRun<LETTER, PLACE> concatenate(final PetriNetRun<LETTER, PLACE> run2) {
-		final ArrayList<Marking<LETTER, PLACE>> concatMarkingSequence = new ArrayList<>();
+		final ArrayList<Marking<PLACE>> concatMarkingSequence = new ArrayList<>();
 		for (int i = 0; i < mMarkingSequence.size(); i++) {
 			concatMarkingSequence.add(this.getMarking(i));
 		}
@@ -154,7 +154,7 @@ public class PetriNetRun<LETTER, PLACE> implements IRun<LETTER, Marking<LETTER, 
 	}
 
 	@Override
-	public List<Marking<LETTER, PLACE>> getStateSequence() {
+	public List<Marking<PLACE>> getStateSequence() {
 		return mMarkingSequence;
 	}
 }

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/netdatastructures/BoundedPetriNet.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/netdatastructures/BoundedPetriNet.java
@@ -344,7 +344,7 @@ public final class BoundedPetriNet<LETTER, PLACE> implements IPetriNet<LETTER, P
 	}
 
 	@Override
-	public boolean isAccepting(final Marking<LETTER, PLACE> marking) {
+	public boolean isAccepting(final Marking<PLACE> marking) {
 		for (final PLACE place : marking) {
 			if (getAcceptingPlaces().contains(place)) {
 				return true;

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/Accepts.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/Accepts.java
@@ -108,7 +108,7 @@ public final class Accepts<LETTER, PLACE> extends UnaryNetOperation<LETTER, PLAC
 		return mResult;
 	}
 
-	private boolean getResultHelper(final int position, final Marking<LETTER, PLACE> marking)
+	private boolean getResultHelper(final int position, final Marking<PLACE> marking)
 			throws AutomataOperationCanceledException, PetriNetNot1SafeException {
 		if (position >= mWord.length()) {
 			return mOperand.isAccepting(marking);
@@ -125,7 +125,7 @@ public final class Accepts<LETTER, PLACE> extends UnaryNetOperation<LETTER, PLAC
 
 		final int nextPosition = position + 1;
 		boolean result = false;
-		Marking<LETTER, PLACE> nextMarking;
+		Marking<PLACE> nextMarking;
 		for (final ITransition<LETTER, PLACE> transition : activeTransitionsWithSymbol(marking, symbol)) {
 			nextMarking = marking.fireTransition(transition, mOperand);
 			if (getResultHelper(nextPosition, nextMarking)) {
@@ -135,11 +135,11 @@ public final class Accepts<LETTER, PLACE> extends UnaryNetOperation<LETTER, PLAC
 		return result;
 	}
 
-	private Set<ITransition<LETTER, PLACE>> activeTransitionsWithSymbol(final Marking<LETTER, PLACE> marking, final LETTER symbol) {
+	private Set<ITransition<LETTER, PLACE>> activeTransitionsWithSymbol(final Marking<PLACE> marking,
+			final LETTER symbol) {
 		final Set<ITransition<LETTER, PLACE>> activeTransitionsWithSymbol = new HashSet<>();
 		for (final PLACE place : marking) {
-			mOperand.getSuccessors(place).stream()
-					.filter(transition -> transition.getSymbol().equals(symbol))
+			mOperand.getSuccessors(place).stream().filter(transition -> transition.getSymbol().equals(symbol))
 					.filter((transition -> marking.isTransitionEnabled(transition, mOperand)))
 					.forEach(activeTransitionsWithSymbol::add);
 		}

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/DifferencePetriNet.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/DifferencePetriNet.java
@@ -394,14 +394,14 @@ public class DifferencePetriNet<LETTER, PLACE> implements IPetriNetSuccessorProv
 	}
 
 	@Override
-	public boolean isAccepting(final Marking<LETTER, PLACE> marking) {
+	public boolean isAccepting(final Marking<PLACE> marking) {
 		final Set<PLACE> petriNetPlaces = new HashSet<>();
 		for (final PLACE place : marking) {
 			if (mMinuendPlaces.contains(place)) {
 				petriNetPlaces.add(place);
 			}
 		}
-		final Marking<LETTER, PLACE> filteredMarking = new Marking<>(ImmutableSet.of(petriNetPlaces));
+		final Marking<PLACE> filteredMarking = new Marking<>(ImmutableSet.of(petriNetPlaces));
 		return mMinuend.isAccepting(filteredMarking);
 	}
 

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/LazyPetriNet2FiniteAutomaton.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/operations/LazyPetriNet2FiniteAutomaton.java
@@ -64,13 +64,13 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.ImmutableSet;
 public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAndTransitionProvider<L, S> {
 
 	private final IPetriNet<L, S> mOperand;
-	private final Predicate<Marking<?, S>> mIsKnownDeadEnd;
+	private final Predicate<Marking<S>> mIsKnownDeadEnd;
 	private final IPetriNet2FiniteAutomatonStateFactory<S> mStateFactory;
-	private final Map<Marking<L, S>, S> mMarking2State = new HashMap<>();
+	private final Map<Marking<S>, S> mMarking2State = new HashMap<>();
 
 	// Needed to compute outgoing transitions. If all outgoing transitions of a state have been computed, we remove the
 	// state from this map (to save on memory).
-	private final Map<S, Marking<L, S>> mState2Marking = new HashMap<>();
+	private final Map<S, Marking<S>> mState2Marking = new HashMap<>();
 
 	private final NwaCacheBookkeeping<L, S> mCacheBookkeeping = new NwaCacheBookkeeping<>();
 	private final NestedWordAutomatonCache<L, S> mCache;
@@ -93,7 +93,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 	 */
 	public LazyPetriNet2FiniteAutomaton(final AutomataLibraryServices services,
 			final IPetriNet2FiniteAutomatonStateFactory<S> factory, final IPetriNet<L, S> operand,
-			final Predicate<Marking<?, S>> isKnownDeadEnd) throws PetriNetNot1SafeException {
+			final Predicate<Marking<S>> isKnownDeadEnd) throws PetriNetNot1SafeException {
 		mOperand = operand;
 		mIsKnownDeadEnd = isKnownDeadEnd;
 		mStateFactory = factory;
@@ -146,7 +146,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 
 	@Override
 	public Set<L> lettersInternal(final S state) {
-		final Marking<L, S> marking = mState2Marking.get(state);
+		final Marking<S> marking = mState2Marking.get(state);
 		if (marking == null) {
 			// All outgoing transitions already cached.
 			return mCache.lettersInternal(state);
@@ -194,7 +194,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 	}
 
 	private void computeOutgoingTransitions(final S state, final L letter) {
-		final Marking<L, S> marking = mState2Marking.get(state);
+		final Marking<S> marking = mState2Marking.get(state);
 		if (marking == null) {
 			// All outgoing transitions already cached.
 			return;
@@ -203,7 +203,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 				.forEach(t -> createAutomatonTransition(state, marking, t));
 	}
 
-	private void createAutomatonTransition(final S state, final Marking<L, S> marking,
+	private void createAutomatonTransition(final S state, final Marking<S> marking,
 			final ITransition<L, S> transition) {
 		try {
 			final S successor = getOrConstructState(marking.fireTransition(transition, mOperand));
@@ -216,7 +216,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 		}
 	}
 
-	private S getOrConstructState(final Marking<L, S> marking) {
+	private S getOrConstructState(final Marking<S> marking) {
 		// Do not use computeIfAbsent, because constructState may return null.
 		if (!mMarking2State.containsKey(marking)) {
 			final S state = constructState(marking, false);
@@ -226,7 +226,7 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 		return mMarking2State.get(marking);
 	}
 
-	private S constructState(final Marking<L, S> marking, final boolean isInitial) {
+	private S constructState(final Marking<S> marking, final boolean isInitial) {
 		if (isKnownDeadEnd(marking)) {
 			return null;
 		}
@@ -242,12 +242,12 @@ public class LazyPetriNet2FiniteAutomaton<L, S> implements INwaOutgoingLetterAnd
 		return state;
 	}
 
-	private Stream<ITransition<L, S>> getOutgoingNetTransitions(final Marking<L, S> marking) {
+	private Stream<ITransition<L, S>> getOutgoingNetTransitions(final Marking<S> marking) {
 		return marking.stream().flatMap(place -> mOperand.getSuccessors(place).stream())
 				.filter(t -> marking.isTransitionEnabled(t, mOperand));
 	}
 
-	private boolean isKnownDeadEnd(final Marking<?, S> marking) {
+	private boolean isKnownDeadEnd(final Marking<S> marking) {
 		if (mIsKnownDeadEnd == null) {
 			return false;
 		}

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/ConditionMarking.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/ConditionMarking.java
@@ -174,7 +174,7 @@ public class ConditionMarking<LETTER, PLACE> implements Iterable<Condition<LETTE
 	/**
 	 * @return A new marking containing the places corresponding to the conditionMarkings Conditions.
 	 */
-	public Marking<LETTER, PLACE> getMarking() throws PetriNetNot1SafeException {
+	public Marking<PLACE> getMarking() throws PetriNetNot1SafeException {
 		final HashSet<PLACE> mark = new HashSet<>();
 		for (final Condition<LETTER, PLACE> c : mConditions) {
 			final boolean wasAddedForTheFirstTime = mark.add(c.getPlace());

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/Event.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/Event.java
@@ -69,7 +69,7 @@ public final class Event<LETTER, PLACE> implements Serializable {
 	private final Configuration<LETTER, PLACE> mLocalConfiguration;
 	// private final Event<LETTER, PLACE>[] mLocalConfiguration;
 	// private final ArrayList<Event<LETTER, PLACE>> mLocalConfiguration;
-	private final Marking<LETTER, PLACE> mMark;
+	private final Marking<PLACE> mMark;
 	private final ConditionMarking<LETTER, PLACE> mConditionMark;
 
 	private Event<LETTER, PLACE> mCompanion;
@@ -258,7 +258,7 @@ public final class Event<LETTER, PLACE> implements Serializable {
 	/**
 	 * @return marking of the local configuration of this.
 	 */
-	public Marking<LETTER, PLACE> getMark() {
+	public Marking<PLACE> getMark() {
 		return mMark;
 	}
 

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/PetriNetUnfolder.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/PetriNetUnfolder.java
@@ -356,15 +356,15 @@ public final class PetriNetUnfolder<L, P> {
 	 * FIXME documentation.
 	 */
 	public class Statistics {
-		private final Map<ITransition<L, P>, Map<Marking<L, P>, Set<Event<L, P>>>> mTrans2Mark2Events = new HashMap<>();
+		private final Map<ITransition<L, P>, Map<Marking<P>, Set<Event<L, P>>>> mTrans2Mark2Events = new HashMap<>();
 		private int mCutOffEvents;
 		private int mNonCutOffEvents;
 
 		public void add(final Event<L, P> event) {
 			// TODO: The hash operations here take A LOT of time (~20% on the VMCAI2021) benchmarks
-			final Marking<L, P> marking = event.getMark();
+			final Marking<P> marking = event.getMark();
 			final ITransition<L, P> transition = event.getTransition();
-			Map<Marking<L, P>, Set<Event<L, P>>> mark2Events = mTrans2Mark2Events.get(transition);
+			Map<Marking<P>, Set<Event<L, P>>> mark2Events = mTrans2Mark2Events.get(transition);
 			if (mark2Events == null) {
 				mark2Events = new HashMap<>();
 				mTrans2Mark2Events.put(transition, mark2Events);

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/PossibleExtensions.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/petrinet/unfolding/PossibleExtensions.java
@@ -69,7 +69,7 @@ public class PossibleExtensions<LETTER, PLACE> implements IPossibleExtensions<LE
 	 */
 	private static final boolean USE_FORWARD_CHECKING = false;
 	private final Queue<Event<LETTER, PLACE>> mPe;
-	private final Map<Marking<LETTER, PLACE>, Event<LETTER, PLACE>> mMarkingEventMap = new HashMap<>();
+	private final Map<Marking<PLACE>, Event<LETTER, PLACE>> mMarkingEventMap = new HashMap<>();
 	private int mMaximalSize = 0;
 	private static final boolean USE_PQ = true;
 	private final boolean mUseFirstbornCutoffCheck;

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/statefactory/IPetriNet2FiniteAutomatonStateFactory.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/statefactory/IPetriNet2FiniteAutomatonStateFactory.java
@@ -46,5 +46,5 @@ public interface IPetriNet2FiniteAutomatonStateFactory<STATE> extends IStateFact
 	 *            Petri net marking
 	 * @return state representing the marking
 	 */
-	STATE getContentOnPetriNet2FiniteAutomaton(Marking<?, STATE> marking);
+	STATE getContentOnPetriNet2FiniteAutomaton(Marking<STATE> marking);
 }

--- a/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/statefactory/StringFactory.java
+++ b/trunk/source/Library-Automata/src/de/uni_freiburg/informatik/ultimate/automata/statefactory/StringFactory.java
@@ -166,7 +166,7 @@ public class StringFactory implements ISenwaStateFactory<String>, IBlackWhiteSta
 	 */
 
 	@Override
-	public String getContentOnPetriNet2FiniteAutomaton(final Marking<?, String> marking) {
+	public String getContentOnPetriNet2FiniteAutomaton(final Marking<String> marking) {
 		final StringBuilder builder = new StringBuilder(marking.size() * MINIMUM_LIST_SIZE);
 		builder.append(OPEN_BRACE);
 		boolean firstElement = true;

--- a/trunk/source/Library-TraceCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/tracecheckerutils/initialabstraction/Petri2FiniteAutomatonAbstractionProvider.java
+++ b/trunk/source/Library-TraceCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/tracecheckerutils/initialabstraction/Petri2FiniteAutomatonAbstractionProvider.java
@@ -82,7 +82,7 @@ public abstract class Petri2FiniteAutomatonAbstractionProvider<L extends IIcfgTr
 	 * corresponding to this marking can be omitted from the program automaton.
 	 */
 	protected boolean areAllLocationsHopeless(final Map<IcfgLocation, Boolean> hopelessCache,
-			final Set<? extends IcfgLocation> errorLocs, final Marking<?, IPredicate> marking) {
+			final Set<? extends IcfgLocation> errorLocs, final Marking<IPredicate> marking) {
 		for (final IPredicate place : marking) {
 			if (place instanceof ISLPredicate) {
 				final IcfgLocation location = ((ISLPredicate) place).getProgramPoint();

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryForInterpolantAutomata.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryForInterpolantAutomata.java
@@ -144,7 +144,7 @@ public class PredicateFactoryForInterpolantAutomata
 	}
 
 	@Override
-	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<?, IPredicate> marking) {
+	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<IPredicate> marking) {
 		/*
 		 * TODO Christian 2017-02-15 This method was not implemented although it was used by class CegarLoopJulian in
 		 * method acceptsPetriViaFA().

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryRefinement.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryRefinement.java
@@ -165,7 +165,7 @@ public class PredicateFactoryRefinement extends PredicateFactoryForInterpolantAu
 	}
 
 	@Override
-	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<?, IPredicate> marking) {
+	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<IPredicate> marking) {
 		final ArrayList<IcfgLocation> programPoints = new ArrayList<>(marking.size());
 		final ArrayList<Term> terms = new ArrayList<>();
 		for (final IPredicate pred : marking) {

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryResultChecking.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/PredicateFactoryResultChecking.java
@@ -108,7 +108,7 @@ public class PredicateFactoryResultChecking
 	}
 
 	@Override
-	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<?, IPredicate> marking) {
+	public IPredicate getContentOnPetriNet2FiniteAutomaton(final Marking<IPredicate> marking) {
 		return mPredicateFactory.newDebugPredicate(STATE_LABEL);
 	}
 }


### PR DESCRIPTION
A marking is a set of places -- so why is it parameterized in a type of letters? It is sufficient to parameterize those methods that deal with transitions.

Removing this parameter simplifies code: It avoids the need to carry around the additional type parameter LETTER when it is not needed, or using wildcards.