### PR TITLE
Remove problematic loop invariant in example program

### DIFF
--- a/trunk/examples/programs/toy/showcase/GoannaDoubleFreeWithoutPointers.c
+++ b/trunk/examples/programs/toy/showcase/GoannaDoubleFreeWithoutPointers.c
@@ -19,7 +19,6 @@
 int main() {
     int p, n;
     p = 42;
-	//@ loop invariant n >= 0;
     while ( n>=0 ) {
         //@ assert p != 0;
         if (n == 0) {


### PR DESCRIPTION
The user experience is suboptimal because the first thing you see is that there are problems with this example, but it is actually correct (only the annotation is "not completely right"). I guess that showcase examples should not contain problematic annotations. The tool can handle this example without the annotation.

![Screenshot_20221102_171903](https://user-images.githubusercontent.com/9656686/199547594-4dbea430-9dd4-4cac-bde2-9ed5c51b530a.png)