### PR TITLE
Support parsing SMT models

### DIFF
--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Executor.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Executor.java
@@ -283,6 +283,10 @@ class Executor {
 		return (Object[]) parse(LexerSymbols.GETINFO).value;
 	}
 
+	public ModelDescription parseGetModelResult() {
+		return (ModelDescription) parse(LexerSymbols.GETMODEL).value;
+	}
+
 	public Object parseGetOptionResult() {
 		return parse(LexerSymbols.GETOPTION).value;
 	}

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/FunctionDefinition.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/FunctionDefinition.java
@@ -26,6 +26,7 @@
  */
 package de.uni_freiburg.informatik.ultimate.smtsolver.external;
 
+import de.uni_freiburg.informatik.ultimate.logic.FunctionSymbol;
 import de.uni_freiburg.informatik.ultimate.logic.Sort;
 import de.uni_freiburg.informatik.ultimate.logic.Term;
 import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
@@ -38,19 +39,20 @@ import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
  *
  */
 public class FunctionDefinition {
-	private final String mName;
+	private final FunctionSymbol mName;
 	private final TermVariable[] mParams;
 	private final Sort mReturnSort;
 	private final Term mBody;
 
-	public FunctionDefinition(final String name, final TermVariable[] params, final Sort returnSort, final Term body) {
+	public FunctionDefinition(final FunctionSymbol name, final TermVariable[] params, final Sort returnSort,
+			final Term body) {
 		mName = name;
 		mParams = params;
 		mReturnSort = returnSort;
 		mBody = body;
 	}
 
-	public String getName() {
+	public FunctionSymbol getName() {
 		return mName;
 	}
 

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/FunctionDefinition.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/FunctionDefinition.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Copyright (C) 2023 University of Freiburg
+ *
+ * This file is part of the ULTIMATE SMTSolverBridge.
+ *
+ * The ULTIMATE SMTSolverBridge is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE SMTSolverBridge is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE SMTSolverBridge. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE SMTSolverBridge, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE SMTSolverBridge grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.smtsolver.external;
+
+import de.uni_freiburg.informatik.ultimate.logic.Sort;
+import de.uni_freiburg.informatik.ultimate.logic.Term;
+import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
+
+/**
+ * Represents an SMT command defining a function. This data structure is also used to represent the response to
+ * (get-model) commands.
+ *
+ * @author Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ *
+ */
+public class FunctionDefinition {
+	private final String mName;
+	private final TermVariable[] mParams;
+	private final Sort mReturnSort;
+	private final Term mBody;
+
+	public FunctionDefinition(final String name, final TermVariable[] params, final Sort returnSort, final Term body) {
+		mName = name;
+		mParams = params;
+		mReturnSort = returnSort;
+		mBody = body;
+	}
+
+	public String getName() {
+		return mName;
+	}
+
+	public TermVariable[] getParams() {
+		return mParams;
+	}
+
+	public Sort getReturnSort() {
+		return mReturnSort;
+	}
+
+	public Term getBody() {
+		return mBody;
+	}
+
+	@Override
+	public String toString() {
+		final var builder = new StringBuilder("(define-fun ");
+		builder.append(mName);
+		builder.append(" (");
+		for (final var param : mParams) {
+			builder.append("(");
+			builder.append(param.getName());
+			builder.append(param.getSort());
+			builder.append(")");
+		}
+		builder.append(") ");
+		builder.append(mReturnSort);
+		builder.append(" ");
+		builder.append(mBody);
+		builder.append(")");
+		return builder.toString();
+	}
+}

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
@@ -45,7 +45,7 @@ import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
  *
  */
 public class ModelDescription implements Model {
-	private final Map<String, FunctionDefinition> mDefinitions;
+	private final Map<FunctionSymbol, FunctionDefinition> mDefinitions;
 
 	public ModelDescription(final Set<FunctionDefinition> definitions) {
 		mDefinitions = definitions.stream().collect(Collectors.toMap(FunctionDefinition::getName, Function.identity()));
@@ -63,9 +63,7 @@ public class ModelDescription implements Model {
 
 	@Override
 	public Set<FunctionSymbol> getDefinedFunctions() {
-		// TODO how to go from function name strings to FunctionSymbols?
-		// return mDefinitions.keySet();
-		throw new UnsupportedOperationException();
+		return mDefinitions.keySet();
 	}
 
 	@Override

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import de.uni_freiburg.informatik.ultimate.logic.FormulaUnLet;
 import de.uni_freiburg.informatik.ultimate.logic.FunctionSymbol;
 import de.uni_freiburg.informatik.ultimate.logic.Model;
 import de.uni_freiburg.informatik.ultimate.logic.Term;
@@ -71,21 +72,20 @@ public class ModelDescription implements Model {
 	public Term getFunctionDefinition(final String func, final TermVariable[] args) {
 		final var def = getFunctionDefinition(func);
 		final var params = def.getParams();
+		assert params.length == args.length : "Number of parameters does not match arity of " + func;
 
 		final var substitution = new HashMap<TermVariable, Term>();
-
-		assert params.length == args.length;
 		for (int i = 0; i < args.length; ++i) {
 			assert Objects.equals(params[i].getSort(), args[i].getSort());
 			substitution.put(params[i], args[i]);
 		}
 
-		// TODO no access to PureSubstitution
-		// return PureSubstitution.apply(def.getBody(), substitution);
-		throw new UnsupportedOperationException();
+		final var unletter = new FormulaUnLet();
+		unletter.addSubstitutions(substitution);
+		return unletter.transform(def.getBody());
 	}
 
-	public FunctionDefinition getFunctionDefinition(final String func) {
+	private FunctionDefinition getFunctionDefinition(final String func) {
 		return mDefinitions.get(func);
 	}
 

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Copyright (C) 2023 University of Freiburg
+ *
+ * This file is part of the ULTIMATE SMTSolverBridge.
+ *
+ * The ULTIMATE SMTSolverBridge is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE SMTSolverBridge is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE SMTSolverBridge. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE SMTSolverBridge, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE SMTSolverBridge grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.smtsolver.external;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import de.uni_freiburg.informatik.ultimate.logic.FunctionSymbol;
+import de.uni_freiburg.informatik.ultimate.logic.Model;
+import de.uni_freiburg.informatik.ultimate.logic.Term;
+import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
+
+/**
+ * An SMT model extracted from a (get-model) response.
+ *
+ * @author Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ *
+ */
+public class ModelDescription implements Model {
+	private final Map<String, FunctionDefinition> mDefinitions;
+
+	public ModelDescription(final Set<FunctionDefinition> definitions) {
+		mDefinitions = definitions.stream().collect(Collectors.toMap(FunctionDefinition::getName, Function.identity()));
+	}
+
+	@Override
+	public Term evaluate(final Term input) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Map<Term, Term> evaluate(final Term[] input) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<FunctionSymbol> getDefinedFunctions() {
+		// TODO how to go from function name strings to FunctionSymbols?
+		// return mDefinitions.keySet();
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Term getFunctionDefinition(final String func, final TermVariable[] args) {
+		final var def = getFunctionDefinition(func);
+		final var params = def.getParams();
+
+		final var substitution = new HashMap<TermVariable, Term>();
+
+		assert params.length == args.length;
+		for (int i = 0; i < args.length; ++i) {
+			assert Objects.equals(params[i].getSort(), args[i].getSort());
+			substitution.put(params[i], args[i]);
+		}
+
+		// TODO no access to PureSubstitution
+		// return PureSubstitution.apply(def.getBody(), substitution);
+		throw new UnsupportedOperationException();
+	}
+
+	public FunctionDefinition getFunctionDefinition(final String func) {
+		return mDefinitions.get(func);
+	}
+
+	@Override
+	public String toString() {
+		return mDefinitions.values().stream().map(Object::toString).collect(Collectors.joining("\n"));
+	}
+}

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelDescription.java
@@ -45,10 +45,11 @@ import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
  *
  */
 public class ModelDescription implements Model {
-	private final Map<FunctionSymbol, FunctionDefinition> mDefinitions;
+	private final Map<String, FunctionDefinition> mDefinitions;
 
 	public ModelDescription(final Set<FunctionDefinition> definitions) {
-		mDefinitions = definitions.stream().collect(Collectors.toMap(FunctionDefinition::getName, Function.identity()));
+		mDefinitions =
+				definitions.stream().collect(Collectors.toMap(def -> def.getName().getName(), Function.identity()));
 	}
 
 	@Override
@@ -63,7 +64,7 @@ public class ModelDescription implements Model {
 
 	@Override
 	public Set<FunctionSymbol> getDefinedFunctions() {
-		return mDefinitions.keySet();
+		return mDefinitions.values().stream().map(FunctionDefinition::getName).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Scriptor.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Scriptor.java
@@ -35,7 +35,6 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.logic.Assignments;
 import de.uni_freiburg.informatik.ultimate.logic.Logics;
-import de.uni_freiburg.informatik.ultimate.logic.Model;
 import de.uni_freiburg.informatik.ultimate.logic.NoopScript;
 import de.uni_freiburg.informatik.ultimate.logic.SMTLIBException;
 import de.uni_freiburg.informatik.ultimate.logic.Sort;
@@ -235,8 +234,9 @@ public class Scriptor extends NoopScript {
 	}
 
 	@Override
-	public Model getModel() throws SMTLIBException, UnsupportedOperationException {
-		throw new UnsupportedOperationException();
+	public ModelDescription getModel() throws SMTLIBException, UnsupportedOperationException {
+		mExecutor.input("(get-model)");
+		return mExecutor.parseGetModelResult();
 	}
 
 	/** This method is used in the output parser, to support (get-info :status) **/

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Scriptor.java
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/Scriptor.java
@@ -35,6 +35,7 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.logic.Assignments;
 import de.uni_freiburg.informatik.ultimate.logic.Logics;
+import de.uni_freiburg.informatik.ultimate.logic.Model;
 import de.uni_freiburg.informatik.ultimate.logic.NoopScript;
 import de.uni_freiburg.informatik.ultimate.logic.SMTLIBException;
 import de.uni_freiburg.informatik.ultimate.logic.Sort;
@@ -234,7 +235,7 @@ public class Scriptor extends NoopScript {
 	}
 
 	@Override
-	public ModelDescription getModel() throws SMTLIBException, UnsupportedOperationException {
+	public Model getModel() throws SMTLIBException, UnsupportedOperationException {
 		mExecutor.input("(get-model)");
 		return mExecutor.parseGetModelResult();
 	}

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/scriptResult.cup
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/scriptResult.cup
@@ -597,7 +597,7 @@ funDef ::= LPAR DEFINEFUN {: localVars.beginScope(); :} symbol:fun
                        // For example, z3 often uses such auxiliary function symbols to give values of array variables.
                        // This will require special support, otherwise the parser crashes when such an auxiliary
                        // function symbol is used.
-                       RESULT = new FunctionDefinition(fun, vars, resultSort, body);
+                       RESULT = new FunctionDefinition(parser.getScript().getFunctionSymbol(fun), vars, resultSort, body);
                    } catch (SMTLIBException se) {
                        parser.report_error(se.getMessage(), fun$);
                        throw se;

--- a/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/scriptResult.cup
+++ b/trunk/source/SMTSolverBridge/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/scriptResult.cup
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
 import com.github.jhoenicke.javacup.runtime.Symbol;
 import com.github.jhoenicke.javacup.runtime.SimpleSymbolFactory;
 import java.util.Iterator;
@@ -324,6 +325,8 @@ non terminal Term[] gaResponse;
 non terminal Object proof;
 non terminal Object gpResponse;
 non terminal Object goResponse;
+non terminal ModelDescription gmResponse;
+non terminal FunctionDefinition funDef;
 non terminal Term[] gucResponse;
 non terminal Term[] ginterpolResponse;
 non terminal HashMap valuationPair;
@@ -341,7 +344,8 @@ goal ::= SUCCESS genResponse {: RESULT = null; :}
        | GETOPTION goResponse:o {: RESULT = o; :}
        | GETINTERPOLANTS ginterpolResponse:o {: RESULT = o; :}
        | GETTERM term:t {: if (t == null) System.err.println(getError());
-       							RESULT = t; :};
+       							RESULT = t; :}
+       | GETMODEL gmResponse:m {: RESULT = m; :};
 
 specConstant ::= NUMERAL:n {: RESULT = n; :}
              | DECIMAL:n {: RESULT = n; :}
@@ -580,3 +584,23 @@ goResponse ::= TRUE {: RESULT = true; :}
 			 | STDOUT:s {: RESULT = s; :}
 			 | STDERR:s {: RESULT = s; :}
 			 | errorResponse;
+
+/* get-model response, currently only for Horn solvers */
+gmResponse ::= LPAR funDef*:d {: RESULT = new ModelDescription(Set.of(d)); :} RPAR;
+
+funDef ::= LPAR DEFINEFUN {: localVars.beginScope(); :} symbol:fun
+                      LPAR sortedVar*:vars RPAR sort:resultSort term:body RPAR
+            {: localVars.endScope();
+               try {
+                       // TODO Support definition of auxiliary functions
+                       // Some solvers, especially z3, define auxiliary functions as part of their model.
+                       // For example, z3 often uses such auxiliary function symbols to give values of array variables.
+                       // This will require special support, otherwise the parser crashes when such an auxiliary
+                       // function symbol is used.
+                       RESULT = new FunctionDefinition(fun, vars, resultSort, body);
+                   } catch (SMTLIBException se) {
+                       parser.report_error(se.getMessage(), fun$);
+                       throw se;
+                   }
+            :};
+

--- a/trunk/source/SMTSolverBridgeTest/META-INF/MANIFEST.MF
+++ b/trunk/source/SMTSolverBridgeTest/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Fragment-Host: de.uni_freiburg.informatik.ultimate.smtsolver.external
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: de.uni_freiburg.informatik.ultimate.lib.test
 Automatic-Module-Name: de.uni.freiburg.informatik.ultimate.smtsolver.external.test
+Import-Package: org.junit

--- a/trunk/source/SMTSolverBridgeTest/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelParserTest.java
+++ b/trunk/source/SMTSolverBridgeTest/src/de/uni_freiburg/informatik/ultimate/smtsolver/external/ModelParserTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Copyright (C) 2023 University of Freiburg
+ *
+ * This file is part of the ULTIMATE SMTSolverBridge.
+ *
+ * The ULTIMATE SMTSolverBridge is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE SMTSolverBridge is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE SMTSolverBridge. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE SMTSolverBridge, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE SMTSolverBridge grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.smtsolver.external;
+
+import java.math.BigInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.uni_freiburg.informatik.ultimate.logic.ConstantTerm;
+import de.uni_freiburg.informatik.ultimate.logic.Logics;
+import de.uni_freiburg.informatik.ultimate.logic.QuantifiedFormula;
+import de.uni_freiburg.informatik.ultimate.logic.Rational;
+import de.uni_freiburg.informatik.ultimate.logic.SMTLIBConstants;
+import de.uni_freiburg.informatik.ultimate.logic.Script;
+import de.uni_freiburg.informatik.ultimate.logic.Sort;
+import de.uni_freiburg.informatik.ultimate.logic.TermVariable;
+import de.uni_freiburg.informatik.ultimate.test.mocks.UltimateMocks;
+
+public class ModelParserTest {
+
+	private Script mScript;
+
+	@Before
+	public void setUp() {
+		mScript = UltimateMocks.createZ3Script();
+	}
+
+	@Test
+	public void testSimpleIntModel() {
+		mScript.setLogic(Logics.LIA);
+		mScript.setOption(SMTLIBConstants.PRODUCE_MODELS, true);
+		mScript.declareFun("x", Script.EMPTY_SORT_ARRAY, mScript.sort("Int"));
+		mScript.assertTerm(mScript.term(">=", mScript.term("x"), mScript.numeral(BigInteger.ZERO)));
+		mScript.checkSat();
+		final var model = mScript.getModel();
+		final var term = model.getFunctionDefinition("x", new TermVariable[0]);
+
+		assert term instanceof ConstantTerm;
+		final var constant = (ConstantTerm) term;
+
+		final var value = constant.getValue();
+		assert value instanceof Rational;
+
+		final var rat = (Rational) value;
+		assert rat.isIntegral() && !rat.isNegative();
+	}
+
+	@Test
+	public void testSimpleHorn() {
+		mScript.setLogic(Logics.HORN);
+		mScript.setOption(SMTLIBConstants.PRODUCE_MODELS, true);
+		mScript.declareFun("P", new Sort[] { mScript.sort("Int") }, mScript.sort("Bool"));
+
+		final var x = mScript.variable("x", mScript.sort("Int"));
+		// x = 0 -> P(x)
+		mScript.assertTerm(mScript.quantifier(QuantifiedFormula.FORALL, new TermVariable[] { x },
+				mScript.term("=>", mScript.term("=", x, mScript.numeral(BigInteger.ZERO)), mScript.term("P", x))));
+		// P(x) /\ x >= 1 -> false
+		mScript.assertTerm(mScript.quantifier(QuantifiedFormula.FORALL, new TermVariable[] { x }, mScript.term("=>",
+				mScript.term("and", mScript.term("P", x), mScript.term(">=", x, mScript.numeral(BigInteger.ONE))),
+				mScript.term("false"))));
+		mScript.checkSat();
+		final var model = mScript.getModel();
+
+		final var app = model.getFunctionDefinition("P", new TermVariable[] { x });
+		assert "(= x 0)".equals(app.toString());
+	}
+
+	@Test
+	public void testDoubleHorn() {
+		mScript.setLogic(Logics.HORN);
+		mScript.setOption(SMTLIBConstants.PRODUCE_MODELS, true);
+		mScript.declareFun("P", new Sort[] { mScript.sort("Int") }, mScript.sort("Bool"));
+		mScript.declareFun("Q", new Sort[] { mScript.sort("Int") }, mScript.sort("Bool"));
+
+		final var x = mScript.variable("x", mScript.sort("Int"));
+		// x >= 0 -> P(x)
+		mScript.assertTerm(mScript.quantifier(QuantifiedFormula.FORALL, new TermVariable[] { x },
+				mScript.term("=>", mScript.term(">=", x, mScript.numeral(BigInteger.ZERO)), mScript.term("P", x))));
+		// x <= 0 -> Q(x)
+		mScript.assertTerm(mScript.quantifier(QuantifiedFormula.FORALL, new TermVariable[] { x },
+				mScript.term("=>", mScript.term("<=", x, mScript.numeral(BigInteger.ZERO)), mScript.term("Q", x))));
+		// P(x) /\ Q(x) /\ x =/= 0 -> false
+		mScript.assertTerm(mScript.quantifier(QuantifiedFormula.FORALL, new TermVariable[] { x },
+				mScript.term("=>",
+						mScript.term("and", mScript.term("P", x), mScript.term("Q", x),
+								mScript.term("distinct", x, mScript.numeral(BigInteger.ZERO))),
+						mScript.term("false"))));
+		mScript.checkSat();
+		final var model = mScript.getModel();
+
+		final var appP = model.getFunctionDefinition("P", new TermVariable[] { x });
+		assert "(>= x 0)".equals(appP.toString());
+
+		final var appQ = model.getFunctionDefinition("Q", new TermVariable[] { x });
+		assert "(<= x 0)".equals(appQ.toString());
+	}
+}


### PR DESCRIPTION
This PR adds support for parsing SMT models as output by Z3. We need this in particular for models returned by Z3's CHC solver, spacer.

There is currently no support for models that define auxiliary functions. Z3 tends to do this for models containing arrays, as well as some other cases. We leave this support to future work ;-)