### PR TITLE
Add build support for macOS

### DIFF
--- a/trunk/source/BA_FeatureDependenciesCommon/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesCommon/feature.xml
@@ -159,6 +159,15 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.cdt.core.macosx"
+         os="macosx"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.core.commands"
          download-size="0"
          install-size="0"
@@ -207,6 +216,15 @@
          id="org.eclipse.core.filesystem.linux.x86_64"
          os="linux"
          arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.filesystem.macosx"
+         os="macosx"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
@@ -177,6 +177,17 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.swt.cocoa.macosx.x86_64"
+         os="macosx"
+         ws="cocoa"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.e4.emf.xpath"
          download-size="0"
          install-size="0"

--- a/trunk/source/BA_FeatureUltimateDebug/feature.xml
+++ b/trunk/source/BA_FeatureUltimateDebug/feature.xml
@@ -3,7 +3,7 @@
       id="BA_FeatureUltimateDebug"
       label="BA_FeatureUltimateDebug"
       version="0.2.3"
-      os="linux,win32"
+      os="linux,win32,macosx"
       arch="x86_64">
 
    <description url="http://www.example.com/description">

--- a/trunk/source/BA_MavenParentUltimate/pom.xml
+++ b/trunk/source/BA_MavenParentUltimate/pom.xml
@@ -363,6 +363,11 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/trunk/source/BA_SiteRepository/Ultimate_E4.17_Java11_MacOS.target
+++ b/trunk/source/BA_SiteRepository/Ultimate_E4.17_Java11_MacOS.target
@@ -50,6 +50,7 @@
 		<plugin id="javax.inject.source" version="1.0.0.v20091030"/>
 		<plugin id="javax.inject" version="1.0.0.v20091030"/>
 		<plugin id="javax.xml.bind"/>
+		<plugin id="javax.xml.bind.source"/>
 		<plugin id="javax.xml.stream" version="1.0.1.v201004272200"/>
 		<plugin id="javax.xml" version="1.3.4.v201005080400"/>
 		<plugin id="org.apache.batik.anim"/>
@@ -188,6 +189,7 @@
 		<plugin id="org.eclipse.equinox.registry" version="3.9.0.v20200625-1425"/>
 		<plugin id="org.eclipse.equinox.registry.source" version="3.9.0.v20200625-1425"/>
 		<plugin id="org.eclipse.help" version="3.8.800.v20200525-0755"/>
+		<plugin id="org.eclipse.help.source"/>
 		<plugin id="org.eclipse.jface.databinding.source" version="1.12.0.v20200717-1533"/>
 		<plugin id="org.eclipse.jface.databinding" version="1.12.0.v20200717-1533"/>
 		<plugin id="org.eclipse.jface" version="3.21.0.v20200821-1458"/>
@@ -195,6 +197,7 @@
 		<plugin id="org.eclipse.ltk.core.refactoring" version="3.11.100.v20200720-0748"/>
 		<plugin id="org.eclipse.ltk.core.refactoring.source" version="3.11.100.v20200720-0748"/>
 		<plugin id="org.eclipse.osgi.services" version="3.9.0.v20200511-1725"/>
+		<plugin id="org.eclipse.osgi.services.source"/>
 		<plugin id="org.eclipse.osgi.source" version="3.16.0.v20200828-0759"/>
 		<plugin id="org.eclipse.osgi" version="3.16.0.v20200828-0759"/>
 		<plugin id="org.eclipse.osgi.util" version="3.5.300.v20190708-1141"/>
@@ -318,5 +321,17 @@
 		<plugin id="org.eclipse.cdt.make.core.source"/>
 		<plugin id="org.eclipse.cdt.build.gcc.core"/>
 		<plugin id="org.eclipse.cdt.build.gcc.core.source"/>
+		<plugin id="org.eclipse.jetty.util"/>
+		<plugin id="org.eclipse.jetty.util.source"/>
+		<plugin id="org.eclipse.jetty.servlet"/>
+		<plugin id="org.eclipse.jetty.servlet.source"/>
+		<plugin id="org.eclipse.jetty.server"/>
+		<plugin id="org.eclipse.jetty.server.source"/>
+		<plugin id="org.eclipse.jetty.security"/>
+		<plugin id="org.eclipse.jetty.security.source"/>
+		<plugin id="org.eclipse.jetty.io"/>
+		<plugin id="org.eclipse.jetty.io.source"/>
+		<plugin id="org.eclipse.jetty.http"/>
+		<plugin id="org.eclipse.jetty.http.source"/>
 	</includeBundles>
 </target>


### PR DESCRIPTION
Build support for macOS was already there but was broken by the commit abbe715b4fa4c8e9bcc4dd5716f989700e6f3bba. This change reactivates build support for macOS and adds missing macOS platform-related dependencies.