### PR TITLE
Fix CArray expression evaluation/conversion to boolean value

### DIFF
--- a/trunk/examples/programs/regression/c/builtin/assert/assert_string-literal_safe_01.c
+++ b/trunk/examples/programs/regression/c/builtin/assert/assert_string-literal_safe_01.c
@@ -1,0 +1,14 @@
+//#Safe
+/*
+ * Valid assertion expression composed of a string literal.
+ * 
+ * Author: Manuel Bentele
+ *   Date: 2023-11-10
+ */
+
+int main()
+{
+    assert("Hello World!");
+
+    return 0;
+}

--- a/trunk/examples/programs/regression/c/builtin/assert/assert_string-literal_safe_02.c
+++ b/trunk/examples/programs/regression/c/builtin/assert/assert_string-literal_safe_02.c
@@ -1,0 +1,17 @@
+//#Safe
+/*
+ * Valid assertion expression composed of subterms and a string literal.
+ * 
+ * Author: Manuel Bentele
+ *   Date: 2023-11-10
+ */
+
+int main()
+{
+    int a = 0;
+    int b = 1;
+
+    assert(a != b && "Error message!");
+
+    return 0;
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
@@ -48,6 +48,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.T
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.MemoryHandler;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizes;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.AuxVarInfoBuilder;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CArray;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CEnum;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
@@ -382,7 +383,7 @@ public abstract class ExpressionTranslation {
 			default:
 				throw new AssertionError("illegal type");
 			}
-		} else if (cType instanceof CPointer) {
+		} else if (cType instanceof CPointer || cType instanceof CArray) {
 			result = constructNullPointer(loc);
 		} else {
 			throw new UnsupportedSyntaxException(loc, "don't know 0 value for type " + cType);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -522,7 +522,7 @@ public class ExpressionResultTransformer {
 		if (underlyingType instanceof CPrimitive) {
 			resultEx = mExprTrans.constructBinaryEqualityExpression(loc, IASTBinaryExpression.op_notequals,
 					rVal.getValue(), rVal.getCType(), zero, underlyingType);
-		} else if (underlyingType instanceof CPointer) {
+		} else if (underlyingType instanceof CPointer || underlyingType instanceof CArray) {
 			resultEx = ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.COMPNEQ, rVal.getValue(),
 					zero);
 		} else {


### PR DESCRIPTION
This patch fixes the `CArray` expression evaluation/conversion to a boolean value to allow a `CArray` evaluation in a boolean expression:
```
assert(a != b && "This is a CArray error message")
```

In this example, the `CArray` as part of the conjunction will be always evaluated with an address check (memory address of `CArray` != `NULL`) to the boolean value `true` since the address of the error message string literal can never be `NULL`.