### PR TITLE
Report invariants enforced by vacuous requirements

### DIFF
--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -95,8 +95,11 @@ import de.uni_freiburg.informatik.ultimate.pea2boogie.results.ReqCheck;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.results.ReqCheckFailResult;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.results.ReqCheckRtInconsistentResult;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.results.ReqCheckSuccessResult;
+import de.uni_freiburg.informatik.ultimate.pea2boogie.results.ReqCheckVacuousResult;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.translator.Req2BoogieTranslator;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.translator.ReqSymboltableBuilder;
+import de.uni_freiburg.informatik.ultimate.pea2boogie.translator.VacuityAnnotation;
+import de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder.cfg.BoogieIcfgLocation;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder.cfg.CodeBlock;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder.cfg.CodeBlockFactory;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.rcfgbuilder.cfg.ParallelComposition;
@@ -186,6 +189,15 @@ public class VerificationResultTransformer {
 					generateTimeSequenceMap(newPe.getProgramStates());
 			final String failurePath = formatTimeSequenceMap(delta2var2value);
 			return new ReqCheckRtInconsistentResult<>(element, plugin, failurePath);
+		}
+		if (spec == Spec.VACUOUS) {
+			// Return a ReqCheckVacuousResult, i.e., a ReqCheckFailResult with additional
+			// VacuityAnnotation containing an invariant that might be enforced by the
+			// vacuous requirement.
+			VacuityAnnotation enforcedInv = VacuityAnnotation
+					.getAnnotation(((BoogieIcfgLocation) element).getBoogieASTNode());
+			return new ReqCheckVacuousResult<>(element, plugin,
+					enforcedInv.getInvariant().toString());
 		}
 		return new ReqCheckFailResult<>(element, plugin);
 	}

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckVacuousResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckVacuousResult.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 University of Freiburg
+ *
+ * This file is part of the ULTIMATE PEAtoBoogie plug-in.
+ *
+ * The ULTIMATE PEAtoBoogie plug-in is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE PEAtoBoogie plug-in is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE PEAtoBoogie plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE PEAtoBoogie plug-in, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE PEAtoBoogie plug-in grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.pea2boogie.results;
+
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IAction;
+import de.uni_freiburg.informatik.ultimate.lib.pea.CDD;
+import de.uni_freiburg.informatik.ultimate.util.CoreUtil;
+
+
+public final class ReqCheckVacuousResult<LOC extends IElement, TE extends IAction, E>
+		extends ReqCheckFailResult<LOC> {
+
+	private final String mEnforcedInvariant;
+
+	public ReqCheckVacuousResult(final LOC element, final String plugin, final String enforcedInvariant) {
+		super(element, plugin);
+		mEnforcedInvariant = enforcedInvariant;
+	}
+
+	public ReqCheckVacuousResult(final LOC element, final String plugin) {
+		this(element, plugin, null);
+	}
+
+	@Override
+	public String getLongDescription() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append(getShortDescription());
+		if (mEnforcedInvariant != CDD.TRUE.toString()) {
+			sb.append(CoreUtil.getPlatformLineSeparator());
+			sb.append("Vacous requirement silently enforces invariant: " + mEnforcedInvariant);
+		}
+		return sb.toString();
+	}
+}

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/translator/VacuityAnnotation.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/translator/VacuityAnnotation.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2024 University of Freiburg
+ * 
+ * This file is part of the ULTIMATE Core.
+ * 
+ * The ULTIMATE Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The ULTIMATE Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE Core. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE Core, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE Core grant you additional permission
+ * to convey the resulting work.
+ */
 package de.uni_freiburg.informatik.ultimate.pea2boogie.translator;
 
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.ModernAnnotations;

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/translator/VacuityAnnotation.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/translator/VacuityAnnotation.java
@@ -1,0 +1,36 @@
+package de.uni_freiburg.informatik.ultimate.pea2boogie.translator;
+
+import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.ModernAnnotations;
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
+import de.uni_freiburg.informatik.ultimate.lib.pea.CDD;
+
+/**
+ * 
+ * Annotation for vacuity checks. This marks whether a vacuous requirement
+ * enforces a trivial invariant.
+ *
+ */
+
+public class VacuityAnnotation extends ModernAnnotations {
+
+	private static final long serialVersionUID = 1L;
+	private final CDD mEnforcedInvariant;
+
+	public VacuityAnnotation(final CDD enforcedInv) {
+		mEnforcedInvariant = enforcedInv;
+	}
+
+	public CDD getInvariant() {
+		return mEnforcedInvariant;
+	}
+
+	public IAnnotations annotate(final IElement elem) {
+		return elem.getPayload().getAnnotations().put(VacuityAnnotation.class.getName(), this);
+	}
+
+	public static VacuityAnnotation getAnnotation(final IElement node) {
+		return ModelUtils.getAnnotation(node, VacuityAnnotation.class);
+	}
+}


### PR DESCRIPTION
This adds a ReqCheckVacuousResult to report invariants that are enforced by vacuous requirements.
A vacuous requirement enforces an invariant if there exists only one location in its PEA representation in which the maximal phase of its corresponding countertrace is not active.
Reporting such invariants may help to better understand vacuous results (e.g. as in #530) and their implications, as for example needed to approach #438.
