### PR TITLE
Let AtomicBlockInfo use more precise types

### DIFF
--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
@@ -34,7 +34,6 @@ import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.ModernAnno
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfgTransition;
-import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocation;
 
 /**
  * An annotation used to mark CFG edges that are the beginning or end of an atomic block, in the sense of SV-COMP's
@@ -87,7 +86,7 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *            The element whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the beginning of an atomic block.
 	 */
-	public static <LOC extends IcfgLocation> boolean isStartOfAtomicBlock(final IIcfgTransition<LOC> edge) {
+	public static boolean isStartOfAtomicBlock(final IIcfgTransition<?> edge) {
 		return hasAnnotatedDelta(edge, d -> d > 0);
 	}
 
@@ -100,22 +99,23 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *            The element whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the end of an atomic block.
 	 */
-	public static <LOC extends IcfgLocation>  boolean isEndOfAtomicBlock(final IIcfgTransition<LOC> edge) {
+	public static boolean isEndOfAtomicBlock(final IIcfgTransition<?> edge) {
 		return hasAnnotatedDelta(edge, d -> d < 0);
 	}
 
 	/**
 	 * Determines if the given element (an edge) is annotated as the result of a complete atomic block composition.
+	 *
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks a complete atomic block.
 	 */
-	public static <LOC extends IcfgLocation>  boolean isCompleteAtomicBlock(final IIcfgTransition<LOC> edge) {
+	public static boolean isCompleteAtomicBlock(final IIcfgTransition<?> edge) {
 		return hasAnnotatedDelta(edge, d -> d == 0);
 	}
 
 	/**
 	 * Marks the given element (an edge) as the beginning of an atomic block.
 	 */
-	public static <LOC extends IcfgLocation>  void addBeginAnnotation(final IIcfgTransition<LOC> edge) {
+	public static void addBeginAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, START_DELTA);
 	}
 
@@ -123,7 +123,7 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 * Marks the given element (an edge) as the end of an atomic block.
 	 *
 	 */
-	public static <LOC extends IcfgLocation>  void addEndAnnotation(final IIcfgTransition<LOC> edge) {
+	public static void addEndAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, END_DELTA);
 	}
 
@@ -131,7 +131,7 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 * Marks the given element (an edge) as the result of a complete atomic block composition.
 	 *
 	 */
-	public static <LOC extends IcfgLocation>  void addCompleteAnnotation(final IIcfgTransition<LOC> edge) {
+	public static void addCompleteAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, 0);
 	}
 
@@ -139,12 +139,11 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 * Removes any {@link AtomicBlockInfo} annotation, if present.
 	 *
 	 */
-	public static <LOC extends IcfgLocation>  void removeAnnotation(final IIcfgTransition<LOC> edge) {
+	public static void removeAnnotation(final IIcfgTransition<?> edge) {
 		edge.getPayload().getAnnotations().remove(AtomicBlockInfo.class.getName());
 	}
 
-	private static <LOC extends IcfgLocation> boolean hasAnnotatedDelta(final IIcfgTransition<LOC> edge,
-			final IntPredicate condition) {
+	private static boolean hasAnnotatedDelta(final IIcfgTransition<?> edge, final IntPredicate condition) {
 		final AtomicBlockInfo annotation = ModelUtils.getAnnotation(edge, AtomicBlockInfo.class);
 		if (annotation != null) {
 			return condition.test(annotation.mDelta);
@@ -152,7 +151,7 @@ final class AtomicBlockInfo extends ModernAnnotations {
 		return false;
 	}
 
-	private static <LOC extends IcfgLocation>  void addAnnotation(final IIcfgTransition<LOC> edge, final int delta) {
+	private static void addAnnotation(final IIcfgTransition<?> edge, final int delta) {
 		final var previous = ModelUtils.getAnnotation(edge, AtomicBlockInfo.class);
 		if (previous != null) {
 			throw new UnsupportedOperationException(

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
@@ -82,8 +82,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *
 	 * Note that an edge can be the start of an atomic block or the end, but not both.
 	 *
-	 * @param element
-	 *            The element whose annotation is examined.
+	 * @param edge
+	 *            The edge whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the beginning of an atomic block.
 	 */
 	public static boolean isStartOfAtomicBlock(final IIcfgTransition<?> edge) {
@@ -95,8 +95,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *
 	 * Note that an edge can be the start of an atomic block or the end, but not both.
 	 *
-	 * @param element
-	 *            The element whose annotation is examined.
+	 * @param edge
+	 *            The edge whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the end of an atomic block.
 	 */
 	public static boolean isEndOfAtomicBlock(final IIcfgTransition<?> edge) {
@@ -106,6 +106,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	/**
 	 * Determines if the given element (an edge) is annotated as the result of a complete atomic block composition.
 	 *
+	 * @param edge
+	 *            The edge whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks a complete atomic block.
 	 */
 	public static boolean isCompleteAtomicBlock(final IIcfgTransition<?> edge) {
@@ -114,6 +116,9 @@ final class AtomicBlockInfo extends ModernAnnotations {
 
 	/**
 	 * Marks the given element (an edge) as the beginning of an atomic block.
+	 *
+	 * @param element
+	 *            The edge to be marked.
 	 */
 	public static void addBeginAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, START_DELTA);
@@ -122,6 +127,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	/**
 	 * Marks the given element (an edge) as the end of an atomic block.
 	 *
+	 * @param element
+	 *            The edge to be marked.
 	 */
 	public static void addEndAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, END_DELTA);
@@ -130,6 +137,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	/**
 	 * Marks the given element (an edge) as the result of a complete atomic block composition.
 	 *
+	 * @param element
+	 *            The edge to be marked.
 	 */
 	public static void addCompleteAnnotation(final IIcfgTransition<?> edge) {
 		addAnnotation(edge, 0);
@@ -138,6 +147,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	/**
 	 * Removes any {@link AtomicBlockInfo} annotation, if present.
 	 *
+	 * @param element
+	 *            The edge from which annotations shall be removed.
 	 */
 	public static void removeAnnotation(final IIcfgTransition<?> edge) {
 		edge.getPayload().getAnnotations().remove(AtomicBlockInfo.class.getName());

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/AtomicBlockInfo.java
@@ -31,9 +31,10 @@ import java.util.Map;
 import java.util.function.IntPredicate;
 
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.ModernAnnotations;
-import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfgTransition;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgLocation;
 
 /**
  * An annotation used to mark CFG edges that are the beginning or end of an atomic block, in the sense of SV-COMP's
@@ -86,8 +87,8 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *            The element whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the beginning of an atomic block.
 	 */
-	public static boolean isStartOfAtomicBlock(final IElement element) {
-		return hasAnnotatedDelta(element, d -> d > 0);
+	public static <LOC extends IcfgLocation> boolean isStartOfAtomicBlock(final IIcfgTransition<LOC> edge) {
+		return hasAnnotatedDelta(edge, d -> d > 0);
 	}
 
 	/**
@@ -99,75 +100,64 @@ final class AtomicBlockInfo extends ModernAnnotations {
 	 *            The element whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks the end of an atomic block.
 	 */
-	public static boolean isEndOfAtomicBlock(final IElement element) {
-		return hasAnnotatedDelta(element, d -> d < 0);
+	public static <LOC extends IcfgLocation>  boolean isEndOfAtomicBlock(final IIcfgTransition<LOC> edge) {
+		return hasAnnotatedDelta(edge, d -> d < 0);
 	}
 
 	/**
 	 * Determines if the given element (an edge) is annotated as the result of a complete atomic block composition.
-	 *
-	 * @param element
-	 *            The element whose annotation is examined.
 	 * @return true if there is an {@link AtomicBlockInfo} annotation that marks a complete atomic block.
 	 */
-	public static boolean isCompleteAtomicBlock(final IElement element) {
-		return hasAnnotatedDelta(element, d -> d == 0);
+	public static <LOC extends IcfgLocation>  boolean isCompleteAtomicBlock(final IIcfgTransition<LOC> edge) {
+		return hasAnnotatedDelta(edge, d -> d == 0);
 	}
 
 	/**
 	 * Marks the given element (an edge) as the beginning of an atomic block.
-	 *
-	 * @param element
-	 *            The edge to be marked.
 	 */
-	public static void addBeginAnnotation(final IElement element) {
-		addAnnotation(element, START_DELTA);
+	public static <LOC extends IcfgLocation>  void addBeginAnnotation(final IIcfgTransition<LOC> edge) {
+		addAnnotation(edge, START_DELTA);
 	}
 
 	/**
 	 * Marks the given element (an edge) as the end of an atomic block.
 	 *
-	 * @param element
-	 *            The edge to be marked.
 	 */
-	public static void addEndAnnotation(final IElement element) {
-		addAnnotation(element, END_DELTA);
+	public static <LOC extends IcfgLocation>  void addEndAnnotation(final IIcfgTransition<LOC> edge) {
+		addAnnotation(edge, END_DELTA);
 	}
 
 	/**
 	 * Marks the given element (an edge) as the result of a complete atomic block composition.
 	 *
-	 * @param element
-	 *            The edge to be marked.
 	 */
-	public static void addCompleteAnnotation(final IElement element) {
-		addAnnotation(element, 0);
+	public static <LOC extends IcfgLocation>  void addCompleteAnnotation(final IIcfgTransition<LOC> edge) {
+		addAnnotation(edge, 0);
 	}
 
 	/**
 	 * Removes any {@link AtomicBlockInfo} annotation, if present.
 	 *
-	 * @param element
-	 *            The edge from which annotations shall be removed
 	 */
-	public static void removeAnnotation(final IElement element) {
-		element.getPayload().getAnnotations().remove(AtomicBlockInfo.class.getName());
+	public static <LOC extends IcfgLocation>  void removeAnnotation(final IIcfgTransition<LOC> edge) {
+		edge.getPayload().getAnnotations().remove(AtomicBlockInfo.class.getName());
 	}
 
-	private static boolean hasAnnotatedDelta(final IElement element, final IntPredicate condition) {
-		final AtomicBlockInfo annotation = ModelUtils.getAnnotation(element, AtomicBlockInfo.class);
+	private static <LOC extends IcfgLocation> boolean hasAnnotatedDelta(final IIcfgTransition<LOC> edge,
+			final IntPredicate condition) {
+		final AtomicBlockInfo annotation = ModelUtils.getAnnotation(edge, AtomicBlockInfo.class);
 		if (annotation != null) {
 			return condition.test(annotation.mDelta);
 		}
 		return false;
 	}
 
-	private static void addAnnotation(final IElement element, final int delta) {
-		final var previous = ModelUtils.getAnnotation(element, AtomicBlockInfo.class);
+	private static <LOC extends IcfgLocation>  void addAnnotation(final IIcfgTransition<LOC> edge, final int delta) {
+		final var previous = ModelUtils.getAnnotation(edge, AtomicBlockInfo.class);
 		if (previous != null) {
 			throw new UnsupportedOperationException(
 					"Incompatible atomic block annotation: " + previous.mDelta + " and " + delta);
 		}
-		element.getPayload().getAnnotations().put(AtomicBlockInfo.class.getName(), new AtomicBlockInfo(delta));
+		edge.getPayload().getAnnotations().put(AtomicBlockInfo.class.getName(), new AtomicBlockInfo(delta));
 	}
 }

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
@@ -1527,7 +1527,7 @@ public class CfgBuilder {
 			assert mCurrent instanceof CodeBlock : "Start marker for atomic section must be an edge";
 
 			// mark current edge as start of atomic block
-			AtomicBlockInfo.addBeginAnnotation(mCurrent);
+			AtomicBlockInfo.addBeginAnnotation((IIcfgTransition<?>) mCurrent);
 		}
 
 		private void endAtomicBlock(final Statement st) {
@@ -1537,13 +1537,13 @@ public class CfgBuilder {
 			}
 			assert mCurrent instanceof CodeBlock : "End marker for atomic section must be an edge";
 
-			if (AtomicBlockInfo.isStartOfAtomicBlock(mCurrent)) {
+			if (AtomicBlockInfo.isEndOfAtomicBlock((IIcfgTransition<?>) mCurrent)) {
 				// if current edge is both start and end of an atomic block, it is already atomic -- nothing else to do
-				AtomicBlockInfo.removeAnnotation(mCurrent);
-				AtomicBlockInfo.addCompleteAnnotation(mCurrent);
+				AtomicBlockInfo.removeAnnotation((IIcfgTransition<?>) mCurrent);
+				AtomicBlockInfo.addCompleteAnnotation((IIcfgTransition<?>) mCurrent);
 			} else {
 				// mark current edge as end of atomic block
-				AtomicBlockInfo.addEndAnnotation(mCurrent);
+				AtomicBlockInfo.addEndAnnotation((IIcfgTransition<?>) mCurrent);
 			}
 
 			// ensure nothing is appended to current edge

--- a/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
+++ b/trunk/source/RCFGBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/rcfgbuilder/cfg/CfgBuilder.java
@@ -1537,7 +1537,7 @@ public class CfgBuilder {
 			}
 			assert mCurrent instanceof CodeBlock : "End marker for atomic section must be an edge";
 
-			if (AtomicBlockInfo.isEndOfAtomicBlock((IIcfgTransition<?>) mCurrent)) {
+			if (AtomicBlockInfo.isStartOfAtomicBlock((IIcfgTransition<?>) mCurrent)) {
 				// if current edge is both start and end of an atomic block, it is already atomic -- nothing else to do
 				AtomicBlockInfo.removeAnnotation((IIcfgTransition<?>) mCurrent);
 				AtomicBlockInfo.addCompleteAnnotation((IIcfgTransition<?>) mCurrent);


### PR DESCRIPTION
Use IIcfgTransition instead of IElement because this annotation is always written to edges.