### PR TITLE
Requirement redundancies: Approximation of explanation via invariants

### DIFF
--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgUtils.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgUtils.java
@@ -85,6 +85,13 @@ public class IcfgUtils {
 			return loa != null && loa.getLoopEntryType() == LoopEntryType.GOTO;
 		})).collect(Collectors.toSet());
 	}
+	
+	/**
+	 * Collect all program points that are predecessors of an error location
+	 */
+	public static <LOC extends IcfgLocation> Set<LOC> getPreErrorLocations(final IIcfg<LOC> icfg) {
+		return (Set<LOC>) IcfgUtils.getErrorLocations(icfg).stream().map(node -> node.getIncomingNodes()).flatMap(List::stream).collect(Collectors.toSet());
+	}
 
 	/**
 	 * Collect all program points that are predecessors or successors of an {@link IIcfgCallTransition}.

--- a/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgUtils.java
+++ b/trunk/source/Library-ModelCheckerUtils/src/de/uni_freiburg/informatik/ultimate/lib/modelcheckerutils/cfg/IcfgUtils.java
@@ -87,7 +87,7 @@ public class IcfgUtils {
 	}
 	
 	/**
-	 * Collect all program points that are predecessors of an error location
+	 * Collect all program points that are predecessors of a final location
 	 */
 	public static <LOC extends IcfgLocation> Set<LOC> getPreErrorLocations(final IIcfg<LOC> icfg) {
 		return (Set<LOC>) IcfgUtils.getErrorLocations(icfg).stream().map(node -> node.getIncomingNodes()).flatMap(List::stream).collect(Collectors.toSet());

--- a/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
+++ b/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
@@ -108,11 +108,15 @@ public final class FloydHoareUtils {
 		final var checks = getCheckedSpecifications(icfg, annotation);
 
 		// find all locations that have outgoing edges which are annotated with LoopEntry, i.e., all loop candidates
-		final Set<IcfgLocation> locsForLoopLocations = new HashSet<>();
-		locsForLoopLocations.addAll(IcfgUtils.getPotentialCycleProgramPoints(icfg));
-		locsForLoopLocations.addAll(icfg.getLoopLocations());
-
-		for (final IcfgLocation locNode : locsForLoopLocations) {
+		final Set<IcfgLocation> locsForInvariants = new HashSet<>();
+		locsForInvariants.addAll(IcfgUtils.getPotentialCycleProgramPoints(icfg));
+		locsForInvariants.addAll(icfg.getLoopLocations());
+		
+		// find the predecessor locations of all error locations
+		var test = IcfgUtils.getPreErrorLocations(icfg);
+		locsForInvariants.addAll(test);
+		
+		for (final IcfgLocation locNode : locsForInvariants) {
 			final IPredicate hoare = annotation.getAnnotation(locNode);
 			if (hoare == null) {
 				continue;
@@ -131,9 +135,9 @@ public final class FloydHoareUtils {
 		// Temporary hack: Get the invariant of the pre-error location
 		// There exists only one in our use case, needs to be generalized if obtaining
 		// invariants for all pre-error locations is desired
-		final var errorLocs = IcfgUtils.getErrorLocations(icfg).iterator();
-		if (errorLocs.hasNext())
-		{
+		//final var errorLocs = IcfgUtils.getErrorLocations(icfg).iterator();
+		//if (errorLocs.hasNext())
+		/*{
 			final var preLocs = errorLocs.next().getIncomingNodes();
 			// Hack: For reqcheck there only exists one pre-error location
 			final var preLoc = preLocs.isEmpty() ? null : preLocs.get(0);
@@ -149,7 +153,7 @@ public final class FloydHoareUtils {
 						new InvariantResult<IIcfgElement>(pluginName, preLoc, backTranslatorService, formula, checks);
 				reporter.accept(invResult);
 			}
-		}
+		}*/
 	}
 
 	public static void createProcedureContractResults(final IUltimateServiceProvider services, final String pluginName,

--- a/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
+++ b/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
@@ -131,29 +131,6 @@ public final class FloydHoareUtils {
 			}
 			new WitnessInvariant(invResult.getInvariant()).annotate(locNode);
 		}
-		
-		// Temporary hack: Get the invariant of the pre-error location
-		// There exists only one in our use case, needs to be generalized if obtaining
-		// invariants for all pre-error locations is desired
-		//final var errorLocs = IcfgUtils.getErrorLocations(icfg).iterator();
-		//if (errorLocs.hasNext())
-		/*{
-			final var preLocs = errorLocs.next().getIncomingNodes();
-			// Hack: For reqcheck there only exists one pre-error location
-			final var preLoc = preLocs.isEmpty() ? null : preLocs.get(0);
-			if (preLoc != null)
-			{
-				final IPredicate hoare = annotation.getAnnotation(preLoc);
-				if (hoare == null)
-				{
-					return;
-				}
-				final Term formula = hoare.getFormula();
-				final var invResult =
-						new InvariantResult<IIcfgElement>(pluginName, preLoc, backTranslatorService, formula, checks);
-				reporter.accept(invResult);
-			}
-		}*/
 	}
 
 	public static void createProcedureContractResults(final IUltimateServiceProvider services, final String pluginName,

--- a/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
+++ b/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
@@ -127,6 +127,29 @@ public final class FloydHoareUtils {
 			}
 			new WitnessInvariant(invResult.getInvariant()).annotate(locNode);
 		}
+		
+		// Temporary hack: Get the invariant of the pre-error location
+		// There exists only one in our use case, needs to be generalized if obtaining
+		// invariants for all pre-error locations is desired
+		final var errorLocs = IcfgUtils.getErrorLocations(icfg).iterator();
+		if (errorLocs.hasNext())
+		{
+			final var preLocs = errorLocs.next().getIncomingNodes();
+			// Hack: For reqcheck there only exists one pre-error location
+			final var preLoc = preLocs.isEmpty() ? null : preLocs.get(0);
+			if (preLoc != null)
+			{
+				final IPredicate hoare = annotation.getAnnotation(preLoc);
+				if (hoare == null)
+				{
+					return;
+				}
+				final Term formula = hoare.getFormula();
+				final var invResult =
+						new InvariantResult<IIcfgElement>(pluginName, preLoc, backTranslatorService, formula, checks);
+				reporter.accept(invResult);
+			}
+		}
 	}
 
 	public static void createProcedureContractResults(final IUltimateServiceProvider services, final String pluginName,

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/InvariantResult.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/InvariantResult.java
@@ -79,4 +79,8 @@ public class InvariantResult<ELEM extends IElement> extends AbstractResultAtElem
 	public Set<Check> getChecks() {
 		return mChecks;
 	}
+	
+	public boolean isLoopLocation() {
+		return mIsLoopLocation;
+	}
 }

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/InvariantResult.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/InvariantResult.java
@@ -80,7 +80,7 @@ public class InvariantResult<ELEM extends IElement> extends AbstractResultAtElem
 		return mChecks;
 	}
 	
-	public boolean isLoopLocation() {
+	public boolean isLoopInvariant() {
 		return mIsLoopLocation;
 	}
 }

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -117,12 +117,14 @@ public class VerificationResultTransformer {
 	private final ILogger mLogger;
 	private final IUltimateServiceProvider mServices;
 	private final IReqSymbolTable mReqSymbolTable;
+	private final Set<String> mProcessedReqs;
 
 	public VerificationResultTransformer(final ILogger logger, final IUltimateServiceProvider services,
 			final IReqSymbolTable reqSymbolTable) {
 		mLogger = logger;
 		mServices = services;
 		mReqSymbolTable = reqSymbolTable;
+		mProcessedReqs = new HashSet<String>();
 	}
 
 	public IResult convertTraceAbstractionResult(final IResult result) {
@@ -153,6 +155,12 @@ public class VerificationResultTransformer {
 				return null;
 			}
 			reqCheck = (ReqCheck) check.get();
+			// If requirement already processed, void the location invariant
+			var reqId = reqCheck.getReqIds().iterator().next();
+			if (mProcessedReqs.contains(reqId)) {
+				return null;
+			}
+			mProcessedReqs.add(reqId);
 			// Important if other specs receive invariants too,
 			// in order to prevent the results to slip through to
 			// the last return unhandled

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -143,7 +143,8 @@ public class VerificationResultTransformer {
 			return null;
 		} else if (result instanceof InvariantResult) {
 			invResult = (InvariantResult<?>) result;
-			if (!invResult.isLoopLocation()) {
+			// Only want to process location invariants
+			if (invResult.isLoopLocation()) {
 				return result;
 			}
 			oldRes = (AbstractResultAtElement<?>) result;
@@ -213,7 +214,7 @@ public class VerificationResultTransformer {
 			final Set<String> redundancySet = ReqCheckRedundancyResult.extractRedundancySet(invariant);
 			// TODO: Apply post-processing to the redundancy set here
 			resultString.append(redundancySet.toString());
-			resultString.append(" derived by loop invariant: ");
+			resultString.append(" derived by location invariant: ");
 			resultString.append(invariant);
 			return new ReqCheckRedundancyResult<>(element, plugin, reqCheck.getReqIds().iterator().next(), resultString.toString());
 		}		

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -117,14 +117,12 @@ public class VerificationResultTransformer {
 	private final ILogger mLogger;
 	private final IUltimateServiceProvider mServices;
 	private final IReqSymbolTable mReqSymbolTable;
-	private final Set<String> mProcessedReqs;
 
 	public VerificationResultTransformer(final ILogger logger, final IUltimateServiceProvider services,
 			final IReqSymbolTable reqSymbolTable) {
 		mLogger = logger;
 		mServices = services;
 		mReqSymbolTable = reqSymbolTable;
-		mProcessedReqs = new HashSet<String>();
 	}
 
 	public IResult convertTraceAbstractionResult(final IResult result) {
@@ -155,12 +153,6 @@ public class VerificationResultTransformer {
 				return null;
 			}
 			reqCheck = (ReqCheck) check.get();
-			// If requirement already processed, void the location invariant
-			var reqId = reqCheck.getReqIds().iterator().next();
-			if (mProcessedReqs.contains(reqId)) {
-				return null;
-			}
-			mProcessedReqs.add(reqId);
 			// Important if other specs receive invariants too,
 			// in order to prevent the results to slip through to
 			// the last return unhandled

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -144,7 +144,7 @@ public class VerificationResultTransformer {
 		} else if (result instanceof InvariantResult) {
 			invResult = (InvariantResult<?>) result;
 			// Only want to process location invariants
-			if (invResult.isLoopLocation()) {
+			if (invResult.isLoopInvariant()) {
 				return result;
 			}
 			oldRes = (AbstractResultAtElement<?>) result;

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/VerificationResultTransformer.java
@@ -153,6 +153,12 @@ public class VerificationResultTransformer {
 				return null;
 			}
 			reqCheck = (ReqCheck) check.get();
+			// Important if other specs receive invariants too,
+			// in order to prevent the results to slip through to
+			// the last return unhandled
+			if (!reqCheck.getSpec().contains(Spec.REDUNDANCY)) {
+				return result;
+			}
 			isPositive = true;
 		} else {
 			return result;

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
@@ -1,0 +1,48 @@
+package de.uni_freiburg.informatik.ultimate.pea2boogie.results;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+
+public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFailResult<LOC> {
+
+	private String mReqName;
+	private String mRedundancySet;
+	
+	public ReqCheckRedundancyResult(LOC element, String plugin, String reqName, String redundancySet) {
+		super(element, plugin);
+		mReqName = reqName;
+		mRedundancySet = redundancySet;
+	}
+
+	@Override
+	public String getLongDescription() {
+		return "Extracted redundancy set for " + mReqName + ": " + mRedundancySet;
+	}
+	
+	/*
+	 * Function that parses loop invariants represented by strings. In the terms of the regex,
+	 * we extract every name of the automata appearing inside of the loop invariant.
+	 * TODO: One issue that persist is if a user names the observable of a requirement
+	 * such that it matches the regex (for example: "input FakeReq_ct0_total_pc IS bool").
+	 * For now the method works under the assumption that names created during the formalization process are
+	 * disjoint of the variable names used in the program that simulates the intersection of automata
+	 */
+	public static Set<String> extractRedundancySet(String invariant) {
+		String regex = "[a-zA-Z_]+[a-zA-Z0-9_]*_total";
+		Pattern pattern = Pattern.compile(regex);
+		Matcher matcher = pattern.matcher(invariant);
+		
+		Set<String> redundancySet = new HashSet<>();
+		
+		while (matcher.find()) {
+			redundancySet.add(matcher.group().split("_ct")[0]);
+		}
+		
+		return redundancySet;
+	}
+	
+}

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
@@ -32,7 +32,7 @@ public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFail
 	 * disjoint of the variable names used in the program that simulates the intersection of automata
 	 */
 	public static Set<String> extractRedundancySet(String invariant) {
-		String regex = "[a-zA-Z_]+[a-zA-Z0-9_]*_total";
+		String regex = "[a-zA-Z_]+[a-zA-Z0-9_]*_ct(0|[1-9][0-9]*)[a-zA-Z0-9_]*_total";
 		Pattern pattern = Pattern.compile(regex);
 		Matcher matcher = pattern.matcher(invariant);
 		

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
@@ -24,7 +24,7 @@ public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFail
 	}
 	
 	/*
-	 * Function that parses loop invariants represented by strings. In the terms of the regex,
+	 * Function that parses (loop/location) invariants represented by strings. In the terms of the regex,
 	 * we extract every name of the automata appearing inside of the loop invariant.
 	 * TODO: One issue that persist is if a user names the observable of a requirement
 	 * such that it matches the regex (for example: "input FakeReq_ct0_total_pc IS bool").

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
@@ -1,6 +1,6 @@
 package de.uni_freiburg.informatik.ultimate.pea2boogie.results;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -36,7 +36,7 @@ public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFail
 		Pattern pattern = Pattern.compile(regex);
 		Matcher matcher = pattern.matcher(invariant);
 		
-		Set<String> redundancySet = new HashSet<>();
+		Set<String> redundancySet = new LinkedHashSet<>();
 		
 		while (matcher.find()) {
 			redundancySet.add(matcher.group().split("_ct")[0]);

--- a/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
+++ b/trunk/source/PEAtoBoogie/src/de/uni_freiburg/informatik/ultimate/pea2boogie/results/ReqCheckRedundancyResult.java
@@ -11,6 +11,7 @@ public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFail
 
 	private String mReqName;
 	private String mRedundancySet;
+	private static String mRegex = "[a-zA-Z_]+[a-zA-Z0-9_]*_ct(0|[1-9][0-9]*)[a-zA-Z0-9_]*_total";
 	
 	public ReqCheckRedundancyResult(LOC element, String plugin, String reqName, String redundancySet) {
 		super(element, plugin);
@@ -32,8 +33,7 @@ public class ReqCheckRedundancyResult<LOC extends IElement> extends ReqCheckFail
 	 * disjoint of the variable names used in the program that simulates the intersection of automata
 	 */
 	public static Set<String> extractRedundancySet(String invariant) {
-		String regex = "[a-zA-Z_]+[a-zA-Z0-9_]*_ct(0|[1-9][0-9]*)[a-zA-Z0-9_]*_total";
-		Pattern pattern = Pattern.compile(regex);
+		Pattern pattern = Pattern.compile(mRegex);
 		Matcher matcher = pattern.matcher(invariant);
 		
 		Set<String> redundancySet = new LinkedHashSet<>();


### PR DESCRIPTION
Pea2Boogie is capable of analyzing a set of requirements for the property of redundancy. In order to better explain a redundancy, we work on post-processing steps in an attempt to extract a set of requirements that are directly involved in the redundancy, a so-called redundancy set. Trace Abstraction (Automizer) offers invariants for the locations of ICFGs that already act as a first good approximation in many cases. For this purpose the following changes have been implemented:

### ReqCheckRedundancyResult.java
A new result class `ReqCheckRedundancyResult` has been added to the results of Pea2Boogie. The result simply reports the redundancy of a given requirement and additionally, outputs the approximation that was computed. A static method inside of it does a simple (and not yet bulletproof) matching on a given invariant which is represented by a string. In the future, functionality like that can be put into a post-processing class that maybe also works in the VerificationResultTransformer class.

###  InvariantResult.java
For this change, I want to ask especially for the approval of @maul-esel 
The InvariantResults were extended by a method to check the boolean field mIsLoopLocation. This can be useful when distinguishing between loop locations, and e.g., pre-error locations that we need for a better approximation. However, if in the future more than just loop/pre-error location invariants can be created, then a better approach is needed in order to distinguish between the different locations, rather than just through a binary decision (which stems from the fact that currently, with my changes and for our purpose, we can assume an InvariantResult to either correspond to a loop location or a pre-error location)

### VerificationResultTransformer.java
The VerificationResultTransformer has been extended to also handle incoming InvariantResults that trace abstraction delivers. Loop invariants are just returned. Location invariants are pre-processed in the scope of a new if-statement that adds specific behavior in case of a redundancy spec, similar to the case of rt-inconsistency above it. If we check a requirement for redundancy and an invariant result is present. The creation of location invariants are implemented through a hack in the following explanation.

### FloydHoareUtils.java
Because this is an area in which @maul-esel works (from what I noticed during my time working here) I want to ask specifically for his approval or ideas for a change. If I should add someone else as a reviewer just let me know!

I am very certain that this is not an acceptable hack and needs a better solution. This is only a temporary workaround so I can see results for my thesis. However, this hack assumes that there is only one pre-error location, i.e., one direct predecessor location in the ICFG for all error locations. This assumption is true for our redundancy checks but of course not true in general. Hence, I think one could add an extraction similar to loop invariants, just for all pre-error locations of an ICFG. Maybe @maul-esel has an idea? For now, the hack works out fine. Overall, the results of the approximations obtained by the location invariants have been rather great.

### Additional remarks
This implementation works only under the following settings:
- Automizer has to run one cegar loop per error location
- Automizer needs to compute Hoare annotations for all locations (otherwise, the more detailed redundancy results will not be computed). This is expensive but one could also change the code via a setting to decide whether loop or location invariants should be used for the first approximation, as I assume that the former is more efficient than the latter.

Example of one specific output:
\- ReqCheckRedundancyResult [Line: -1]: Requirement ID_007 is redundant
 Extracted redundancy set for ID_007: [ID_003, ID_012, ID_000, ID_007] derived by location invariant: (Omitted for brevity)

I am looking forward to hear your feedback in order to improve, as I only started delving into ULTIMATE very recently! Thank you! Again, if certain people are missing as reviewers just let me know!

