### PR TITLE
Fix translation of atomic functions

### DIFF
--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_load_n_sideeffects.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_load_n_sideeffects.c
@@ -1,0 +1,25 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-07-19
+ */
+
+typedef unsigned long pthread_t;
+
+int c;
+int x[2] = {0, 1};
+
+void* thread1() {
+  __atomic_load_n(x + c++, 5);
+}
+
+void* thread2() {
+  int local = c;
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_memory_order.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_memory_order.c
@@ -1,0 +1,25 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-07-19
+ */
+
+typedef unsigned long pthread_t;
+
+int x;
+int c = 4;
+
+void* thread1() {
+  __atomic_store_n(&x, 1, ++c); // Data-Race: ++c is not executed atomically
+}
+
+void* thread2() {
+  int local = __atomic_load_n(&c, 5);
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/stdatomic/regression/atomic_exchange_sideeffects.c
+++ b/trunk/examples/concurrent/stdatomic/regression/atomic_exchange_sideeffects.c
@@ -1,0 +1,16 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-07-19
+ */
+
+int main(void) {
+  int c = 0;
+  int x[2] = {0, 1};
+  int y = 1;
+  int z = 2;
+  __atomic_exchange(x + c++, &y, &z, 5);
+  //@ assert c == 1;
+  //@ assert x[0] == 1 && y == 1 && z == 0;
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -1080,13 +1080,12 @@ public class StandardFunctionHandler {
 		final ExpressionResult memoryOrder =
 				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[2]);
 		builder.addAllExceptLrValue(pointer1, pointer2, memoryOrder);
-		final ExpressionResultBuilder atomicBuilder = new ExpressionResultBuilder();
+		// Make sure that only the read, but not the write is atomic
 		final ExpressionResult read = mExprResultTransformer.readPointerValue(loc, pointer1.getLrValue());
-		atomicBuilder.addAllExceptLrValue(read,
-				mExprResultTransformer.makePointerAssignment(loc, pointer2.getLrValue(), read.getLrValue().getValue()));
-		// Both the read and the write are atomic
-		return builder.addAllIncludingLrValue(
-				applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
+		final ExpressionResult write =
+				mExprResultTransformer.makePointerAssignment(loc, pointer2.getLrValue(), read.getLrValue().getValue());
+		return builder.addAllIncludingLrValue(applyMemoryOrder(loc, read, memoryOrder.getLrValue().getValue()))
+				.addAllExceptLrValue(write).build();
 	}
 
 	private Result handleAtomicStore(final IDispatcher main, final IASTFunctionCallExpression node, final ILocation loc,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/ThreadIdManager.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/ThreadIdManager.java
@@ -63,6 +63,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultBuilder;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultTransformer;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultTransformer.IPointerReadWrite;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
@@ -131,7 +132,9 @@ public class ThreadIdManager {
 
 		final Expression threadId = getOldForkCounterAsTemp(loc, erb);
 		incrementForkCounter(loc, erb);
-		erb.addAllExceptLrValue(mExpressionResultTransformer.dispatchPointerWrite(dispatcher, loc, argument, threadId));
+		final IPointerReadWrite rw =
+				mExpressionResultTransformer.dispatchPointerWithOptimization(dispatcher, loc, argument);
+		erb.addAllExceptLrValue(rw.getDispatchedResult(), rw.getWrite(threadId));
 
 		if (UNAMBIGUOUS_THREAD_ID_OPTIMIZATION) {
 			final Integer unambiguousId = getUnambiguousThreadIdCounter(argument);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/ThreadIdManager.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/ThreadIdManager.java
@@ -63,7 +63,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultBuilder;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultTransformer;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultTransformer.IPointerReadWrite;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
@@ -132,9 +131,8 @@ public class ThreadIdManager {
 
 		final Expression threadId = getOldForkCounterAsTemp(loc, erb);
 		incrementForkCounter(loc, erb);
-		final IPointerReadWrite rw =
-				mExpressionResultTransformer.dispatchPointerWithOptimization(dispatcher, loc, argument);
-		erb.addAllExceptLrValue(rw.getDispatchedResult(), rw.getWrite(threadId));
+		final ExpressionResult pointerLValue = mExpressionResultTransformer.dispatchPointerLValue(dispatcher, loc, argument);
+		erb.addAllExceptLrValue(pointerLValue, mExpressionResultTransformer.makePointerAssignment(loc, pointerLValue.getLrValue(), threadId));
 
 		if (UNAMBIGUOUS_THREAD_ID_OPTIMIZATION) {
 			final Integer unambiguousId = getUnambiguousThreadIdCounter(argument);


### PR DESCRIPTION
PR #657 added support for atomic functions. This had however two problems (in the current version):
* To improve our performance, this PR tried to avoid unecessary heap variables, i.e., we tried to translate `__atomic_store_n(&x, 1, 5)` to `x := 1` inside an atomic block rather than `write~(x, 1)` (see d08b25f and in the [PR](https://github.com/ultimate-pa/ultimate/pull/657#issuecomment-1883310446)). This way the arguments were dispatched possibly multiple times, which is problematic if they have side-effects (see [atomic_load_n_sideeffects.c](https://github.com/ultimate-pa/ultimate/compare/dev...wip/fs/atomic-fix#diff-d25c8f52ac3262e385e626766bb1204bcdc757a393dfc39c4f9ae3903c818526)).
* We put everything inside an atomic-block. However, not everything is guaranteed to be executed atomically, e.g. for `__atomic_store_n(&x, expr1, expr2)` only the actual write on `x` is atomic, not the evaluation of `expr1` or `expr2`. This could have led to missed data-races (see [atomic_memory_order.c](https://github.com/ultimate-pa/ultimate/compare/dev...wip/fs/atomic-fix#diff-6ea6a44548a6065be56965bfb6edc8167a6833a1a439bc060a9694b709734be7))
* We considered the read and write to be atomic for `__atomic_load`, but only the read should be atomic (fixed in f2e474d)

~~To fix these issues, the PR adds an interface `IPointerReadWrite` (and two implementations) that allows to get the dispatched argument, a read and a write separately (s.t. we can "control" the atomicity) and that guarantees that the dispatch is only done once. This interface is the used in `StandardFunctionHandler` for the translation of atomic functions.~~

To fix these issues, the PR adds three separate method to `ExpressionResultTransformer`:
* `dispatchPointerLValue` to dispatch the pointer expression, but tries to produce `LocalLValue`
* `makePointerAssignment` writes to the given address, produces simple assignment for `LocalLValue` and write-call for `HeapLValue`
* `readPointerValue` reads from the given address, always returns an aux-var as `RValue`, assigns the `LocalLValue` to the aux-var or reads to the aux-var from the memory for `HeapLValue`