### PR TITLE
Backtranslation of contracts with handling of "modifies" clause

### DIFF
--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/NameHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/NameHandler.java
@@ -94,7 +94,7 @@ public class NameHandler implements INameHandler {
 			while (curr != null && !(curr.getParent() instanceof IASTTranslationUnit)) {
 				if (curr instanceof IASTCompositeTypeSpecifier) {
 					boogieId = cId;
-					mBacktranslator.putVar(boogieId, cId, cType, decInfo);
+					mBacktranslator.putVar(boogieId, cId, cType, decInfo, isOnHeap);
 					return boogieId;
 				}
 				curr = curr.getParent();
@@ -115,7 +115,7 @@ public class NameHandler implements INameHandler {
 		} else {
 			boogieId = "~" + onHeapStr + cId;
 		}
-		mBacktranslator.putVar(boogieId, cId, cType, decInfo);
+		mBacktranslator.putVar(boogieId, cId, cType, decInfo, isOnHeap);
 		return boogieId;
 	}
 
@@ -157,10 +157,9 @@ public class NameHandler implements INameHandler {
 	public String getTempVarUIDForBlockScope(final SFO.AUXVAR purpose, final CType cType) {
 		final String boogieId = SFO.TEMP + purpose.getId() + mTmpUID++;
 		// do not add it as a temp var since it should not be havocced immediately (at C statement level)
-//		mBacktranslator.putTempVar(boogieId, purpose, cType);
+		// mBacktranslator.putTempVar(boogieId, purpose, cType);
 		return boogieId;
 	}
-
 
 	@Override
 	public String getGloballyUniqueIdentifier(final String looplabel) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
@@ -111,15 +111,14 @@ public final class Boogie2ACSL {
 	public BacktranslatedExpression translateEnsuresExpression(
 			final de.uni_freiburg.informatik.ultimate.boogie.ast.Expression expression, final ILocation context,
 			final Set<de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression> modifiableGlobals) {
-		final var intType = new CPrimitive(CPrimitives.INT);
-		final var boolRange = BigInterval.booleanRange();
-
-		if (expression == null) {
+		final var mainExpression = expression == null ? null : translateExpression(expression, context);
+		if (mainExpression == null) {
+			final var intType = new CPrimitive(CPrimitives.INT);
+			final var boolRange = BigInterval.booleanRange();
 			return computeOldVarEqualities(modifiableGlobals)
 					.map(e -> new BacktranslatedExpression(e, intType, boolRange)).orElse(null);
 		}
 
-		final var mainExpression = translateExpression(expression, context);
 		final var oldVarEqualities = computeOldVarEqualities(modifiableGlobals);
 		if (oldVarEqualities.isPresent()) {
 			return new BacktranslatedExpression(

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
@@ -63,6 +63,7 @@ import de.uni_freiburg.informatik.ultimate.model.acsl.ast.RealLiteral;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.BigInterval;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
+import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * Translate Boogie expressions to ACSL
@@ -139,7 +140,9 @@ public final class Boogie2ACSL {
 			final var range = getRangeForCType(type);
 			return new BacktranslatedExpression(new ACSLResultExpression(), type, range);
 		} else if (mMapping.hasVar(boogieId, expr.getDeclarationInformation())) {
-			final Pair<String, CType> pair = mMapping.getVar(boogieId, expr.getDeclarationInformation());
+			final Triple<String, CType, Boolean> pair = mMapping.getVar(boogieId, expr.getDeclarationInformation());
+			// TODO Should we do something different if the variable is on-heap?
+
 			if (isPresentInContext(pair.getFirst(), context)) {
 				final var range = getRangeForCType(pair.getSecond());
 				return new BacktranslatedExpression(new IdentifierExpression(pair.getFirst()), pair.getSecond(), range);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
@@ -224,7 +224,13 @@ public final class Boogie2ACSL {
 			return new BacktranslatedExpression(new ACSLResultExpression(), type, range);
 		} else if (mMapping.hasVar(boogieId, expr.getDeclarationInformation())) {
 			final Triple<String, CType, Boolean> pair = mMapping.getVar(boogieId, expr.getDeclarationInformation());
-			// TODO Should we do something different if the variable is on-heap?
+
+			// TODO If the C variable is on-heap, we technically have to backtranslate the Boogie variable to an
+			// address-of expression (the Boogie variable represents the pointer to the C variable), and similarly for
+			// in-vars below.
+			// However, this only becomes critical once we can actually backtranslate expressions with pointers. At the
+			// moment, instead of a pointer variable x we get expressions involving x!base and x!offset, which are
+			// treated as unknown variables anyway.
 
 			if (isPresentInContext(pair.getFirst(), context)) {
 				final var range = getRangeForCType(pair.getSecond());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslatorMapping.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslatorMapping.java
@@ -36,6 +36,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO.AUXVAR;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
+import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * Translates Boogie identifiers of variables and functions back to the identifiers of variables and operators in C.
@@ -47,7 +48,7 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
 
 public class CACSL2BoogieBacktranslatorMapping implements ICACSL2BoogieBacktranslatorMapping {
 	private final Map<Pair<String, DeclarationInformation>, Pair<String, CType>> mInVar2CVar;
-	private final Map<Pair<String, DeclarationInformation>, Pair<String, CType>> mVar2CVar;
+	private final Map<Pair<String, DeclarationInformation>, Triple<String, CType, Boolean>> mVar2CVar;
 	private final Map<String, SFO.AUXVAR> mTempVar2Obj;
 	private final Map<String, CType> mFunctions;
 
@@ -59,9 +60,9 @@ public class CACSL2BoogieBacktranslatorMapping implements ICACSL2BoogieBacktrans
 	}
 
 	@Override
-	public void putVar(final String boogieId, final String cId, final CType cType,
-			final DeclarationInformation decInfo) {
-		mVar2CVar.put(new Pair<>(boogieId, normalize(decInfo)), new Pair<>(cId, cType));
+	public void putVar(final String boogieId, final String cId, final CType cType, final DeclarationInformation decInfo,
+			final boolean isOnHeap) {
+		mVar2CVar.put(new Pair<>(boogieId, normalize(decInfo)), new Triple<>(cId, cType, isOnHeap));
 	}
 
 	@Override
@@ -92,7 +93,7 @@ public class CACSL2BoogieBacktranslatorMapping implements ICACSL2BoogieBacktrans
 		return mVar2CVar.containsKey(new Pair<>(boogieId, normalize(decInfo)));
 	}
 
-	Pair<String, CType> getVar(final String boogieId, final DeclarationInformation decInfo) {
+	Triple<String, CType, Boolean> getVar(final String boogieId, final DeclarationInformation decInfo) {
 		return mVar2CVar.get(new Pair<>(boogieId, normalize(decInfo)));
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/ICACSL2BoogieBacktranslatorMapping.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/ICACSL2BoogieBacktranslatorMapping.java
@@ -38,7 +38,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.S
  */
 public interface ICACSL2BoogieBacktranslatorMapping {
 
-	void putVar(String boogieId, String cId, CType cType, DeclarationInformation decInfo);
+	void putVar(String boogieId, String cId, CType cType, DeclarationInformation decInfo, boolean isOnHeap);
 
 	void putInVar(String boogieId, String cId, CType cType, DeclarationInformation decInfo);
 

--- a/trunk/source/CoreRCP/src/de/uni_freiburg/informatik/ultimate/core/coreplugin/services/BacktranslationService.java
+++ b/trunk/source/CoreRCP/src/de/uni_freiburg/informatik/ultimate/core/coreplugin/services/BacktranslationService.java
@@ -28,6 +28,7 @@ package de.uni_freiburg.informatik.ultimate.core.coreplugin.services;
 
 import java.util.List;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationService;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IStorable;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IToolchainStorage;
@@ -88,6 +89,12 @@ public class BacktranslationService implements IStorable, IBacktranslationServic
 	}
 
 	@Override
+	public <TE, SE, CTX> ProcedureContract<TE, ? extends TE> translateProcedureContract(
+			final ProcedureContract<SE, ? extends SE> contract, final CTX context, final Class<SE> clazz) {
+		return mTranslatorSequence.translateProcedureContract(contract, context, clazz);
+	}
+
+	@Override
 	public <SE> String translateExpressionToString(final SE expression, final Class<SE> clazz) {
 		return mTranslatorSequence.translateExpressionToString(expression, clazz);
 	}
@@ -127,5 +134,4 @@ public class BacktranslationService implements IStorable, IBacktranslationServic
 	public void destroy() {
 		mTranslatorSequence = null;
 	}
-
 }

--- a/trunk/source/CoreRCP/src/de/uni_freiburg/informatik/ultimate/core/coreplugin/services/ModelTranslationContainer.java
+++ b/trunk/source/CoreRCP/src/de/uni_freiburg/informatik/ultimate/core/coreplugin/services/ModelTranslationContainer.java
@@ -31,6 +31,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Stack;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationService;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IBacktranslatedCFG;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
@@ -328,6 +329,24 @@ class ModelTranslationContainer implements IBacktranslationService {
 				(ITranslator<STE, TTE, SE, TE, SVL, TVL, ?>) remaining.pop();
 		final IBacktranslatedCFG<?, TTE> translated = translator.translateCFG(cfg);
 		return translateCFG(remaining, translated);
+	}
+
+	@Override
+	public <TE, SE, CTX> ProcedureContract<TE, ? extends TE> translateProcedureContract(
+			final ProcedureContract<SE, ? extends SE> contract, final CTX context, final Class<SE> clazz) {
+		final Stack<ITranslator<?, ?, ?, ?, ?, ?, ?>> current = prepareTranslatorStackAndCheckSourceExpression(clazz);
+		return translateProcedureContract(current, contract, context);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <TE, SE, CTX> ProcedureContract<TE, ? extends TE> translateProcedureContract(
+			final Stack<ITranslator<?, ?, ?, ?, ?, ?, ?>> remaining, final ProcedureContract<SE, ? extends SE> contract,
+			final CTX context) {
+		if (remaining.isEmpty()) {
+			return (ProcedureContract<TE, ? extends TE>) contract;
+		}
+		final ITranslator<?, ?, SE, TE, ?, ?, CTX> tmp = (ITranslator<?, ?, SE, TE, ?, ?, CTX>) remaining.pop();
+		return translateProcedureContract(remaining, tmp.translateProcedureContract(contract, context), context);
 	}
 
 	@Override

--- a/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
+++ b/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
@@ -133,7 +133,7 @@ public final class FloydHoareUtils {
 	public static void createProcedureContractResults(final IUltimateServiceProvider services, final String pluginName,
 			final IIcfg<IcfgLocation> icfg, final IFloydHoareAnnotation<IcfgLocation> annotation,
 			final IBacktranslationService backTranslatorService,
-			final Consumer<ProcedureContractResult<IIcfgElement>> reporter) {
+			final Consumer<ProcedureContractResult<IIcfgElement, ?>> reporter) {
 		final var checks = getCheckedSpecifications(icfg, annotation);
 		final var csToolkit = icfg.getCfgSmtToolkit();
 		final var logger = services.getLoggingService().getLogger(FloydHoareUtils.class);
@@ -182,8 +182,8 @@ public final class FloydHoareUtils {
 				continue;
 			}
 
-			final var result =
-					new ProcedureContractResult<IIcfgElement>(pluginName, exit, procName, translatedContract, checks);
+			final var result = new ProcedureContractResult<IIcfgElement, Object>(pluginName, exit, procName,
+					translatedContract, checks);
 			reporter.accept(result);
 			new WitnessProcedureContract(translatedContract).annotate(exit);
 		}

--- a/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
+++ b/trunk/source/Library-Proofs/src/de/uni_freiburg/informatik/ultimate/lib/proofs/floydhoare/FloydHoareUtils.java
@@ -41,6 +41,7 @@ import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.WitnessPro
 import de.uni_freiburg.informatik.ultimate.core.lib.results.InvariantResult;
 import de.uni_freiburg.informatik.ultimate.core.lib.results.ProcedureContractResult;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationService;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
@@ -168,14 +169,23 @@ public final class FloydHoareUtils {
 			checkPermissibleVariables(ensuresFormula, permissibleForEnsures(procName, csToolkit),
 					"ensures for " + procName);
 
-			final var result = new ProcedureContractResult<IIcfgElement>(pluginName, exit, backTranslatorService,
-					procName, requiresFormula, ensuresFormula, checks);
-			if (result.isTrivial()) {
+			final var modifies = csToolkit.getModifiableGlobalsTable().getModifiedBoogieVars(procName).stream()
+					.map(IProgramVar::getTermVariable).collect(Collectors.toSet());
+			final var contract = new ProcedureContract<>(procName,
+					requiresFormula == null || SmtUtils.isTrueLiteral(requiresFormula) ? null : requiresFormula,
+					ensuresFormula == null || SmtUtils.isTrueLiteral(ensuresFormula) ? null : ensuresFormula, modifies);
+
+			final ILocation context = ILocation.getAnnotation(exit);
+			final var translatedContract =
+					backTranslatorService.translateProcedureContract(contract, context, Term.class);
+			if (translatedContract.isTrivial()) {
 				continue;
 			}
 
+			final var result =
+					new ProcedureContractResult<IIcfgElement>(pluginName, exit, procName, translatedContract, checks);
 			reporter.accept(result);
-			new WitnessProcedureContract(result.getRequiresResult(), result.getEnsuresResult()).annotate(exit);
+			new WitnessProcedureContract(translatedContract).annotate(exit);
 		}
 	}
 

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/models/annotation/WitnessProcedureContract.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/models/annotation/WitnessProcedureContract.java
@@ -29,6 +29,7 @@ package de.uni_freiburg.informatik.ultimate.core.lib.models.annotation;
 
 import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelUtils;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Visualizable;
 
 /**
@@ -45,22 +46,22 @@ public class WitnessProcedureContract extends ModernAnnotations {
 	private static final String KEY = WitnessProcedureContract.class.getName();
 
 	@Visualizable
-	private final String mRequiresClause;
+	private final ProcedureContract<?, ?> mContract;
 
-	@Visualizable
-	private final String mEnsuresClause;
+	public WitnessProcedureContract(final ProcedureContract<?, ?> contract) {
+		mContract = contract;
+	}
 
-	public WitnessProcedureContract(final String requiresClause, final String ensuresClause) {
-		mRequiresClause = requiresClause;
-		mEnsuresClause = ensuresClause;
+	public ProcedureContract<?, ?> getContract() {
+		return mContract;
 	}
 
 	public String getRequires() {
-		return mRequiresClause;
+		return mContract.getRequires() == null ? null : mContract.getRequires().toString();
 	}
 
 	public String getEnsures() {
-		return mEnsuresClause;
+		return mContract.getEnsures() == null ? null : mContract.getEnsures().toString();
 	}
 
 	public void annotate(final IElement node) {

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/ProcedureContractResult.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/ProcedureContractResult.java
@@ -38,9 +38,9 @@ import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
  *
  * @author Matthias Heizmann
  */
-public class ProcedureContractResult<ELEM extends IElement> extends AbstractResultAtElement<ELEM> {
+public class ProcedureContractResult<ELEM extends IElement, E> extends AbstractResultAtElement<ELEM> {
 
-	private final ProcedureContract<?, ?> mContract;
+	private final ProcedureContract<E, ? extends E> mContract;
 	private final String mProcedureName;
 	private final Set<Check> mChecks;
 
@@ -50,7 +50,7 @@ public class ProcedureContractResult<ELEM extends IElement> extends AbstractResu
 	 * @param location
 	 *            the Location
 	 */
-	public <E> ProcedureContractResult(final String plugin, final ELEM position, final String procedureName,
+	public ProcedureContractResult(final String plugin, final ELEM position, final String procedureName,
 			final ProcedureContract<E, ? extends E> contract, final Set<Check> checks) {
 		super(position, plugin);
 		mProcedureName = procedureName;
@@ -58,12 +58,12 @@ public class ProcedureContractResult<ELEM extends IElement> extends AbstractResu
 		mChecks = checks;
 	}
 
-	public String getEnsures() {
-		return mContract.getEnsures() == null ? null : mContract.getEnsures().toString();
+	public E getEnsures() {
+		return mContract.getEnsures();
 	}
 
-	public String getRequires() {
-		return mContract.getRequires() == null ? null : mContract.getRequires().toString();
+	public E getRequires() {
+		return mContract.getRequires();
 	}
 
 	@Override

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/ProcedureContractResult.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/results/ProcedureContractResult.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Check;
 import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
-import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationService;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 
 /**
  * Report a procedure contract that holds at ELEM which is a node in an Ultimate model.
@@ -40,8 +40,7 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationS
  */
 public class ProcedureContractResult<ELEM extends IElement> extends AbstractResultAtElement<ELEM> {
 
-	private final String mEnsures;
-	private final String mRequires;
+	private final ProcedureContract<?, ?> mContract;
 	private final String mProcedureName;
 	private final Set<Check> mChecks;
 
@@ -51,35 +50,20 @@ public class ProcedureContractResult<ELEM extends IElement> extends AbstractResu
 	 * @param location
 	 *            the Location
 	 */
-	public <E> ProcedureContractResult(final String plugin, final ELEM position,
-			final IBacktranslationService translatorSequence, final String procedureName, final E requires,
-			final E ensures, final Set<Check> checks) {
+	public <E> ProcedureContractResult(final String plugin, final ELEM position, final String procedureName,
+			final ProcedureContract<E, ? extends E> contract, final Set<Check> checks) {
 		super(position, plugin);
 		mProcedureName = procedureName;
-		mRequires = translateTerm(translatorSequence, requires);
-		mEnsures = translateTerm(translatorSequence, ensures);
+		mContract = contract;
 		mChecks = checks;
 	}
 
-	@SuppressWarnings("unchecked")
-	private <E> String translateTerm(final IBacktranslationService translatorSequence, final E term) {
-		if (term == null) {
-			return null;
-		}
-		final String result = translatorSequence.translateExpressionWithContextToString(term, getLocation(),
-				(Class<E>) term.getClass());
-		if ("1".equals(result)) {
-			return null;
-		}
-		return result;
+	public String getEnsures() {
+		return mContract.getEnsures() == null ? null : mContract.getEnsures().toString();
 	}
 
-	public String getEnsuresResult() {
-		return mEnsures;
-	}
-
-	public String getRequiresResult() {
-		return mRequires;
+	public String getRequires() {
+		return mContract.getRequires() == null ? null : mContract.getRequires().toString();
 	}
 
 	@Override
@@ -93,19 +77,17 @@ public class ProcedureContractResult<ELEM extends IElement> extends AbstractResu
 		sb.append("Derived contract for procedure ");
 		sb.append(mProcedureName);
 		sb.append(".");
-		if (mRequires != null) {
+		final var requires = getRequires();
+		if (requires != null) {
 			sb.append(" Requires: ");
-			sb.append(mRequires);
+			sb.append(requires);
 		}
-		if (mEnsures != null) {
+		final var ensures = getEnsures();
+		if (ensures != null) {
 			sb.append(" Ensures: ");
-			sb.append(mEnsures);
+			sb.append(ensures);
 		}
 		return sb.toString();
-	}
-
-	public boolean isTrivial() {
-		return mRequires == null && mEnsures == null;
 	}
 
 	/**

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/translation/TranslatorConcatenation.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/translation/TranslatorConcatenation.java
@@ -29,6 +29,7 @@ package de.uni_freiburg.informatik.ultimate.core.lib.translation;
 
 import java.util.List;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IBacktranslatedCFG;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution.ProgramState;
@@ -126,6 +127,13 @@ public class TranslatorConcatenation<STE, ITE, TTE, SE, IE, TE, SVL, IVL, TVL, L
 	}
 
 	@Override
+	public ProcedureContract<TE, ? extends TE>
+			translateProcedureContract(final ProcedureContract<SE, ? extends SE> contract, final LOC context) {
+		return mIntermediate2TargetTranslator.translateProcedureContract(
+				mSource2IntermediateTranslator.translateProcedureContract(contract, context), context);
+	}
+
+	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
 		sb.append(getClass().getSimpleName());
@@ -145,5 +153,4 @@ public class TranslatorConcatenation<STE, ITE, TTE, SE, IE, TE, SVL, IVL, TVL, L
 		return mIntermediate2TargetTranslator
 				.translateProgramState(mSource2IntermediateTranslator.translateProgramState(oldProgramState));
 	}
-
 }

--- a/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/models/ProcedureContract.java
+++ b/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/models/ProcedureContract.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Copyright (C) 2024 University of Freiburg
+ *
+ * This file is part of the ULTIMATE Core.
+ *
+ * The ULTIMATE Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE Core. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE Core, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE Core grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.core.model.models;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Visualizable;
+
+/**
+ * A contract specifying the behaviour of a procedure (in Boogie or the ICFG) or function (in C).
+ *
+ * The behaviour is specified using up to three kinds of clauses:
+ * <ol>
+ * <li>A "requires" clause specifies a precondition that must hold before a call.
+ * <li>An "ensures" clause specifies a relation guaranteed to hold between the state before the call and the state at
+ * the procedure exit.
+ * <li>Optionally, a "modifies" clause specifies a subset of global variables that the procedure may write to. Writes to
+ * any other global state is forbidden.
+ * </ol>
+ *
+ * @author Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ *
+ * @param <E>
+ *            The type of expressions
+ * @param <V>
+ *            The type of variables
+ */
+public class ProcedureContract<E, V> {
+	@Visualizable
+	private final String mProcedure;
+
+	@Visualizable
+	private final E mRequires;
+
+	@Visualizable
+	private final E mEnsures;
+
+	@Visualizable
+	private final Set<V> mModifies;
+
+	public ProcedureContract(final String procedure, final E requires, final E ensures) {
+		mProcedure = procedure;
+		mRequires = requires;
+		mEnsures = ensures;
+		mModifies = null;
+	}
+
+	public ProcedureContract(final String procedure, final E requires, final E ensures, final Set<V> modifies) {
+		mProcedure = procedure;
+		mRequires = requires;
+		mEnsures = ensures;
+		mModifies = Objects.requireNonNull(modifies);
+	}
+
+	public boolean hasModifies() {
+		return mModifies != null;
+	}
+
+	public String getProcedure() {
+		return mProcedure;
+	}
+
+	public E getRequires() {
+		return mRequires;
+	}
+
+	public E getEnsures() {
+		return mEnsures;
+	}
+
+	public Set<V> getModifies() {
+		return Collections.unmodifiableSet(mModifies);
+	}
+
+	public boolean isTrivial() {
+		return mRequires == null && mEnsures == null && !hasModifies();
+	}
+}

--- a/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/services/IBacktranslationService.java
+++ b/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/services/IBacktranslationService.java
@@ -28,6 +28,7 @@ package de.uni_freiburg.informatik.ultimate.core.model.services;
 
 import java.util.List;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IBacktranslatedCFG;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution.ProgramState;
@@ -73,6 +74,9 @@ public interface IBacktranslationService {
 	<SE> String translateProgramStateToString(ProgramState<SE> programState);
 
 	<STE, SE> IBacktranslatedCFG<?, ?> translateCFG(IBacktranslatedCFG<?, STE> cfg);
+
+	<TE, SE, CTX> ProcedureContract<TE, ? extends TE>
+			translateProcedureContract(ProcedureContract<SE, ? extends SE> contract, CTX context, Class<SE> clazz);
 
 	/**
 	 * Use this if you want to keep a certain state of the backtranslation chain during toolchain execution.

--- a/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/translation/ITranslator.java
+++ b/trunk/source/Library-UltimateModel/src/de/uni_freiburg/informatik/ultimate/core/model/translation/ITranslator.java
@@ -29,6 +29,7 @@ package de.uni_freiburg.informatik.ultimate.core.model.translation;
 
 import java.util.List;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution.ProgramState;
 
 /**
@@ -84,6 +85,9 @@ public interface ITranslator<STE, TTE, SE, TE, SVL, TVL, CTX> {
 	IProgramExecution<TTE, TE> translateProgramExecution(IProgramExecution<STE, SE> programExecution);
 
 	IBacktranslatedCFG<TVL, TTE> translateCFG(IBacktranslatedCFG<SVL, STE> cfg);
+
+	ProcedureContract<TE, ? extends TE> translateProcedureContract(ProcedureContract<SE, ? extends SE> contract,
+			CTX context);
 
 	Class<? extends STE> getSourceTraceElementClass();
 

--- a/trunk/source/Library-UltimateTest/src/de/uni_freiburg/informatik/ultimate/test/mocks/BacktranslationServiceMock.java
+++ b/trunk/source/Library-UltimateTest/src/de/uni_freiburg/informatik/ultimate/test/mocks/BacktranslationServiceMock.java
@@ -30,6 +30,7 @@ package de.uni_freiburg.informatik.ultimate.test.mocks;
 import java.util.Collections;
 import java.util.List;
 
+import de.uni_freiburg.informatik.ultimate.core.model.models.ProcedureContract;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IBacktranslationService;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IBacktranslatedCFG;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
@@ -93,6 +94,12 @@ final class BacktranslationServiceMock implements IBacktranslationService {
 
 	@Override
 	public <STE, SE> IBacktranslatedCFG<?, ?> translateCFG(final IBacktranslatedCFG<?, STE> cfg) {
+		return null;
+	}
+
+	@Override
+	public <TE, SE, CTX> ProcedureContract<TE, ? extends TE> translateProcedureContract(
+			final ProcedureContract<SE, ? extends SE> contract, final CTX context, final Class<SE> clazz) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR changes the backtranslation of procedure contracts.
- When backtranslating contracts from Boogie (which has `modifies` clauses to encode frame conditions) to C/ACSL (where our contracts currently do not have `modifies` or other features for frame conditions), we add conjuncts of the form `x == \old(x)` for variables that are not modifiable by the procedure.
- To support this, we add a specialized method for contract backtranslation to the `ITranslator` interface.