### PR TITLE
Support atomic types

### DIFF
--- a/trunk/examples/concurrent/pthreads/races/atomic_type_pointer.c
+++ b/trunk/examples/concurrent/pthreads/races/atomic_type_pointer.c
@@ -1,0 +1,31 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-18
+ *
+ * This is an example where the pointer itself is atomic, not the underlying type
+ * (see https://stackoverflow.com/questions/42082219/declaring-atomic-pointers-vs-pointers-to-atomics)
+ *
+ * We currently are not able to deal with atomic pointers,
+ * we cannot even parse the atomic keyword properly at this location.
+ */
+
+typedef unsigned long pthread_t;
+
+int * _Atomic x;
+int * _Atomic y;
+
+void* thread1() {
+  x = y; // No race: the pointer itself is atomic, not the underlying type
+}
+
+void* thread2() {
+  y = x; // No race: the pointer itself is atomic, not the underlying type
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_array.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_array.c
@@ -1,0 +1,24 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-18
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int x[10];
+
+void* thread1() {
+  int local = x[7];
+}
+
+void* thread2() {
+  x[7] = 42;
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe.c
@@ -1,0 +1,27 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-18
+ */
+
+typedef unsigned long pthread_t;
+
+// This defines an atomic pointer
+// See https://stackoverflow.com/questions/42082219/declaring-atomic-pointers-vs-pointers-to-atomics
+int * _Atomic x;
+int * _Atomic y;
+
+void* thread1() {
+  *x = *y; // Race: The dereference is not atomic
+}
+
+void* thread2() {
+  *y = *x; // Race: The dereference is not atomic
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe2.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe2.c
@@ -1,0 +1,25 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-18
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int* x;
+_Atomic int* y;
+
+void* thread1() {
+  x = y; // Race: The pointer itself is not atomic
+}
+
+void* thread2() {
+  y = x; // Race: The pointer itself is not atomic
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe3.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_pointer_unsafe3.c
@@ -1,0 +1,26 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-24
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int* x;
+
+void* thread1() {
+  (*(x++))++; // Race: The pointer x itself is not atomic and its increment is not executed atomically either
+}
+
+void* thread2() {
+  _Atomic int* y = __atomic_load_n(&x, 5); // Race
+}
+
+int main() {
+  pthread_t t1, t2;
+  x = malloc(sizeof(_Atomic int));
+  *x = 7;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_unsafe.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_unsafe.c
@@ -1,0 +1,25 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-24
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int x;
+int* y;
+
+void* thread1() {
+  x += (*y)++; // Race: y is not atomic and its increment is not executed atomically either
+}
+
+void* thread2() {
+  __atomic_store_n(y, 5, 5); // Race
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_type_unsafe2.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_type_unsafe2.c
@@ -1,0 +1,25 @@
+//#Unsafe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-30
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int x;
+int y;
+
+void* thread1() {
+  x = (y += 3); // Race: y is not atomic and its increment is not executed atomically either
+}
+
+void* thread2() {
+  __atomic_store_n(&y, 5, 5); // Race
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_types.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_types.c
@@ -1,0 +1,27 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-16
+ */
+
+typedef unsigned long pthread_t;
+
+_Atomic int x;
+_Atomic int* p;
+
+void* thread1() {
+  *p = x;
+}
+
+void* thread2() {
+  x = *p;
+}
+
+int main() {
+  p = malloc(sizeof(int));
+  *p = 0;
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/regression/atomicInc.c
+++ b/trunk/examples/concurrent/pthreads/regression/atomicInc.c
@@ -1,0 +1,23 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-16
+ */
+
+_Atomic int x;
+
+void* thread(void* arg) {
+  ++x;
+}
+
+int main() {
+  pthread_t t1, t2, t3;
+  pthread_create(&t1, NULL, thread, NULL);
+  pthread_create(&t2, NULL, thread, NULL);
+  pthread_create(&t3, NULL, thread, NULL);
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
+  pthread_join(t3, NULL);
+  //@ assert x == 3;
+}

--- a/trunk/examples/concurrent/pthreads/regression/atomicIncPointer.c
+++ b/trunk/examples/concurrent/pthreads/regression/atomicIncPointer.c
@@ -1,0 +1,27 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-16
+ */
+
+typedef _Atomic int atomic_int;
+
+atomic_int *x;
+
+void* thread(void* arg) {
+  (*x)++;
+}
+
+int main() {
+  x = malloc(sizeof(int));
+  *x = 0;
+  pthread_t t1, t2, t3;
+  pthread_create(&t1, NULL, thread, NULL);
+  pthread_create(&t2, NULL, thread, NULL);
+  pthread_create(&t3, NULL, thread, NULL);
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
+  pthread_join(t3, NULL);
+  //@ assert *x == 3;
+}

--- a/trunk/examples/concurrent/pthreads/regression/atomicIncPointer2.c
+++ b/trunk/examples/concurrent/pthreads/regression/atomicIncPointer2.c
@@ -1,0 +1,27 @@
+//#Safe
+
+/*
+ * Author: Frank Schüssele (schuessf@informatik.uni-freiburg.de)
+ * Date: 2024-10-24
+ */
+
+typedef _Atomic int atomic_int;
+
+atomic_int *x;
+
+void* thread(void* arg) {
+  *x += 2;
+}
+
+int main() {
+  x = malloc(sizeof(int));
+  *x = 0;
+  pthread_t t1, t2, t3;
+  pthread_create(&t1, NULL, thread, NULL);
+  pthread_create(&t2, NULL, thread, NULL);
+  pthread_create(&t3, NULL, thread, NULL);
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
+  pthread_join(t3, NULL);
+  //@ assert *x == 6;
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -130,6 +130,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.annotation.LTLPropertyCheck;
 import de.uni_freiburg.informatik.ultimate.boogie.annotation.LTLPropertyCheck.CheckableExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Attribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Axiom;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
@@ -835,7 +836,11 @@ public class CHandler {
 			final ExpressionResult rr = mExprResultTransformer.transformSwitchRexBoolToInt(rightOperand, loc, node);
 			final ExpressionResult result =
 					mCExpressionTranslator.handleMultiplicativeOperation(loc, node.getOperator(), rl, rr);
-			return makeAssignment(loc, leftOperand.getLrValue(), Collections.emptyList(), result, node);
+			// Make sure that the evaluation of the operands is not inside an atomic block, but the read of the left
+			// operand (i.e., the potential of a heap variable) is.
+			final List<Statement> statementsBeforeRead =
+					DataStructureUtils.concat(leftOperand.getStatements(), rr.getStatements());
+			return handleAtomicReadWrite(loc, leftOperand.getLrValue(), statementsBeforeRead, result, node);
 		}
 		case IASTBinaryExpression.op_plus:
 		case IASTBinaryExpression.op_minus: {
@@ -859,7 +864,11 @@ public class CHandler {
 					mExprResultTransformer.transformDecaySwitchRexBoolToInt(rightOperand, loc, node);
 			final ExpressionResult result =
 					mCExpressionTranslator.handleAdditiveOperation(loc, node.getOperator(), rl, rr);
-			return makeAssignment(loc, leftOperand.getLrValue(), Collections.emptyList(), result, node);
+			// Make sure that the evaluation of the operands is not inside an atomic block, but the read of the left
+			// operand (i.e., the potential of a heap variable) is.
+			final List<Statement> statementsBeforeRead =
+					DataStructureUtils.concat(leftOperand.getStatements(), rr.getStatements());
+			return handleAtomicReadWrite(loc, leftOperand.getLrValue(), statementsBeforeRead, result, node);
 		}
 		case IASTBinaryExpression.op_binaryAnd:
 		case IASTBinaryExpression.op_binaryOr:
@@ -875,7 +884,11 @@ public class CHandler {
 			final ExpressionResult rr = mExprResultTransformer.transformSwitchRexBoolToInt(rightOperand, loc, node);
 			final ExpressionResult result =
 					mCExpressionTranslator.handleBitwiseArithmeticOperation(loc, node.getOperator(), rl, rr);
-			return makeAssignment(loc, leftOperand.getLrValue(), Collections.emptyList(), result, node);
+			// Make sure that the evaluation of the operands is not inside an atomic block, but the read of the left
+			// operand (i.e., the potential of a heap variable) is.
+			final List<Statement> statementsBeforeRead =
+					DataStructureUtils.concat(leftOperand.getStatements(), rr.getStatements());
+			return handleAtomicReadWrite(loc, leftOperand.getLrValue(), statementsBeforeRead, result, node);
 		}
 		case IASTBinaryExpression.op_shiftLeft:
 		case IASTBinaryExpression.op_shiftRight: {
@@ -890,7 +903,11 @@ public class CHandler {
 			final ExpressionResult rr = mExprResultTransformer.transformSwitchRexBoolToInt(rightOperand, loc, node);
 			final ExpressionResult result =
 					mCExpressionTranslator.handleBitshiftOperation(loc, node.getOperator(), rl, rr);
-			return makeAssignment(loc, leftOperand.getLrValue(), Collections.emptyList(), result, node);
+			// Make sure that the evaluation of the operands is not inside an atomic block, but the read of the left
+			// operand (i.e., the potential of a heap variable) is.
+			final List<Statement> statementsBeforeRead =
+					DataStructureUtils.concat(leftOperand.getStatements(), rr.getStatements());
+			return handleAtomicReadWrite(loc, leftOperand.getLrValue(), statementsBeforeRead, result, node);
 		}
 		default:
 			final String msg = "Unknown or unsupported unary operation";
@@ -2549,12 +2566,12 @@ public class CHandler {
 		case IASTUnaryExpression.op_postFixIncr:
 		case IASTUnaryExpression.op_postFixDecr: {
 			return mCExpressionTranslator.handlePostfixIncrementAndDecrement(loc, node.getOperator(), operand, node,
-					a -> makeAssignment(loc, operand.getLrValue(), Collections.emptyList(), a, node));
+					a -> handleAtomicReadWrite(loc, operand.getLrValue(), operand.getStatements(), a, node));
 		}
 		case IASTUnaryExpression.op_prefixDecr:
 		case IASTUnaryExpression.op_prefixIncr: {
 			return mCExpressionTranslator.handlePrefixIncrementAndDecrement(node.getOperator(), loc, operand, node,
-					a -> makeAssignment(loc, operand.getLrValue(), Collections.emptyList(), a, node));
+					a -> handleAtomicReadWrite(loc, operand.getLrValue(), operand.getStatements(), a, node));
 		}
 		case IASTUnaryExpression.op_bracketedPrimary:
 			return operand;
@@ -2713,6 +2730,28 @@ public class CHandler {
 		}
 	}
 
+	private ExpressionResult handleAtomicReadWrite(final ILocation loc, final LRValue leftHandSide,
+			final List<Statement> statementsBeforeRead, final ExpressionResult rhs, final IASTNode hook) {
+		final ExpressionResult assignment = makeAssignment(loc, leftHandSide, Set.of(), rhs, hook);
+		if (!leftHandSide.getCType().isAtomic()) {
+			// For non-atomic types return the normal assignment
+			return assignment;
+		}
+		final List<Statement> allStatements = assignment.getStatements();
+
+		// Check if statementsBeforeRead are a prefix of allStatements
+		if (!statementsBeforeRead.equals(allStatements.subList(0, statementsBeforeRead.size()))) {
+			throw new AssertionError(
+					"Unexpected result of makeAssignment: statements do not start with statements of rhs");
+		}
+		// For atomic types make sure that all statement except the ones before the read are in an atomic block
+		final List<Statement> atomicStatements =
+				allStatements.subList(statementsBeforeRead.size(), allStatements.size());
+		return new ExpressionResultBuilder().addStatements(statementsBeforeRead)
+				.addAllExceptLrValueAndStatements(assignment).setLrValue(assignment.getLrValue())
+				.addStatement(StatementFactory.constructAtomicStatement(loc, atomicStatements)).build();
+	}
+
 	/**
 	 *
 	 * @param loc
@@ -2800,6 +2839,7 @@ public class CHandler {
 				builder.addStatement(assignment);
 				resultRhs = auxVar.getExp();
 			}
+			// MemoryHandler::getWriteCall already handles atomic types properly, so there is nothing to do here.
 			builder.addStatements(mMemoryHandler.getWriteCall(loc, hlv, resultRhs,
 					rightHandSideValueWithConversionsApplied.getCType(), false));
 
@@ -2840,7 +2880,12 @@ public class CHandler {
 		final AssignmentStatement assignStmt = StatementFactory.constructAssignmentStatement(loc,
 				new LeftHandSide[] { lValue.getLhs() }, new Expression[] { rhsWithBitfieldTreatment });
 
-		builder.addStatement(assignStmt);
+		if (leftHandSide.getCType().isAtomic()) {
+			// For atomic types, make this assignment into an atomic block
+			builder.addStatement(new AtomicStatement(loc, new Statement[] { assignStmt }));
+		} else {
+			builder.addStatement(assignStmt);
+		}
 
 		for (final Overapprox oa : rhsConverted.getOverapprs()) {
 			new OverapproxVariable(oa.getOverapproximatedLocations()).annotate(assignStmt);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -2175,8 +2175,7 @@ public class CHandler {
 			return new SkipResult();
 		}
 		// TODO: This is just a workaround for now to crash when thread local variables are used in a concurrent program
-		if (Arrays.stream(node.getDeclSpecifier().getAttributes()).map(x -> String.valueOf(x.getName()))
-				.anyMatch("thread"::equals)) {
+		if (CTranslationUtil.hasAttribute(node.getDeclSpecifier(), "thread")) {
 			mHasThreadLocalVars = true;
 			// Only crash for thread local variable in concurrent programs
 			if (mIsConcurrent) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
@@ -28,12 +28,14 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.cdt.core.dom.ast.IASTCompoundStatement;
+import org.eclipse.cdt.core.dom.ast.IASTDeclSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTStatement;
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTCompoundStatementExpression;
@@ -529,5 +531,14 @@ public class CTranslationUtil {
 		}
 
 		return hook;
+	}
+
+	/**
+	 * Returns true iff the given {@code declSpec} has an attribute with the given {@code name}, i.e., is preceded by
+	 * {@code __attribute__((name))}.
+	 */
+	public static boolean hasAttribute(final IASTDeclSpecifier declSpec, final String attributeName) {
+		return Arrays.stream(declSpec.getAttributes()).map(x -> String.valueOf(x.getName()))
+				.anyMatch(attributeName::equals);
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/DataRaceChecker.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/DataRaceChecker.java
@@ -260,6 +260,10 @@ public final class DataRaceChecker {
 	}
 
 	private static boolean isRaceImpossible(final LRValue lrVal) {
+		if (lrVal.getCType().isAtomic()) {
+			// Atomic types cannot lead to data races
+			return true;
+		}
 		if (lrVal instanceof HeapLValue) {
 			final Expression address = ((HeapLValue) lrVal).getAddress();
 			return address instanceof IdentifierExpression

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -781,7 +781,11 @@ public class MemoryHandler {
 		final CallStatement call = StatementFactory.constructCallStatement(loc, false, lhss,
 				determineReadProcedure(resultType, unchecked, loc),
 				new Expression[] { address, calculateSizeOf(loc, resultType) });
-		resultBuilder.addStatement(call);
+		if (resultType.isAtomic()) {
+			resultBuilder.addStatement(new AtomicStatement(loc, new Statement[] { call }));
+		} else {
+			resultBuilder.addStatement(call);
+		}
 		assert CTranslationUtil.isAuxVarMapComplete(mNameHandler, resultBuilder);
 		// TODO Frank 2022-12-16: We should add an in-range assumption here, but this could be problematic if we cast
 		// e.g. unsigned to signed pointers and read from them
@@ -856,7 +860,11 @@ public class MemoryHandler {
 
 		final HeapWriteMode writeMode =
 				isStaticInitialization ? HeapWriteMode.STORE_UNCHECKED : HeapWriteMode.STORE_CHECKED;
-		return getWriteCall(loc, hlv, value, realValueType, writeMode);
+		final List<Statement> result = getWriteCall(loc, hlv, value, realValueType, writeMode);
+		if (valueType.isAtomic()) {
+			return List.of(StatementFactory.constructAtomicStatement(loc, result));
+		}
+		return result;
 	}
 
 	private List<Statement> getWriteCall(final ILocation loc, final HeapLValue hlv, final Expression value,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -58,7 +58,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BooleanLiteral;
@@ -1553,7 +1552,7 @@ public class StandardFunctionHandler {
 		final ExpressionResultBuilder builder = new ExpressionResultBuilder(body);
 		builder.resetStatements(List.of());
 
-		final Statement atomic = new AtomicStatement(loc, body.getStatements().toArray(Statement[]::new));
+		final Statement atomic = StatementFactory.constructAtomicStatement(loc, body.getStatements());
 
 		// create condition checking whether all memory orders are supported
 		final CPrimitive intType = new CPrimitive(CPrimitives.INT);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -72,7 +72,7 @@ public class CArray extends CType {
 	 */
 	public CArray(final RValue bound, final CType valueType) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 		mBound = bound;
 		mValueType = valueType;
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CEnum.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CEnum.java
@@ -64,7 +64,7 @@ public class CEnum extends CType implements ICPossibleIncompleteType<CEnum> {
 	 */
 	public CEnum(final String id, final String[] fNames) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 
 		assert id != null;
 		mIdentifier = id;
@@ -74,7 +74,7 @@ public class CEnum extends CType implements ICPossibleIncompleteType<CEnum> {
 
 	public CEnum(final String id) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 
 		mIdentifier = id;
 		mIsComplete = false;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CFunction.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CFunction.java
@@ -60,7 +60,7 @@ public class CFunction extends CType {
 	private CFunction(final boolean isConst, final boolean isInline, final boolean isRestrict, final boolean isVolatile,
 			final boolean isExtern, final CType resultType, final CDeclaration[] paramTypes, final boolean takesVarArgs,
 			final VarArgsUsage varArgsUsage) {
-		super(isConst, isInline, isRestrict, isVolatile, isExtern);
+		super(isConst, isInline, isRestrict, isVolatile, isExtern, false);
 		mResultType = resultType;
 		mParamTypes = paramTypes;
 		mTakesVarArgs = takesVarArgs;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CNamed.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CNamed.java
@@ -57,7 +57,7 @@ public class CNamed extends CType {
 	 */
 	public CNamed(final String name, final CType mappedType) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, mappedType.isAtomic());
 		mName = name;
 		mMappedType = mappedType;
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CPointer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CPointer.java
@@ -51,7 +51,7 @@ public class CPointer extends CType {
 	 */
 	public CPointer(final CType pointsToType) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 		mPointsToType = pointsToType;
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CPrimitive.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CPrimitive.java
@@ -33,6 +33,8 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.conta
 import org.eclipse.cdt.core.dom.ast.IASTDeclSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTSimpleDeclSpecifier;
 
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.CTranslationUtil;
+
 /**
  * @author Markus Lindenmann
  * @date 13.07.2012
@@ -147,7 +149,7 @@ public class CPrimitive extends CType {
 
 	public CPrimitive(final CPrimitives type) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 		mType = type;
 		mGeneralType = getGeneralType(type);
 	}
@@ -160,7 +162,7 @@ public class CPrimitive extends CType {
 	 */
 	public CPrimitive(final IASTDeclSpecifier cDeclSpec) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, CTranslationUtil.hasAttribute(cDeclSpec, "atomic"));
 		if (!(cDeclSpec instanceof IASTSimpleDeclSpecifier)) {
 			throw new IllegalArgumentException("Unknown C Declaration!");
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CStructOrUnion.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CStructOrUnion.java
@@ -82,7 +82,7 @@ public class CStructOrUnion extends CType implements ICPossibleIncompleteType<CS
 	public CStructOrUnion(final StructOrUnion isStructOrUnion, final String name, final String[] fNames,
 			final CType[] fTypes, final List<Integer> bitFieldWidths) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 		assert name != null;
 		assert fNames.length == bitFieldWidths.size();
 		mIsStructOrUnion = isStructOrUnion;
@@ -95,7 +95,7 @@ public class CStructOrUnion extends CType implements ICPossibleIncompleteType<CS
 
 	public CStructOrUnion(final StructOrUnion isStructOrUnion, final String name) {
 		// FIXME: integrate those flags -- you will also need to change the equals method if you do
-		super(false, false, false, false, false);
+		super(false, false, false, false, false, false);
 		assert name != null && !name.isEmpty();
 		mIsStructOrUnion = isStructOrUnion;
 		mFieldNames = new String[0];

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CType.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CType.java
@@ -48,6 +48,7 @@ public abstract class CType {
 	private final boolean mIsVolatile;
 
 	private final boolean mIsExtern;
+	private final boolean mIsAtomic;
 
 	/**
 	 * Constructor.
@@ -55,12 +56,13 @@ public abstract class CType {
 	 * @param isExtern
 	 */
 	public CType(final boolean isConst, final boolean isInline, final boolean isRestrict, final boolean isVolatile,
-			final boolean isExtern) {
+			final boolean isExtern, final boolean isAtomic) {
 		mIsConst = isConst;
 		mIsInline = isInline;
 		mIsRestrict = isRestrict;
 		mIsVolatile = isVolatile;
 		mIsExtern = isExtern;
+		mIsAtomic = isAtomic;
 	}
 
 	public boolean isConst() {
@@ -81,6 +83,10 @@ public abstract class CType {
 
 	public boolean isExtern() {
 		return mIsExtern;
+	}
+
+	public boolean isAtomic() {
+		return mIsAtomic;
 	}
 
 	public abstract boolean isIncomplete();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/witness/ExtractedGhostUpdate.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/witness/ExtractedGhostUpdate.java
@@ -30,6 +30,7 @@ package de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietransl
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.cdt.core.dom.ast.IASTExpression;
 import org.eclipse.cdt.core.dom.ast.IASTExpressionStatement;
@@ -39,6 +40,7 @@ import org.eclipse.cdt.core.dom.ast.IASTNode;
 
 import de.uni_freiburg.informatik.ultimate.acsl.parser.ACSLSyntaxErrorException;
 import de.uni_freiburg.informatik.ultimate.acsl.parser.Parser;
+import de.uni_freiburg.informatik.ultimate.boogie.StatementFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ForkStatement;
@@ -50,7 +52,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultBuilder;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.DataStructureUtils;
 
 /**
  * Witness entry for the update of ghost variables
@@ -127,8 +128,8 @@ public class ExtractedGhostUpdate implements IExtractedWitnessEntry {
 			if (Arrays.stream(atomicBody).anyMatch(
 					x -> x instanceof CallStatement && ((CallStatement) x).getMethodName().equals(functionName))) {
 				isAnnotated = true;
-				result.add(new AtomicStatement(loc,
-						DataStructureUtils.concat(ghostUpdate.toArray(Statement[]::new), atomicBody)));
+				result.add(StatementFactory.constructAtomicStatement(loc,
+						Stream.concat(ghostUpdate.stream(), Arrays.stream(atomicBody))));
 			} else {
 				result.add(st);
 			}
@@ -146,7 +147,7 @@ public class ExtractedGhostUpdate implements IExtractedWitnessEntry {
 		for (final Statement st : programStatements) {
 			if (!isAnnotated && st instanceof ForkStatement) {
 				isAnnotated = true;
-				result.add(new AtomicStatement(loc, ghostUpdate.toArray(Statement[]::new)));
+				result.add(StatementFactory.constructAtomicStatement(loc, ghostUpdate));
 			}
 			result.add(st);
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/witness/ExtractedLocationInvariant.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/witness/ExtractedLocationInvariant.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 
-import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.StatementFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Label;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.IDispatcher;
@@ -66,8 +66,7 @@ public class ExtractedLocationInvariant extends ExtractedWitnessInvariant {
 				new ExpressionResultBuilder(expressionResult).addAllExceptLrValueAndStatements(invariantExprResult);
 
 		// Make sure that the location invariant (incl. all auxiliary statements) is executed atomically.
-		final Statement invariant =
-				new AtomicStatement(loc, invariantExprResult.getStatements().toArray(Statement[]::new));
+		final Statement invariant = StatementFactory.constructAtomicStatement(loc, invariantExprResult.getStatements());
 
 		// Insert the location invariant at the appropriate location.
 		if (mIsBefore) {

--- a/trunk/source/CDTParser/src/de/uni_freiburg/informatik/ultimate/cdt/parser/GccStaticLanguageSettingsProvider.java
+++ b/trunk/source/CDTParser/src/de/uni_freiburg/informatik/ultimate/cdt/parser/GccStaticLanguageSettingsProvider.java
@@ -263,7 +263,8 @@ public class GccStaticLanguageSettingsProvider implements ILanguageSettingsProvi
 				createEntry("_thiscall", "__attribute__((__thiscall__))"),
 				createEntry("__builtin_va_arg(ap,type)", "*((typeof(type) *)((ap += sizeof(type)) - sizeof(type)))"),
 				createEntry("__thread", "__attribute__((thread))"),
-				createEntry("thread_local", "__attribute__((thread))") };
+				createEntry("thread_local", "__attribute__((thread))"),
+				createEntry("_Atomic", "__attribute__((atomic))") };
 
 		mSettings = LanguageSettingsStorage.getPooledList(Arrays.asList(entries));
 

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/StatementFactory.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/StatementFactory.java
@@ -26,9 +26,12 @@
  */
 package de.uni_freiburg.informatik.ultimate.boogie;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IfStatement;
@@ -92,5 +95,22 @@ public class StatementFactory {
 	public static Statement constructIfStatement(final ILocation loc, final Expression condition,
 			final List<Statement> thenPart) {
 		return constructIfStatement(loc, condition, thenPart.toArray(Statement[]::new), new Statement[0]);
+	}
+
+	public static AtomicStatement constructAtomicStatement(final ILocation loc, final List<Statement> statements) {
+		return constructAtomicStatement(loc, statements.stream());
+	}
+
+	public static AtomicStatement constructAtomicStatement(final ILocation loc, final Stream<Statement> statements) {
+		return new AtomicStatement(loc,
+				statements.flatMap(StatementFactory::getFlattenedStatements).toArray(Statement[]::new));
+	}
+
+	private static Stream<Statement> getFlattenedStatements(final Statement statement) {
+		if (statement instanceof AtomicStatement) {
+			return Arrays.stream(((AtomicStatement) statement).getBody())
+					.flatMap(StatementFactory::getFlattenedStatements);
+		}
+		return Stream.of(statement);
 	}
 }


### PR DESCRIPTION
This PR adds support for [atomic types](https://en.cppreference.com/w/c/language/atomic) (`_Atomic`). To do so, I performed the following steps:
* First the keyword is replaced by some artificial GCC attribute (`__attribute__((atomic))`) for our parser not to crash.
* Whether we have an atomic type is then stored in the `CType`. This flag is only set explicitly in `CPrimitive` (based on the GCC attribute) and a `CNamed` is atomic iff the underlying type is atomic. All other types are currently not atomic. There can be actually an atomic pointer (see [here](https://stackoverflow.com/questions/42082219/declaring-atomic-pointers-vs-pointers-to-atomics)), but we cannot parse the attribute properly at this location and thus don't support atomic pointers.
* We don't check for data-races on atomic types (see `DataRaceChecker`).
* We have to ensure that all operations on atomic variables are actually performed atomically. Therefore the translation of reads (see `MemoryHandler::getReadCall`), writes (see `MemoryHandler::getWriteCall` and `CHandler::makeAssignment`) and combined read-writes (e.g. `++`, `--`, `*=`, ...) (see `CHandler::makeAtomicAssignmentIfNecessary`) was adapted.