### PR TITLE
Support `__atomic_compare_exchange`

### DIFF
--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_mustfail.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_mustfail.c
@@ -1,0 +1,43 @@
+//#Safe
+
+/*
+ * Author: Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Date: 2024-10-22
+ */
+
+typedef unsigned long pthread_t;
+
+int x, y;
+int z = 42;
+
+int memorder_SEQCST = 5;
+
+void* thread1(void* ptr) {
+  y = 6;
+  _Bool weak = 1;
+  _Bool success = __atomic_compare_exchange(&x, &y, &z, weak, memorder_SEQCST, memorder_SEQCST);
+  if (success) {
+    x = -1; // access would race, but is unreachable as __atomic_compare_exchange will fail (x stores 21, y stores 6, so they differ)
+    return;
+  }
+
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+  if (local != 21) {
+    x = -1; // access would race, but is unreachable as the previous __atomic_compare_exchange failed and x still stores 21 (not 42)
+    return;
+  }
+}
+
+void* thread2(void* ptr) {
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+  __atomic_load(&z, &local, memorder_SEQCST);
+}
+
+int main() {
+  pthread_t t1, t2;
+  x = 21;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_pointer_strong.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_pointer_strong.c
@@ -1,0 +1,41 @@
+//#Safe
+
+/*
+ * Author: Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Date: 2024-10-22
+ */
+
+typedef unsigned long pthread_t;
+
+int x, y;
+int z = 42;
+
+int memorder_SEQCST = 5;
+
+void* thread1(void* ptr) {
+  _Bool weak = 0;
+  _Bool success = __atomic_compare_exchange(&x, &y, &z, weak, memorder_SEQCST, memorder_SEQCST);
+  if (! success) {
+    x = -1; // access would race, but is unreachable as strong __atomic_compare_exchange cannot fail here
+    return;
+  }
+
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+  if (local != 42) {
+    x = -1; // access would race, but is unreachable as strong __atomic_compare_exchange cannot fail here
+    return;
+  }
+}
+
+void* thread2(void* ptr) {
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+  __atomic_load(&z, &local, memorder_SEQCST);
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_pointer_weak.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_pointer_weak.c
@@ -1,0 +1,31 @@
+//#Unsafe
+
+/*
+ * Author: Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Date: 2024-10-22
+ */
+
+typedef unsigned long pthread_t;
+
+int x, y, z;
+
+int memorder_SEQCST = 5;
+
+void* thread1(void* ptr) {
+  _Bool weak = 1;
+  _Bool success = __atomic_compare_exchange_n(&x, &y, 42, weak, memorder_SEQCST, memorder_SEQCST);
+  if (! success) {
+    x = -1; // RACE, reachable since weak __atomic_compare_exchange_n may spuriously fail
+  }
+}
+
+void* thread2(void* ptr) {
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_strong.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_strong.c
@@ -1,0 +1,53 @@
+//#Safe
+
+/*
+ * Author: Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Date: 2024-10-22
+ */
+
+typedef unsigned long pthread_t;
+
+int x, y;
+
+int memorder_SEQCST = 5;
+
+void* thread1(void* ptr) {
+  _Bool weak = 0;
+  _Bool success = __atomic_compare_exchange_n(&x, &y, 42, weak, memorder_SEQCST, memorder_SEQCST);
+  if (! success) {
+    x = -1; // access would race, but is unreachable as strong __atomic_compare_exchange_n cannot fail here
+    return;
+  }
+
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+  if (local != 42) {
+    x = -1; // access would race, but is unreachable as strong __atomic_compare_exchange_n cannot fail here
+    return;
+  }
+
+  y = 6;
+  weak = 1;
+  success = __atomic_compare_exchange_n(&x, &y, 0, weak, memorder_SEQCST, memorder_SEQCST);
+  if (success) {
+    x = -1; // access would race, but is unreachable as __atomic_compare_exchange_n will fail (x stores 42, y stores 6, so they differ)
+    return;
+  }
+
+  __atomic_load(&x, &local, memorder_SEQCST);
+  if (local != 42) {
+    x = -1; // access would race, but is unreachable as the previous __atomic_compare_exchange_n failed and x still stores 42 (not 0)
+    return;
+  }
+}
+
+void* thread2(void* ptr) {
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_strong.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_strong.c
@@ -13,7 +13,7 @@ int memorder_SEQCST = 5;
 
 void* thread1(void* ptr) {
   _Bool weak = 0;
-  _Bool success = __atomic_compare_exchange_n(&x, &y, 42, weak, memorder_SEQCST, memorder_SEQCST);
+  _Bool success = __atomic_compare_exchange_n(&x, &y, 42, 0, memorder_SEQCST, memorder_SEQCST);
   if (! success) {
     x = -1; // access would race, but is unreachable as strong __atomic_compare_exchange_n cannot fail here
     return;

--- a/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_weak.c
+++ b/trunk/examples/concurrent/pthreads/races/regression/atomic_compare_exchange_weak.c
@@ -1,0 +1,31 @@
+//#Unsafe
+
+/*
+ * Author: Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Date: 2024-10-22
+ */
+
+typedef unsigned long pthread_t;
+
+int x, y, z;
+
+int memorder_SEQCST = 5;
+
+void* thread1(void* ptr) {
+  _Bool weak = 1;
+  _Bool success = __atomic_compare_exchange_n(&x, &y, 42, weak, memorder_SEQCST, memorder_SEQCST);
+  if (! success) {
+    x = -1; // RACE, reachable since weak __atomic_compare_exchange_n may spuriously fail
+  }
+}
+
+void* thread2(void* ptr) {
+  int local;
+  __atomic_load(&x, &local, memorder_SEQCST);
+}
+
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
@@ -559,6 +559,31 @@ public abstract class ExpressionTranslation {
 		}
 	}
 
+	public Expression boolToInt(final ILocation loc, final Expression boolExpr) {
+		return boolToInt(loc, boolExpr, CPrimitives.INT);
+	}
+
+	public Expression boolToInt(final ILocation loc, final Expression boolExpr, final CPrimitives intType) {
+		final Expression one = mTypeSizes.constructLiteralForIntegerType(loc, new CPrimitive(intType), BigInteger.ONE);
+		final Expression zero =
+				mTypeSizes.constructLiteralForIntegerType(loc, new CPrimitive(intType), BigInteger.ZERO);
+		return ExpressionFactory.constructIfThenElseExpression(loc, boolExpr, one, zero);
+	}
+
+	public Expression toBool(final ILocation loc, final Expression intExpr, final CType cType) {
+		final CType underlyingType = CEnum.replaceEnumWithInt(cType.getUnderlyingType());
+		final Expression zero = constructZero(loc, underlyingType);
+
+		if (underlyingType instanceof CPrimitive) {
+			return constructBinaryEqualityExpression(loc, IASTBinaryExpression.op_notequals, intExpr, cType, zero,
+					underlyingType);
+		}
+		if (underlyingType instanceof CPointer || underlyingType instanceof CArray) {
+			return ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.COMPNEQ, intExpr, zero);
+		}
+		throw new UnsupportedSyntaxException(loc, "unsupported type " + underlyingType);
+	}
+
 	public abstract Expression transformBitvectorToFloat(ILocation loc, Expression bitvector, CPrimitives floatType);
 
 	public abstract Expression transformFloatToBitvector(ILocation loc, Expression value, CPrimitives cprimitive);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -1305,8 +1305,9 @@ public class StandardFunctionHandler {
 	// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#index-_005f_005fatomic_005fcompare_005fexchange_005fn
 	// https://en.cppreference.com/w/c/atomic/atomic_compare_exchange
 	//
-	// The implementation below generates Boogie code that roughly follows this schema, where success and ptr_val are
-	// auxiliary variables:
+	// The implementation below generates Boogie code that roughly follows the schema below, where success and ptr_val
+	// are auxiliary variables. However, if the memoryOrder argument is not sequential consistency, we instead
+	// overapproximate the method with "assert false".
 	//
 	// @formatter:off
 	// (evaluate arguments)
@@ -1432,8 +1433,9 @@ public class StandardFunctionHandler {
 	// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#index-_005f_005fatomic_005fcompare_005fexchange_005fn
 	// https://en.cppreference.com/w/c/atomic/atomic_compare_exchange
 	//
-	// The implementation below generates Boogie code that roughly follows this schema, where success and ptr_val are
-	// auxiliary variables:
+	// The implementation below generates Boogie code that roughly follows the schema below, where success and ptr_val
+	// are auxiliary variables. However, if the memoryOrder argument is not sequential consistency, we instead
+	// overapproximate the method with "assert false".
 	//
 	// @formatter:off
 	// (evaluate arguments)

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -1220,7 +1220,7 @@ public class StandardFunctionHandler {
 		final ExpressionResult write =
 				mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(), mExpressionTranslation
 						.constructLiteralForIntegerType(loc, new CPrimitive(CPrimitives.BOOL), BigInteger.ZERO));
-		return builder.addAllExceptLrValue(applyMemoryOrder(loc, write, memoryOrder.getLrValue().getValue())).build();
+		return builder.addAllExceptLrValue(applyMemoryOrders(loc, write, memoryOrder.getLrValue().getValue())).build();
 	}
 
 	private Result handleAtomicTestAndSet(final IDispatcher main, final IASTFunctionCallExpression node,
@@ -1238,7 +1238,7 @@ public class StandardFunctionHandler {
 		final ExpressionResult memoryOrder =
 				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[1]);
 		builder.addAllExceptLrValue(pointer, memoryOrder).addAllIncludingLrValue(
-				applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue()));
+				applyMemoryOrders(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue()));
 		return builder.build();
 	}
 
@@ -1256,7 +1256,7 @@ public class StandardFunctionHandler {
 		final ExpressionResult read = mExprResultTransformer.readPointerValue(loc, pointer1.getLrValue());
 		final ExpressionResult write =
 				mExprResultTransformer.makePointerAssignment(loc, pointer2.getLrValue(), read.getLrValue().getValue());
-		return builder.addAllIncludingLrValue(applyMemoryOrder(loc, read, memoryOrder.getLrValue().getValue()))
+		return builder.addAllIncludingLrValue(applyMemoryOrders(loc, read, memoryOrder.getLrValue().getValue()))
 				.addAllExceptLrValue(write).build();
 	}
 
@@ -1273,7 +1273,7 @@ public class StandardFunctionHandler {
 		final ExpressionResult read = mExprResultTransformer.readPointerValue(loc, pointer2.getLrValue());
 		builder.addAllExceptLrValue(read);
 		// Make sure that only the write, but not the read is atomic
-		builder.addAllExceptLrValue(applyMemoryOrder(loc,
+		builder.addAllExceptLrValue(applyMemoryOrders(loc,
 				mExprResultTransformer.makePointerAssignment(loc, pointer1.getLrValue(), read.getLrValue().getValue()),
 				memoryOrder.getLrValue().getValue()));
 		return builder.build();
@@ -1298,7 +1298,7 @@ public class StandardFunctionHandler {
 				mExprResultTransformer.makePointerAssignment(loc, pointer3.getLrValue(), read0.getLrValue().getValue()),
 				read1, mExprResultTransformer.makePointerAssignment(loc, pointer1.getLrValue(),
 						read1.getLrValue().getValue()));
-		builder.addAllExceptLrValue(applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue()));
+		builder.addAllExceptLrValue(applyMemoryOrders(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue()));
 		return builder.build();
 	}
 
@@ -1371,7 +1371,7 @@ public class StandardFunctionHandler {
 								new LeftHandSide[] { success.getLhs() }, new Expression[] { mExpressionTranslation
 										.constructLiteralForIntegerType(loc, boolType, BigInteger.ZERO) }) }))
 				.build();
-		final var atomic = applyMemoryOrder(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
+		final var atomic = applyMemoryOrders(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
 				failureMemoryOrder.getLrValue().getValue());
 
 		final var expectedWrite = mExprResultTransformer.makePointerAssignment(loc, expectedResult.getLrValue(),
@@ -1391,7 +1391,7 @@ public class StandardFunctionHandler {
 		final ExpressionResult memoryOrder =
 				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[1]);
 		return new ExpressionResultBuilder().addAllExceptLrValue(pointer, memoryOrder)
-				.addAllIncludingLrValue(applyMemoryOrder(loc, read, memoryOrder.getLrValue().getValue())).build();
+				.addAllIncludingLrValue(applyMemoryOrders(loc, read, memoryOrder.getLrValue().getValue())).build();
 	}
 
 	private Result handleAtomicStoreN(final IDispatcher main, final IASTFunctionCallExpression node,
@@ -1408,7 +1408,7 @@ public class StandardFunctionHandler {
 		// Make sure that only the write, but not the read is atomic
 		final ExpressionResult write = mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(),
 				valueResult.getLrValue().getValue());
-		return builder.addAllExceptLrValue(applyMemoryOrder(loc, write, memoryOrder.getLrValue().getValue())).build();
+		return builder.addAllExceptLrValue(applyMemoryOrders(loc, write, memoryOrder.getLrValue().getValue())).build();
 	}
 
 	private Result handleAtomicExchangeN(final IDispatcher main, final IASTFunctionCallExpression node,
@@ -1427,7 +1427,7 @@ public class StandardFunctionHandler {
 		atomicBuilder.addAllExceptLrValue(mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(),
 				valueResult.getLrValue().getValue()));
 		return builder.addAllIncludingLrValue(
-				applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
+				applyMemoryOrders(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
 	}
 
 	// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#index-_005f_005fatomic_005fcompare_005fexchange_005fn
@@ -1497,7 +1497,7 @@ public class StandardFunctionHandler {
 								new LeftHandSide[] { success.getLhs() }, new Expression[] { mExpressionTranslation
 										.constructLiteralForIntegerType(loc, boolType, BigInteger.ZERO) }) }))
 				.build();
-		final var atomic = applyMemoryOrder(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
+		final var atomic = applyMemoryOrders(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
 				failureMemoryOrder.getLrValue().getValue());
 
 		final var expectedWrite = mExprResultTransformer.makePointerAssignment(loc, expectedResult.getLrValue(),
@@ -1538,13 +1538,13 @@ public class StandardFunctionHandler {
 				.addAllExceptLrValue(mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(), newValue));
 		// Make sure that only the write, but not the read is atomic
 		return builder.addAllIncludingLrValue(
-				applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
+				applyMemoryOrders(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
 	}
 
 	/**
-	 * Apply the {@code memoryOrder} to the {@code body} for stdatomic-library. If the memory order is equal to
-	 * {@code MEMORY_ORDER_SEQ_CST}, we just make all statements atomic. For all other cases we just overapproximate
-	 * (using an {@code assert false}), since we only support sequential consistency.
+	 * Apply the given {@code memoryOrders} to the {@code body} for stdatomic-library. If every given memory order is
+	 * equal to {@code MEMORY_ORDER_SEQ_CST}, we just make all statements atomic. For all other cases we just
+	 * overapproximate (using an {@code assert false}), since we only support sequential consistency.
 	 *
 	 * @param loc
 	 *            The C location
@@ -1554,7 +1554,7 @@ public class StandardFunctionHandler {
 	 *            The memory orders to apply
 	 * @return An ExpressionResult representing the translation respecting the memory order
 	 */
-	private ExpressionResult applyMemoryOrder(final ILocation loc, final ExpressionResult body,
+	private ExpressionResult applyMemoryOrders(final ILocation loc, final ExpressionResult body,
 			final Expression... memoryOrders) {
 		final ExpressionResultBuilder builder = new ExpressionResultBuilder(body);
 		builder.resetStatements(List.of());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -508,6 +508,7 @@ public class StandardFunctionHandler {
 		fill(map, "__atomic_load_n", this::handleAtomicLoadN);
 		fill(map, "__atomic_store_n", this::handleAtomicStoreN);
 		fill(map, "__atomic_exchange_n", this::handleAtomicExchangeN);
+		fill(map, "__atomic_compare_exchange_n", this::handleAtomicCompareExchangeN);
 
 		fill(map, "__atomic_fetch_add",
 				(main, node, loc, name) -> handleAtomicFetch(main, node, loc, name, IASTBinaryExpression.op_plus));
@@ -524,9 +525,6 @@ public class StandardFunctionHandler {
 		fill(map, "__atomic_clear", this::handleAtomicClear);
 
 		fill(map, "__atomic_compare_exchange",
-				(main, node, loc, name) -> handleUnsupportedFunctionByOverapproximation(main, loc, name,
-						new CPrimitive(CPrimitives.BOOL)));
-		fill(map, "__atomic_compare_exchange_n",
 				(main, node, loc, name) -> handleUnsupportedFunctionByOverapproximation(main, loc, name,
 						new CPrimitive(CPrimitives.BOOL)));
 		fill(map, "__atomic_thread_fence", (main, node, loc, name) -> handleUnsupportedFunctionByOverapproximation(main,
@@ -1351,6 +1349,85 @@ public class StandardFunctionHandler {
 				valueResult.getLrValue().getValue()));
 		return builder.addAllIncludingLrValue(
 				applyMemoryOrder(loc, atomicBuilder.build(), memoryOrder.getLrValue().getValue())).build();
+	}
+
+	// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#index-_005f_005fatomic_005fcompare_005fexchange_005fn
+	// https://en.cppreference.com/w/c/atomic/atomic_compare_exchange
+	//
+	// The implementation below generates Boogie code that roughly follows this schema, where success and ptr_val are
+	// auxiliary variables:
+	//
+	// @formatter:off
+	// (evaluate arguments)
+	// atomic {
+	//  if weak
+	//    havoc success
+	//  else
+	//    success := true
+	//  ptr_val := read(ptr)
+	//  if success && ptr_val == read(expected):
+	//    write(desired, ptr)
+	//  else
+	//    success := false
+	// }
+	// if !success
+	//   write(ptr_val, expected)
+	// return success
+	// @formatter:on
+	private Result handleAtomicCompareExchangeN(final IDispatcher main, final IASTFunctionCallExpression node,
+			final ILocation loc, final String name) {
+		final IASTInitializerClause[] arguments = node.getArguments();
+		checkArguments(loc, 6, name, arguments);
+		final ExpressionResult pointer = mExprResultTransformer.dispatchPointerLValue(main, loc, arguments[0]);
+		final ExpressionResult expectedResult = mExprResultTransformer.dispatchPointerLValue(main, loc, arguments[1]);
+		final ExpressionResult desiredResult =
+				mExprResultTransformer.transformDecaySwitch((ExpressionResult) main.dispatch(arguments[2]), loc, node);
+		final ExpressionResult weakResult = mExprResultTransformer
+				.transformSwitchRexIntToBool((ExpressionResult) main.dispatch(arguments[3]), loc, node);
+		final ExpressionResult successMemoryOrder =
+				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[4]);
+		final ExpressionResult failureMemoryOrder =
+				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[5]);
+		final var resultBuilder = new ExpressionResultBuilder().addAllExceptLrValue(pointer, expectedResult,
+				desiredResult, weakResult, successMemoryOrder, failureMemoryOrder);
+
+		final var boolType = new CPrimitive(CPrimitives.BOOL);
+		final var success = mAuxVarInfoBuilder.constructAuxVarInfo(loc, boolType, AUXVAR.RETURNED);
+		final var pointerRead = mExprResultTransformer.readPointerValue(loc, pointer.getLrValue());
+		final var expectedRead = mExprResultTransformer.readPointerValue(loc, expectedResult.getLrValue());
+		final var pointerWrite = mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(),
+				desiredResult.getLrValue().getValue());
+
+		final var successBoolean =
+				mExpressionTranslation.constructBinaryEqualityExpression(loc, IASTBinaryExpression.op_notequals,
+						success.getExp(), boolType, mExpressionTranslation.constructZero(loc, boolType), boolType);
+		final var atomicBody = new ExpressionResultBuilder().addAuxVarWithDeclaration(success)
+				.addStatement(StatementFactory.constructIfStatement(loc, weakResult.getLrValue().getValue(),
+						new Statement[] { new HavocStatement(loc, new VariableLHS[] { success.getLhs() }) },
+						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
+								new LeftHandSide[] { success.getLhs() },
+								new Expression[] { mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
+										BigInteger.ONE) }) }))
+				.addAllExceptLrValue(pointerRead, expectedRead).addAllExceptLrValueAndStatements(pointerWrite)
+				.addStatement(StatementFactory.constructIfStatement(loc,
+						new BinaryExpression(loc, Operator.LOGICAND, successBoolean,
+								new BinaryExpression(loc, Operator.COMPEQ, pointerRead.getLrValue().getValue(),
+										expectedRead.getLrValue().getValue())),
+						pointerWrite.getStatements().toArray(Statement[]::new),
+						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
+								new LeftHandSide[] { success.getLhs() }, new Expression[] { mExpressionTranslation
+										.constructLiteralForIntegerType(loc, boolType, BigInteger.ZERO) }) }))
+				.build();
+		final var atomic =
+				applyMemoryOrder(loc, applyMemoryOrder(loc, atomicBody, successMemoryOrder.getLrValue().getValue()),
+						failureMemoryOrder.getLrValue().getValue());
+
+		final var expectedWrite = mExprResultTransformer.makePointerAssignment(loc, expectedResult.getLrValue(),
+				pointerRead.getLrValue().getValue());
+		return resultBuilder.addAllExceptLrValue(atomic).addAllExceptLrValueAndStatements(expectedWrite)
+				.addStatement(StatementFactory.constructIfStatement(loc, successBoolean, new Statement[0],
+						expectedWrite.getStatements().toArray(Statement[]::new)))
+				.setLrValue(new RValue(success.getExp(), boolType)).build();
 	}
 
 	private Result handleAtomicFetch(final IDispatcher main, final IASTFunctionCallExpression node, final ILocation loc,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -1355,10 +1355,9 @@ public class StandardFunctionHandler {
 		final var atomicBody = new ExpressionResultBuilder().addAuxVarWithDeclaration(success)
 				.addStatement(StatementFactory.constructIfStatement(loc, weakResult.getLrValue().getValue(),
 						new Statement[] { new HavocStatement(loc, new VariableLHS[] { success.getLhs() }) },
-						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
-								new LeftHandSide[] { success.getLhs() },
-								new Expression[] { mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
-										BigInteger.ONE) }) }))
+						new Statement[] { StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
+								mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
+										BigInteger.ONE)) }))
 				.addAllExceptLrValue(pointerRead, expectedRead).addAllExceptLrValueAndStatements(desiredRead)
 				.addAllExceptLrValueAndStatements(pointerWrite)
 				.addStatement(StatementFactory.constructIfStatement(loc,
@@ -1367,9 +1366,9 @@ public class StandardFunctionHandler {
 										expectedRead.getLrValue().getValue())),
 						DataStructureUtils.concat(desiredRead.getStatements(), pointerWrite.getStatements())
 								.toArray(Statement[]::new),
-						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
-								new LeftHandSide[] { success.getLhs() }, new Expression[] { mExpressionTranslation
-										.constructLiteralForIntegerType(loc, boolType, BigInteger.ZERO) }) }))
+						new Statement[] { StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
+								mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
+										BigInteger.ZERO)) }))
 				.build();
 		final var atomic = applyMemoryOrders(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
 				failureMemoryOrder.getLrValue().getValue());
@@ -1483,19 +1482,18 @@ public class StandardFunctionHandler {
 		final var atomicBody = new ExpressionResultBuilder().addAuxVarWithDeclaration(success)
 				.addStatement(StatementFactory.constructIfStatement(loc, weakResult.getLrValue().getValue(),
 						new Statement[] { new HavocStatement(loc, new VariableLHS[] { success.getLhs() }) },
-						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
-								new LeftHandSide[] { success.getLhs() },
-								new Expression[] { mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
-										BigInteger.ONE) }) }))
+						new Statement[] { StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
+								mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
+										BigInteger.ONE)) }))
 				.addAllExceptLrValue(pointerRead, expectedRead).addAllExceptLrValueAndStatements(pointerWrite)
 				.addStatement(StatementFactory.constructIfStatement(loc,
 						new BinaryExpression(loc, Operator.LOGICAND, successBoolean,
 								new BinaryExpression(loc, Operator.COMPEQ, pointerRead.getLrValue().getValue(),
 										expectedRead.getLrValue().getValue())),
 						pointerWrite.getStatements().toArray(Statement[]::new),
-						new Statement[] { StatementFactory.constructAssignmentStatement(loc,
-								new LeftHandSide[] { success.getLhs() }, new Expression[] { mExpressionTranslation
-										.constructLiteralForIntegerType(loc, boolType, BigInteger.ZERO) }) }))
+						new Statement[] { StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
+								mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
+										BigInteger.ZERO)) }))
 				.build();
 		final var atomic = applyMemoryOrders(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
 				failureMemoryOrder.getLrValue().getValue());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/standardfunctions/StandardFunctionHandler.java
@@ -1343,19 +1343,18 @@ public class StandardFunctionHandler {
 	//
 	// @formatter:off
 	// (evaluate arguments)
-	// atomic {
-	//  if weak
-	//    havoc success
-	//  else
-	//    success := true
-	//  ptr_val := read(ptr)
-	//  if success && ptr_val == read(expected):
-	//    write(read(desired), ptr)
-	//  else
-	//    success := false
+	// havoc success
+	// if (!weak || success) {
+	//   atomic {
+	//     ptr_val := read(ptr)
+	//     success := ptr_val == read(expected)
+	//     if (success) {
+	//       write(read(desired), ptr)
+	//     } else {
+	//       write(ptr_val, expected)
+	//     }
+	//   }
 	// }
-	// if !success
-	//   write(ptr_val, expected)
 	// return success
 	// @formatter:on
 	private Result handleAtomicCompareExchange(final IDispatcher main, final IASTFunctionCallExpression node,
@@ -1373,47 +1372,57 @@ public class StandardFunctionHandler {
 				mExprResultTransformer.transformDispatchSwitchRexBoolToInt(main, loc, arguments[5]);
 		final var resultBuilder = new ExpressionResultBuilder().addAllExceptLrValue(pointer, expectedResult,
 				desiredResult, weakResult, successMemoryOrder, failureMemoryOrder);
+		final boolean mayFailSpuriously = !ExpressionFactory.isFalseLiteral(weakResult.getLrValue().getValue());
 
 		// Introduce an auxvar indicating whether the function is successful, i.e., the exchange was performed.
+		// We immediately havoc the auxvar.
 		final var boolType = new CPrimitive(CPrimitives.BOOL);
 		final var success = mAuxVarInfoBuilder.constructAuxVarInfo(loc, boolType, AUXVAR.RETURNED);
-		final var boolZero = mExpressionTranslation.constructZero(loc, boolType);
-		final var successBoolean = mExpressionTranslation.constructBinaryEqualityExpression(loc,
-				IASTBinaryExpression.op_notequals, success.getExp(), boolType, boolZero, boolType);
-		final var noSuccessBoolean = mExpressionTranslation.constructBinaryEqualityExpression(loc,
-				IASTBinaryExpression.op_equals, success.getExp(), boolType, boolZero, boolType);
+		final var successBoolean = mExpressionTranslation.toBool(loc, success.getExp(), boolType);
+		resultBuilder.addAuxVarWithDeclaration(success);
+		if (mayFailSpuriously) {
+			resultBuilder.addStatement(new HavocStatement(loc, new VariableLHS[] { success.getLhs() }));
+		}
 
+		// Construct the code that actually executes the compare-and-exchange.
 		final var pointerRead = mExprResultTransformer.readPointerValue(loc, pointer.getLrValue());
 		final var expectedRead = mExprResultTransformer.readPointerValue(loc, expectedResult.getLrValue());
 		final var pointerWrite = mExprResultTransformer.makePointerAssignment(loc, pointer.getLrValue(),
 				desiredRead.getLrValue().getValue());
-
-		final var atomicBody = new ExpressionResultBuilder().addAuxVarWithDeclaration(success)
-				.addStatement(StatementFactory.constructIfStatement(loc, weakResult.getLrValue().getValue(),
-						new Statement[] { new HavocStatement(loc, new VariableLHS[] { success.getLhs() }) },
-						new Statement[] { StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
-								mExpressionTranslation.constructLiteralForIntegerType(loc, boolType,
-										BigInteger.ONE)) }))
-				.addAllExceptLrValue(pointerRead, expectedRead).addAllExceptLrValueAndStatements(desiredRead)
-				.addAllExceptLrValueAndStatements(pointerWrite)
-				.addStatement(StatementFactory.constructIfStatement(loc,
-						ExpressionFactory.and(loc,
-								List.of(successBoolean, ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ,
-										pointerRead.getLrValue().getValue(), expectedRead.getLrValue().getValue()))),
-						DataStructureUtils.concat(desiredRead.getStatements(), pointerWrite.getStatements())
-								.toArray(Statement[]::new),
-						new Statement[] {
-								StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(), boolZero) }))
+		final var expectedWrite = mExprResultTransformer.makePointerAssignment(loc, expectedResult.getLrValue(),
+				pointerRead.getLrValue().getValue());
+		final var atomicBody = new ExpressionResultBuilder().addAllExceptLrValue(pointerRead, expectedRead)
+				.addAllExceptLrValueAndStatements(desiredRead).addAllExceptLrValueAndStatements(pointerWrite)
+				.addAllExceptLrValueAndStatements(expectedWrite)
+				// success := read(ptr) == read(expected)
+				.addStatement(StatementFactory.constructSingleAssignmentStatement(loc, success.getLhs(),
+						mExpressionTranslation.boolToInt(loc,
+								mExpressionTranslation.constructBinaryEqualityExpression(loc,
+										IASTBinaryExpression.op_equals, pointerRead.getLrValue().getValue(),
+										pointerRead.getLrValue().getCType(), expectedRead.getLrValue().getValue(),
+										expectedRead.getCType()))))
+				// if (success) { write(read(desired), ptr) } else { write(ptr_val, expected) }
+				.addStatement(StatementFactory.constructIfStatement(loc, successBoolean,
+						DataStructureUtils.concat(desiredRead.getStatements(), pointerWrite.getStatements()),
+						expectedWrite.getStatements()))
 				.build();
+
+		// Wrap the compare-exchange in an atomic block, and check if the memory order arguments are supported.
 		final var atomic = applyMemoryOrders(loc, atomicBody, successMemoryOrder.getLrValue().getValue(),
 				failureMemoryOrder.getLrValue().getValue());
 
-		final var expectedWrite = mExprResultTransformer.makePointerAssignment(loc, expectedResult.getLrValue(),
-				pointerRead.getLrValue().getValue());
-		return resultBuilder.addAllExceptLrValue(atomic).addAllExceptLrValueAndStatements(expectedWrite)
-				.addStatement(StatementFactory.constructIfStatement(loc, noSuccessBoolean,
-						expectedWrite.getStatements().toArray(Statement[]::new), new Statement[0]))
-				.setLrValue(new RValue(success.getExp(), boolType)).build();
+		// Wrap atomic compare-exchange block in "if (success || !weak) { ... }" to model spurious failures.
+		if (mayFailSpuriously) {
+			resultBuilder.addAllExceptLrValueAndStatements(atomic)
+					.addStatement(StatementFactory.constructIfStatement(loc,
+							ExpressionFactory.or(loc, successBoolean,
+									ExpressionFactory.not(loc, weakResult.getLrValue().getValue())),
+							atomic.getStatements()));
+		} else {
+			resultBuilder.addAllExceptLrValue(atomic);
+		}
+
+		return resultBuilder.setLrValue(new RValue(success.getExp(), boolType)).build();
 	}
 
 	private Result handleAtomicLoadN(final IDispatcher main, final IASTFunctionCallExpression node, final ILocation loc,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -43,7 +43,6 @@ import org.eclipse.cdt.core.dom.ast.IASTUnaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.StatementFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayLHS;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
@@ -517,19 +516,7 @@ public class ExpressionResultTransformer {
 	 */
 	private RValue toBoolean(final ILocation loc, final RValue rVal) {
 		assert !rVal.isBoogieBool();
-		final CType underlyingType = CEnum.replaceEnumWithInt(rVal.getCType().getUnderlyingType());
-		final Expression zero = mExprTrans.constructZero(loc, underlyingType);
-
-		final Expression resultEx;
-		if (underlyingType instanceof CPrimitive) {
-			resultEx = mExprTrans.constructBinaryEqualityExpression(loc, IASTBinaryExpression.op_notequals,
-					rVal.getValue(), rVal.getCType(), zero, underlyingType);
-		} else if (underlyingType instanceof CPointer || underlyingType instanceof CArray) {
-			resultEx = ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.COMPNEQ, rVal.getValue(),
-					zero);
-		} else {
-			throw new UnsupportedSyntaxException(loc, "unsupported type " + underlyingType);
-		}
+		final Expression resultEx = mExprTrans.toBool(loc, rVal.getValue(), rVal.getCType());
 		return new RValue(resultEx, new CPrimitive(CPrimitives.INT), true);
 	}
 
@@ -549,12 +536,7 @@ public class ExpressionResultTransformer {
 
 	private RValue toInteger(final ILocation loc, final RValue rVal) {
 		assert rVal.isBoogieBool();
-		final Expression one =
-				mTypeSizes.constructLiteralForIntegerType(loc, new CPrimitive(CPrimitives.INT), BigInteger.ONE);
-		final Expression zero =
-				mTypeSizes.constructLiteralForIntegerType(loc, new CPrimitive(CPrimitives.INT), BigInteger.ZERO);
-		return new RValue(ExpressionFactory.constructIfThenElseExpression(loc, rVal.getValue(), one, zero),
-				rVal.getCType(), false);
+		return new RValue(mExprTrans.boolToInt(loc, rVal.getValue()), rVal.getCType(), false);
 	}
 
 	/**

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/ExpressionFactory.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/ExpressionFactory.java
@@ -121,6 +121,10 @@ public class ExpressionFactory {
 		return new UnaryExpression(loc, resultType, operator, expr);
 	}
 
+	public static Expression not(final ILocation loc, final Expression expr) {
+		return constructUnaryExpression(loc, UnaryExpression.Operator.LOGICNEG, expr);
+	}
+
 	public static Expression newBinaryExpression(final ILocation loc, final Operator op, final Expression left,
 			final Expression right) {
 
@@ -419,11 +423,17 @@ public class ExpressionFactory {
 	}
 
 	public static boolean isTrueLiteral(final Expression expr) {
+		return isBooleanLiteral(expr, true);
+	}
+
+	public static boolean isFalseLiteral(final Expression expr) {
+		return isBooleanLiteral(expr, false);
+	}
+
+	public static boolean isBooleanLiteral(final Expression expr, final boolean value) {
 		if (expr instanceof BooleanLiteral) {
 			final BooleanLiteral bl = (BooleanLiteral) expr;
-			if (bl.getValue()) {
-				return true;
-			}
+			return bl.getValue() == value;
 		}
 		return false;
 	}
@@ -479,6 +489,10 @@ public class ExpressionFactory {
 
 	public static Expression or(final ILocation loc, final List<Expression> exprs) {
 		return bin(loc, exprs, false, Operator.LOGICOR);
+	}
+
+	public static Expression or(final ILocation loc, final Expression... exprs) {
+		return or(loc, Arrays.asList(exprs));
 	}
 
 	private static Expression bin(final ILocation loc, final List<Expression> exprs, final boolean neutralElement,

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/StatementFactory.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/StatementFactory.java
@@ -26,6 +26,8 @@
  */
 package de.uni_freiburg.informatik.ultimate.boogie;
 
+import java.util.List;
+
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
@@ -81,4 +83,14 @@ public class StatementFactory {
 		return new IfStatement(loc, condition, thenPart, elsePart);
 	}
 
+	public static Statement constructIfStatement(final ILocation loc, final Expression condition,
+			final List<Statement> thenPart, final List<Statement> elsePart) {
+		return constructIfStatement(loc, condition, thenPart.toArray(Statement[]::new),
+				elsePart.toArray(Statement[]::new));
+	}
+
+	public static Statement constructIfStatement(final ILocation loc, final Expression condition,
+			final List<Statement> thenPart) {
+		return constructIfStatement(loc, condition, thenPart.toArray(Statement[]::new), new Statement[0]);
+	}
 }


### PR DESCRIPTION
This PR adds support for the builtin atomic functions `__atomic_compare_exchange_n` and `__atomic_compare_exchange`.