### PR TITLE
Use assert orders for Craig_TreeInterpolation

### DIFF
--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/AssertionOrderModulation.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/AssertionOrderModulation.java
@@ -114,9 +114,9 @@ public class AssertionOrderModulation<LETTER> {
 
 		switch (interpolationTechnique) {
 		case Craig_NestedInterpolation:
-		case Craig_TreeInterpolation:
 		case PDR:
 			return AssertCodeBlockOrder.NOT_INCREMENTALLY;
+		case Craig_TreeInterpolation:
 		case ForwardPredicates:
 		case BackwardPredicates:
 		case FPandBP:

--- a/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/strategy/CamelRefinementStrategy.java
+++ b/trunk/source/TraceAbstraction/src/de/uni_freiburg/informatik/ultimate/plugins/generator/traceabstraction/tracehandling/strategy/CamelRefinementStrategy.java
@@ -59,7 +59,7 @@ public class CamelRefinementStrategy<L extends IIcfgTransition<?>> extends Basic
 			createModules(final StrategyFactory<L>.StrategyModuleFactory factory) {
 
 		final List<IIpTcStrategyModule<?, L>> rtr = new ArrayList<>();
-		rtr.add(factory.createIpTcStrategyModuleSmtInterpolCraig(InterpolationTechnique.Craig_NestedInterpolation));
+		rtr.add(factory.createIpTcStrategyModuleSmtInterpolCraig(InterpolationTechnique.Craig_TreeInterpolation));
 		rtr.add(factory.createIpTcStrategyModuleZ3(InterpolationTechnique.FPandBPonlyIfFpWasNotPerfect));
 		return rtr.toArray(new IIpTcStrategyModule[rtr.size()]);
 	}


### PR DESCRIPTION
We support assert orders for FP and BP since a few years.
This summer I added support also our Craig interpolations.
Craig_NestedInterpolation is still buggy.
Craig_TreeInterpolation should work.
Hence I changed the interpolation technique in the Camel refinement strategy from Craig_NestedInterpolation to Craig_TreeInterpolation.