### PR TITLE
Refactor unchecked reads to improve support for dereferences in ACSL

### DIFF
--- a/trunk/examples/CToBoogieTranslation/regression/all/ACSL-pointerFloat.c
+++ b/trunk/examples/CToBoogieTranslation/regression/all/ACSL-pointerFloat.c
@@ -1,0 +1,12 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  float x = 1.57;
+  float* p = &x;
+  //@ assert *p > 0;
+}

--- a/trunk/examples/CToBoogieTranslation/regression/all/ACSL-pointerLongLong.c
+++ b/trunk/examples/CToBoogieTranslation/regression/all/ACSL-pointerLongLong.c
@@ -1,0 +1,12 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  long long x = 32;
+  long long* p = &x;
+  //@ assert *p == 32;
+}

--- a/trunk/examples/programs/regression/c/.testignore
+++ b/trunk/examples/programs/regression/c/.testignore
@@ -95,6 +95,18 @@ TIMEOUT:
 - task: ACSL-at.c
   settings: AutomizerC-BitvectorTranslation.epf
   toolchain: AutomizerC.xml
+- task: ACSL-quantifierArray.c
+  settings: AutomizerC-BitvectorTranslation.epf
+  toolchain: AutomizerC.xml
+- task: ACSL-quantifierArray.c
+  settings: AutomizerC-nestedInterpolants.epf
+  toolchain: AutomizerC.xml
+- task: ACSL-quantifierArray.c
+  settings: AutomizerC-nestedInterpolants_const.epf
+  toolchain: AutomizerC.xml
+- task: ACSL-quantifierArray.c
+  settings: KojakC-Reach-32Bit-Default.epf
+  toolchain: KojakC.xml
 
 unable to decide satisfiability of path constraint:
 - task: array10_pattern_simplified.c

--- a/trunk/examples/programs/regression/c/ACSL-array_contract.c
+++ b/trunk/examples/programs/regression/c/ACSL-array_contract.c
@@ -1,0 +1,19 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int* a;
+
+//@ ensures a[0] == 7;
+void init() {
+  a[0] = 7;
+}
+
+int main() {
+  a = malloc(sizeof(int));
+  init();
+  //@ assert *a == 7;
+}

--- a/trunk/examples/programs/regression/c/ACSL-array_loop_invariant.c
+++ b/trunk/examples/programs/regression/c/ACSL-array_loop_invariant.c
@@ -1,0 +1,14 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  int* a = malloc(sizeof(int));
+  a[0] = 7;
+  //@ loop invariant a[0] == 7;
+  while (__VERIFIER_nondet_int());
+  //@ assert *a == 7;
+}

--- a/trunk/examples/programs/regression/c/ACSL-quantifierArray.c
+++ b/trunk/examples/programs/regression/c/ACSL-quantifierArray.c
@@ -1,0 +1,15 @@
+// #Safe
+/*
+ * Date: 2025-01-13
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  int n = __VERIFIER_nondet_ushort();
+  int* a = malloc(n * sizeof(int));
+  //@ loop invariant \forall int j; (0 <= j && j < i) ==> a[j] == 42;
+  for (int i=0; i<n; i++) {
+    a[i] = 42;
+  }
+}

--- a/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/memoryslicer/MemoryArrayReplacer.java
+++ b/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/memoryslicer/MemoryArrayReplacer.java
@@ -239,6 +239,15 @@ public class MemoryArrayReplacer extends BoogieTransformer {
 		return super.processStatement(statement);
 	}
 
+	@Override
+	protected Expression processExpression(final Expression expr) {
+		if (expr instanceof final IdentifierExpression id && id.getIdentifier().startsWith("#memory")) {
+			throw new MemorySliceException(
+					"Found direct access to memory array (without a read-call), which is not supported yet.");
+		}
+		return super.processExpression(expr);
+	}
+
 	private AssignmentStatement handleArrayWrite(final AssignmentStatement as) {
 		if (as.getLhs().length != 1) {
 			return null;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
@@ -407,7 +407,10 @@ public class ACSLHandler implements IACSLHandler {
 	private ExpressionResult dispatchSwitch(final IDispatcher main,
 			final de.uni_freiburg.informatik.ultimate.model.acsl.ast.Expression node, final ILocation loc) {
 		final ExpressionResult expr = (ExpressionResult) main.dispatch(node, main.getAcslHook());
-		return mExprResultTransformer.switchToRValue(expr, loc, main.getAcslHook());
+		// Perform an unchecked switch to RValue (i.e., without checking for memsafety).
+		// This also ensures that there are no read-calls for dereferences and thus allows us to use also dereferences
+		// inside ACSL expressions that have to be side-effect-free (e.g., loop invariant or contracts)
+		return mExprResultTransformer.switchToRValueUnchecked(expr, loc, main.getAcslHook());
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/BaseMemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/BaseMemoryModel.java
@@ -34,13 +34,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.LocationFactory;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.ExpressionTranslation;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitiveCategory;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitives;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
@@ -137,11 +138,11 @@ public abstract class BaseMemoryModel {
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures) {
 		if (hda == mPointerArray) {
 			if (requiredMemoryModelFeatures.isPointerOnHeapRequired()) {
-				return Collections.singletonList(new ReadWriteDefinition(getPointerHeapArray().getName(),
-						bytesizeOfStoredPointerComponents(), getPointerHeapArray().getASTType(), Collections.emptySet(),
-						requiredMemoryModelFeatures.isPointerUncheckedWriteRequired(),
-						requiredMemoryModelFeatures.isPointerInitRequired(),
-						requiredMemoryModelFeatures.isPointerUncheckedReadRequired()));
+				return Collections.singletonList(
+						new ReadWriteDefinition(getPointerHeapArray().getName(), bytesizeOfStoredPointerComponents(),
+								getPointerHeapArray().getASTType(), new CPointer(new CPrimitive(CPrimitives.INT)),
+								requiredMemoryModelFeatures.isPointerUncheckedWriteRequired(),
+								requiredMemoryModelFeatures.isPointerInitRequired()));
 			}
 			return Collections.emptyList();
 		}
@@ -159,32 +160,22 @@ public abstract class BaseMemoryModel {
 		private final String mProcedureSuffix;
 		private final int mBytesize;
 		private final ASTType mASTType;
-		private final Set<CPrimitives> mPrimitives;
-		private final Set<CPrimitiveCategory> mCPrimitiveCategory;
 		private final boolean mAlsoUncheckedWrite;
 		private final boolean mAlsoInit;
-		private final boolean mAlsoUncheckedRead;
+		private final ICType mRepresentativeType;
 
 		public ReadWriteDefinition(final String procedureName, final int bytesize, final ASTType astType,
-				final Set<CPrimitives> primitives, final boolean alsoUncheckedWrite, final boolean alsoInit,
-				final boolean alsoUncheckedRead) {
+				final ICType representativeType, final boolean alsoUncheckedWrite, final boolean alsoInit) {
 			mProcedureSuffix = procedureName;
 			mBytesize = bytesize;
 			mASTType = astType;
-			mPrimitives = primitives;
-			mCPrimitiveCategory =
-					primitives.stream().map(CPrimitives::getPrimitiveCategory).collect(Collectors.toSet());
+			mRepresentativeType = representativeType;
 			mAlsoUncheckedWrite = alsoUncheckedWrite;
 			mAlsoInit = alsoInit;
-			mAlsoUncheckedRead = alsoUncheckedRead;
 		}
 
 		public String getReadProcedureName() {
 			return READ_PROCEDURE_PREFIX + mProcedureSuffix;
-		}
-
-		public String getUncheckedReadProcedureName() {
-			return READ_PROCEDURE_PREFIX + UNCHECKED_PREFIX + mProcedureSuffix;
 		}
 
 		public String getWriteProcedureName() {
@@ -213,13 +204,6 @@ public abstract class BaseMemoryModel {
 			return mAlsoInit;
 		}
 
-		/**
-		 * @return if true, we also need the unchecked variant of the read definition.
-		 */
-		public boolean alsoUncheckedRead() {
-			return mAlsoUncheckedRead;
-		}
-
 		public int getBytesize() {
 			return mBytesize;
 		}
@@ -228,20 +212,15 @@ public abstract class BaseMemoryModel {
 			return mASTType;
 		}
 
-		public Set<CPrimitives> getPrimitives() {
-			return mPrimitives;
-		}
-
-		public Set<CPrimitiveCategory> getCPrimitiveCategory() {
-			return mCPrimitiveCategory;
+		public ICType getRepresentativeType() {
+			return mRepresentativeType;
 		}
 
 		@Override
 		public String toString() {
 			return "ReadWriteDefinition [mProcedureSuffix=" + mProcedureSuffix + ", mBytesize=" + mBytesize
-					+ ", mASTType=" + mASTType + ", mPrimitives=" + mPrimitives + ", mCPrimitiveCategory="
-					+ mCPrimitiveCategory + ", mAlsoUncheckedWrite=" + mAlsoUncheckedWrite + ", mAlsoInit=" + mAlsoInit
-					+ ", mAlsoUncheckedRead=" + mAlsoUncheckedRead + "]";
+					+ ", mASTType=" + mASTType + ", mRepresentativeType=" + mRepresentativeType
+					+ ", mAlsoUncheckedWrite=" + mAlsoUncheckedWrite + ", mAlsoInit=" + mAlsoInit + "]";
 		}
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -764,15 +764,14 @@ public class MemoryHandler {
 	 * expression of the returned ResultExpression. Note that we only read simple types from the heap -- when reading
 	 * e.g. an array, we have to make readCalls for each cell.
 	 *
-	 * @param tPointer
+	 * @param address
 	 *            the address to read from.
-	 * @param pointerCType
-	 *            the CType of the pointer in tPointer
+	 * @param resultType
+	 *            the CType of the pointer
 	 *
 	 * @return all declarations and statements required to perform the read, plus an identifierExpression holding the
 	 *         read value.
 	 */
-	// 2015-10
 	public ExpressionResult getReadCall(final Expression address, final ICType resultType) {
 		final ILocation loc = address.getLocation();
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
@@ -795,6 +794,16 @@ public class MemoryHandler {
 		return resultBuilder.build();
 	}
 
+	/**
+	 * Handles a read to the given address without any additional memory checks. Therefore, this method always returns a
+	 * single Expression (i.e., access in the corresponding memory array) without any additional statements etc.
+	 *
+	 * @param address
+	 *            the address to read from.
+	 * @param resultType
+	 *            the CType of the pointer
+	 * @return an ExpressionResult consisting only of a array access to the memory array.
+	 */
 	public ExpressionResult getReadUnchecked(final Expression address, final ICType resultType) {
 		final int byteSize;
 		if (resultType instanceof CPointer) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -774,24 +774,7 @@ public class MemoryHandler {
 	 */
 	// 2015-10
 	public ExpressionResult getReadCall(final Expression address, final ICType resultType) {
-		return getReadCall(address, resultType, false);
-	}
-
-	public ExpressionResult getReadCall(final Expression address, final ICType resultType, final boolean unchecked) {
 		final ILocation loc = address.getLocation();
-		if (unchecked) {
-			final int byteSize;
-			if (resultType instanceof CPointer) {
-				byteSize = mTypeSizes.getSizeOfPointer();
-			} else if (resultType instanceof final CPrimitive prim) {
-				byteSize = mTypeSizes.getSize(prim.getType());
-			} else {
-				throw new AssertionError("We only support reading primitive or pointer types");
-			}
-			return new ExpressionResult(new RValue(
-					readFromHeap(loc, determineMemoryArrayForType(resultType), address, resultType, byteSize),
-					resultType));
-		}
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
 		final AuxVarInfo auxvar = mAuxVarInfoBuilder.constructAuxVarInfo(loc, resultType, SFO.AUXVAR.MEMREAD);
 		resultBuilder.addAuxVarWithDeclaration(auxvar);
@@ -810,6 +793,20 @@ public class MemoryHandler {
 		// mExpressionTranslation.addAssumeValueInRangeStatements(loc, auxvar.getExp(), resultType, resultBuilder);
 		resultBuilder.setLrValue(new RValue(auxvar.getExp(), resultType));
 		return resultBuilder.build();
+	}
+
+	public ExpressionResult getReadUnchecked(final Expression address, final ICType resultType) {
+		final int byteSize;
+		if (resultType instanceof CPointer) {
+			byteSize = mTypeSizes.getSizeOfPointer();
+		} else if (resultType instanceof final CPrimitive prim) {
+			byteSize = mTypeSizes.getSize(prim.getType());
+		} else {
+			throw new AssertionError("We only support reading primitive or pointer types");
+		}
+		final ILocation loc = address.getLocation();
+		return new ExpressionResult(new RValue(
+				readFromHeap(loc, determineMemoryArrayForType(resultType), address, resultType, byteSize), resultType));
 	}
 
 	private String determineReadProcedure(final ICType resultType, final ILocation loc) throws AssertionError {
@@ -1406,7 +1403,7 @@ public class MemoryHandler {
 
 			final Expression srcAcc;
 			{
-				final ExpressionResult srcAccExpRes = this.getReadCall(currentSrc, new CPrimitive(CPrimitives.CHAR));
+				final ExpressionResult srcAccExpRes = getReadCall(currentSrc, new CPrimitive(CPrimitives.CHAR));
 				srcAcc = srcAccExpRes.getLrValue().getValue();
 				loopBody.addAll(srcAccExpRes.getStatements());
 				decl.addAll(srcAccExpRes.getDeclarations());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -114,7 +114,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CNamed;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitiveCategory;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitives;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CStructOrUnion;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
@@ -748,6 +747,18 @@ public class MemoryHandler {
 		return new Pair<>(addressRValue, ultimateAllocCall);
 	}
 
+	private HeapDataArray determineMemoryArrayForType(final ICType type) {
+		if (type instanceof CPointer) {
+			mRequiredMemoryModelFeatures.reportPointerOnHeapRequired();
+			return mMemoryModel.getPointerHeapArray();
+		}
+		if (type instanceof final CPrimitive primitive) {
+			mRequiredMemoryModelFeatures.reportDataOnHeapRequired(primitive.getType());
+			return mMemoryModel.getDataHeapArray(primitive.getType());
+		}
+		throw new AssertionError("There is no memory array for the type " + type);
+	}
+
 	/**
 	 * Generates a call of the read procedure and writes the returned value to a temp variable, returned in the
 	 * expression of the returned ResultExpression. Note that we only read simple types from the heap -- when reading
@@ -768,13 +779,26 @@ public class MemoryHandler {
 
 	public ExpressionResult getReadCall(final Expression address, final ICType resultType, final boolean unchecked) {
 		final ILocation loc = address.getLocation();
+		if (unchecked) {
+			final int byteSize;
+			if (resultType instanceof CPointer) {
+				byteSize = mTypeSizes.getSizeOfPointer();
+			} else if (resultType instanceof final CPrimitive prim) {
+				byteSize = mTypeSizes.getSize(prim.getType());
+			} else {
+				throw new AssertionError("We only support reading primitive or pointer types");
+			}
+			return new ExpressionResult(new RValue(
+					readFromHeap(loc, determineMemoryArrayForType(resultType), address, resultType, byteSize),
+					resultType));
+		}
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
 		final AuxVarInfo auxvar = mAuxVarInfoBuilder.constructAuxVarInfo(loc, resultType, SFO.AUXVAR.MEMREAD);
 		resultBuilder.addAuxVarWithDeclaration(auxvar);
 		final VariableLHS[] lhss = { auxvar.getLhs() };
-		final CallStatement call = StatementFactory.constructCallStatement(loc, false, lhss,
-				determineReadProcedure(resultType, unchecked, loc),
-				new Expression[] { address, calculateSizeOf(loc, resultType) });
+		final CallStatement call =
+				StatementFactory.constructCallStatement(loc, false, lhss, determineReadProcedure(resultType, loc),
+						new Expression[] { address, calculateSizeOf(loc, resultType) });
 		if (resultType.isAtomic()) {
 			resultBuilder.addStatement(new AtomicStatement(loc, new Statement[] { call }));
 		} else {
@@ -788,18 +812,17 @@ public class MemoryHandler {
 		return resultBuilder.build();
 	}
 
-	private String determineReadProcedure(final ICType resultType, final boolean unchecked, final ILocation loc)
-			throws AssertionError {
+	private String determineReadProcedure(final ICType resultType, final ILocation loc) throws AssertionError {
 		final ICType ut = resultType.getUnderlyingType();
 		if (ut instanceof CPrimitive) {
 			final CPrimitive cp = (CPrimitive) ut;
 			checkFloatOnHeapSupport(loc, cp);
 			mRequiredMemoryModelFeatures.reportDataOnHeapRequired(cp.getType());
-			return determineReadProcedureForPrimitive(cp.getType(), unchecked);
+			return determineReadProcedureForPrimitive(cp.getType());
 		}
 		if (ut instanceof CPointer) {
 			mRequiredMemoryModelFeatures.reportPointerOnHeapRequired();
-			return determineReadProcedureForPointer(unchecked);
+			return determineReadProcedureForPointer();
 		}
 		if (ut instanceof CArray) {
 			// we assume it is an Array on Heap
@@ -807,30 +830,22 @@ public class MemoryHandler {
 			// but it may not only be on heap, because it is addressoffed, but also because it is inside
 			// a struct that is addressoffed..
 			mRequiredMemoryModelFeatures.reportPointerOnHeapRequired();
-			return determineReadProcedureForPointer(unchecked);
+			return determineReadProcedureForPointer();
 		}
 		if (ut instanceof CEnum) {
 			// enum is treated like an int
 			mRequiredMemoryModelFeatures.reportDataOnHeapRequired(CPrimitives.INT);
-			return determineReadProcedureForPrimitive(CPrimitives.INT, unchecked);
+			return determineReadProcedureForPrimitive(CPrimitives.INT);
 		}
 		throw new UnsupportedOperationException("unsupported type " + ut);
 	}
 
-	private String determineReadProcedureForPointer(final boolean unchecked) {
-		if (unchecked) {
-			mRequiredMemoryModelFeatures.reportPointerUncheckedReadRequired();
-			return mMemoryModel.getUncheckedReadPointerProcedureName();
-		}
+	private String determineReadProcedureForPointer() {
 		mRequiredMemoryModelFeatures.reportPointerOnHeapRequired();
 		return mMemoryModel.getReadPointerProcedureName();
 	}
 
-	private String determineReadProcedureForPrimitive(final CPrimitives prim, final boolean unchecked) {
-		if (unchecked) {
-			mRequiredMemoryModelFeatures.reportUncheckedReadRequired(prim);
-			return mMemoryModel.getUncheckedReadProcedureName(prim);
-		}
+	private String determineReadProcedureForPrimitive(final CPrimitives prim) {
 		return mMemoryModel.getReadProcedureName(prim);
 	}
 
@@ -998,9 +1013,9 @@ public class MemoryHandler {
 	}
 
 	/**
-	 * Like {@link #doPointerArithmetic(int, ILocation, Expression, RValue, ICType)} but additionally the integer operand
-	 * is converted to the same type that we use to represent pointer components. As a consequence we have to return an
-	 * ExpressionResult.
+	 * Like {@link #doPointerArithmetic(int, ILocation, Expression, RValue, ICType)} but additionally the integer
+	 * operand is converted to the same type that we use to represent pointer components. As a consequence we have to
+	 * return an ExpressionResult.
 	 */
 	public ExpressionResult doPointerArithmeticWithConversion(final int operator, final ILocation loc,
 			final Expression ptrAddress, final RValue integer, final ICType valueType) {
@@ -1715,10 +1730,7 @@ public class MemoryHandler {
 		final List<Declaration> result = new ArrayList<>();
 		for (final ReadWriteDefinition rda : mMemoryModel.getReadWriteDefinitionForHeapDataArray(heapDataArray,
 				mRequiredMemoryModelFeatures)) {
-			if (rda.alsoUncheckedRead()) {
-				result.addAll(constructSingleReadProcedure(main, loc, heapDataArray, rda, true));
-			}
-			result.addAll(constructSingleReadProcedure(main, loc, heapDataArray, rda, false));
+			result.addAll(constructSingleReadProcedure(main, loc, heapDataArray, rda));
 		}
 		return result;
 	}
@@ -1806,8 +1818,8 @@ public class MemoryHandler {
 			swrite.addAll(constructPointerTargetFullyAllocatedCheck(loc, sizeWrite, inPtr, procName));
 		}
 
-		final boolean floating2bitvectorTransformationNeeded = mMemoryModel instanceof MemoryModel_SingleBitprecise
-				&& rda.getCPrimitiveCategory().contains(CPrimitiveCategory.FLOATTYPE);
+		final boolean floating2bitvectorTransformationNeeded =
+				mMemoryModel instanceof MemoryModel_SingleBitprecise && rda.getRepresentativeType().isFloatingType();
 
 		final Expression nonFPBVReturnValue = ExpressionFactory.constructIdentifierExpression(loc,
 				mTypeHandler.getBoogieTypeForBoogieASTType(valueAstType), "#value",
@@ -1815,7 +1827,7 @@ public class MemoryHandler {
 		final CPrimitives cprimitive;
 		final Expression returnValue;
 		if (floating2bitvectorTransformationNeeded) {
-			cprimitive = rda.getPrimitives().iterator().next();
+			cprimitive = ((CPrimitive) rda.getRepresentativeType()).getType();
 			if (mSettings.useFpToIeeeBvExtension()) {
 				returnValue = mExpressionTranslation.transformFloatToBitvector(loc, nonFPBVReturnValue, cprimitive);
 			} else {
@@ -1927,14 +1939,14 @@ public class MemoryHandler {
 	 * @return
 	 */
 	private List<Procedure> constructSingleReadProcedure(final CHandler main, final ILocation loc,
-			final HeapDataArray hda, final ReadWriteDefinition rda, final boolean unchecked) {
+			final HeapDataArray hda, final ReadWriteDefinition rda) {
 		// specification for memory reads
 		final String returnValue = "#value";
 		final ASTType valueAstType = rda.getASTType();
 		final String ptrId = "#ptr";
 		final String readTypeSize = "#sizeOfReadType";
 
-		final String readProcedureName = unchecked ? rda.getUncheckedReadProcedureName() : rda.getReadProcedureName();
+		final String readProcedureName = rda.getReadProcedureName();
 
 		// create procedure signature
 		{
@@ -1949,49 +1961,20 @@ public class MemoryHandler {
 		}
 
 		// create procedure specifications
-		final ArrayList<Specification> sread = new ArrayList<>();
+		final ArrayList<Specification> sread =
+				new ArrayList<>(constructPointerBaseValidityCheck(loc, ptrId, readProcedureName));
 
-		if (!unchecked) {
-			sread.addAll(constructPointerBaseValidityCheck(loc, ptrId, readProcedureName));
+		final Expression sizeRead =
+				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogieTypeForPointerComponents(),
+						readTypeSize, new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, readProcedureName));
 
-			final Expression sizeRead = ExpressionFactory.constructIdentifierExpression(loc,
-					mTypeHandler.getBoogieTypeForPointerComponents(), readTypeSize,
-					new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, readProcedureName));
+		sread.addAll(constructPointerTargetFullyAllocatedCheck(loc, sizeRead, ptrId, readProcedureName));
 
-			sread.addAll(constructPointerTargetFullyAllocatedCheck(loc, sizeRead, ptrId, readProcedureName));
-		}
-
-		final Expression arr = hda.getIdentifierExpression();
 		final Expression ptrExpr =
 				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogiePointerType(), ptrId,
 						new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, readProcedureName));
 
-		Expression dataFromHeap;
-		if (rda.getBytesize() == hda.getSize()) {
-			dataFromHeap = constructOneDimensionalArrayAccess(loc, arr, ptrExpr);
-		} else if (rda.getBytesize() < hda.getSize()) {
-			dataFromHeap = mExpressionTranslation.extractBits(loc,
-					constructOneDimensionalArrayAccess(loc, arr, ptrExpr), rda.getBytesize() * 8, 0);
-		} else {
-			assert rda.getBytesize() % hda.getSize() == 0 : "incompatible sizes";
-			final Expression[] dataChunks = new Expression[rda.getBytesize() / hda.getSize()];
-			for (int i = 0; i < dataChunks.length; i++) {
-				if (i == 0) {
-					dataChunks[dataChunks.length - 1 - 0] = constructOneDimensionalArrayAccess(loc, arr, ptrExpr);
-				} else {
-					final Expression index =
-							addIntegerConstantToPointer(loc, ptrExpr, BigInteger.valueOf(i * hda.getSize()));
-					dataChunks[dataChunks.length - 1 - i] = constructOneDimensionalArrayAccess(loc, arr, index);
-				}
-			}
-			dataFromHeap = mExpressionTranslation.concatBits(loc, Arrays.asList(dataChunks), hda.getSize());
-		}
-
-		if (mMemoryModel instanceof MemoryModel_SingleBitprecise
-				&& rda.getCPrimitiveCategory().contains(CPrimitiveCategory.FLOATTYPE)) {
-			final CPrimitives cprimitive = rda.getPrimitives().iterator().next();
-			dataFromHeap = mExpressionTranslation.transformBitvectorToFloat(loc, dataFromHeap, cprimitive);
-		}
+		final Expression dataFromHeap = readFromHeap(loc, hda, ptrExpr, rda.getRepresentativeType(), rda.getBytesize());
 
 		final Expression valueExpr = ExpressionFactory.constructIdentifierExpression(loc,
 				mTypeHandler.getBoogieTypeForBoogieASTType(valueAstType), returnValue,
@@ -2004,6 +1987,39 @@ public class MemoryHandler {
 		mProcedureManager.endCustomProcedure(main, readProcedureName);
 
 		return Collections.emptyList();
+	}
+
+	private Expression readFromHeap(final ILocation loc, final HeapDataArray hda, final Expression address,
+			final ICType resultType, final int bytesize) {
+		final Expression result;
+		final Expression memoryArray = hda.getIdentifierExpression();
+		if (bytesize == hda.getSize() || hda.getSize() == 0) {
+			// If the size of the heap array matches the desired bytesize, or if we are using integer translation (where
+			// the size of the heap array is zero), then construct a simple access in the memory array.
+			result = constructOneDimensionalArrayAccess(loc, memoryArray, address);
+		} else if (bytesize < hda.getSize()) {
+			result = mExpressionTranslation.extractBits(loc,
+					constructOneDimensionalArrayAccess(loc, memoryArray, address), bytesize * 8, 0);
+		} else {
+			assert bytesize % hda.getSize() == 0 : "incompatible sizes";
+			final Expression[] dataChunks = new Expression[bytesize / hda.getSize()];
+			for (int i = 0; i < dataChunks.length; i++) {
+				if (i == 0) {
+					dataChunks[dataChunks.length - 1 - 0] =
+							constructOneDimensionalArrayAccess(loc, memoryArray, address);
+				} else {
+					final Expression index =
+							addIntegerConstantToPointer(loc, address, BigInteger.valueOf(i * hda.getSize()));
+					dataChunks[dataChunks.length - 1 - i] = constructOneDimensionalArrayAccess(loc, memoryArray, index);
+				}
+			}
+			result = mExpressionTranslation.concatBits(loc, Arrays.asList(dataChunks), hda.getSize());
+		}
+
+		if (mMemoryModel instanceof MemoryModel_SingleBitprecise && resultType.isFloatingType()) {
+			return mExpressionTranslation.transformBitvectorToFloat(loc, result, ((CPrimitive) resultType).getType());
+		}
+		return result;
 	}
 
 	public Expression addIntegerConstantToPointer(final ILocation loc, final Expression ptrExpr,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModelDeclarations.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModelDeclarations.java
@@ -172,11 +172,9 @@ public enum MemoryModelDeclarations {
 		// TODO: using members instead of getters here to avoid "checkIsFrozen" calls -- not nice..
 		for (final CPrimitives prim : new HashSet<>(mmf.getDataOnHeapRequiredUnchecked())) {
 			changedSomething |= mmf.reportUncheckedWriteRequired(prim);
-			changedSomething |= mmf.reportUncheckedReadRequired(prim);
 		}
 		if (mmf.isPointerOnHeapRequiredUnchecked()) {
 			changedSomething |= mmf.reportPointerUncheckedWriteRequired();
-			changedSomething |= mmf.reportPointerUncheckedReadRequired();
 		}
 		changedSomething |= mmf.require(ULTIMATE_DATA_RACE_MEMORY);
 		return changedSomething;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_MultiBitprecise.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_MultiBitprecise.java
@@ -114,10 +114,8 @@ public class MemoryModel_MultiBitprecise extends BaseMemoryModel {
 					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedWriteRequired(), primitives);
 			final boolean alsoInit = DataStructureUtils
 					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getInitWriteRequired(), primitives);
-			final boolean alsoUncheckedRead = DataStructureUtils
-					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedReadRequired(), primitives);
-			result.add(new ReadWriteDefinition(procedureName, bytesize, astType, primitives, alsoUncheckedWrite,
-					alsoInit, alsoUncheckedRead));
+			result.add(new ReadWriteDefinition(procedureName, bytesize, astType, new CPrimitive(representative),
+					alsoUncheckedWrite, alsoInit));
 		}
 		return result;
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_SingleBitprecise.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_SingleBitprecise.java
@@ -101,10 +101,8 @@ public class MemoryModel_SingleBitprecise extends BaseMemoryModel {
 						.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedWriteRequired(), primitives);
 				final boolean alsoInit = DataStructureUtils
 						.haveNonEmptyIntersection(requiredMemoryModelFeatures.getInitWriteRequired(), primitives);
-				final boolean alsoUncheckedRead = DataStructureUtils
-						.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedReadRequired(), primitives);
-				result.add(new ReadWriteDefinition(procedureName, bytesize, astType, primitives, alsoUncheckedWrite,
-						alsoInit, alsoUncheckedRead));
+				result.add(new ReadWriteDefinition(procedureName, bytesize, astType, new CPrimitive(representative),
+						alsoUncheckedWrite, alsoInit));
 			}
 		}
 		return result;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_Unbounded.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel_Unbounded.java
@@ -116,10 +116,8 @@ public class MemoryModel_Unbounded extends BaseMemoryModel {
 					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedWriteRequired(), primitives);
 			final boolean alsoInit = DataStructureUtils
 					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getInitWriteRequired(), primitives);
-			final boolean alsoUncheckedRead = DataStructureUtils
-					.haveNonEmptyIntersection(requiredMemoryModelFeatures.getUncheckedReadRequired(), primitives);
-			result.add(new ReadWriteDefinition(procedureName, bytesize, astType, primitives, alsoUncheckedWrite,
-					alsoInit, alsoUncheckedRead));
+			result.add(new ReadWriteDefinition(procedureName, bytesize, astType, new CPrimitive(representative),
+					alsoUncheckedWrite, alsoInit));
 		}
 		return result;
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/RequiredMemoryModelFeatures.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/RequiredMemoryModelFeatures.java
@@ -59,15 +59,11 @@ public final class RequiredMemoryModelFeatures {
 
 	private boolean mMemoryModelInfrastructureRequiredHasBeenQueried;
 
-	private final Set<CPrimitives> mDataUncheckedReadRequired;
-	private boolean mPointerUncheckedReadRequired;
-
 	public RequiredMemoryModelFeatures() {
 		mDataOnHeapRequired = new HashSet<>();
 		mRequiredMemoryModelDeclarations = new HashSet<>();
 		mDataUncheckedWriteRequired = new HashSet<>();
 		mDataInitWriteRequired = new HashSet<>();
-		mDataUncheckedReadRequired = new HashSet<>();
 		mDataOnHeapInitFunctionRequired = new HashSet<>();
 		mDataOnHeapStoreFunctionRequired = new HashSet<>();
 	}
@@ -106,16 +102,6 @@ public final class RequiredMemoryModelFeatures {
 		return true;
 	}
 
-	public boolean reportPointerUncheckedReadRequired() {
-		if (mPointerUncheckedReadRequired) {
-			return false;
-		}
-		checkNotFrozen();
-		reportPointerOnHeapRequired();
-		mPointerUncheckedReadRequired = true;
-		return true;
-	}
-
 	public boolean reportPointerInitWriteRequired() {
 		if (mPointerInitWriteRequired) {
 			return false;
@@ -133,16 +119,6 @@ public final class RequiredMemoryModelFeatures {
 		checkNotFrozen();
 		requireMemoryModelInfrastructure();
 		mDataOnHeapRequired.add(primitive);
-		return true;
-	}
-
-	public boolean reportUncheckedReadRequired(final CPrimitives primitive) {
-		if (mDataUncheckedReadRequired.contains(primitive)) {
-			return false;
-		}
-		checkNotFrozen();
-		reportDataOnHeapRequired(primitive);
-		mDataUncheckedReadRequired.add(primitive);
 		return true;
 	}
 
@@ -216,11 +192,6 @@ public final class RequiredMemoryModelFeatures {
 		return mPointerUncheckedWriteRequired;
 	}
 
-	public boolean isPointerUncheckedReadRequired() {
-		checkIsFrozen();
-		return mPointerUncheckedReadRequired;
-	}
-
 	public boolean isPointerInitRequired() {
 		checkIsFrozen();
 		return mPointerInitWriteRequired;
@@ -249,11 +220,6 @@ public final class RequiredMemoryModelFeatures {
 	public boolean isDataOnHeapStoreFunctionRequired(final CPrimitives prim) {
 		checkIsFrozen();
 		return mDataOnHeapStoreFunctionRequired.contains(prim);
-	}
-
-	public Set<CPrimitives> getUncheckedReadRequired() {
-		checkIsFrozen();
-		return mDataUncheckedReadRequired;
 	}
 
 	public Set<CPrimitives> getUncheckedWriteRequired() {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
@@ -233,7 +233,8 @@ public class StructHandler {
 		final Expression newPointer = computeStructFieldAddress(loc, fieldIndex, structAddress, structType);
 		final ICType resultType = structType.getFieldTypes()[fieldIndex];
 
-		final ExpressionResult call = mMemoryHandler.getReadCall(newPointer, resultType, unchecked);
+		final ExpressionResult call = unchecked ? mMemoryHandler.getReadUnchecked(newPointer, resultType)
+				: mMemoryHandler.getReadCall(newPointer, resultType);
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
 		resultBuilder.addAllExceptLrValue(call);
 		resultBuilder.setLrValue(new RValue(call.getLrValue().getValue(), resultType));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
@@ -229,11 +229,11 @@ public class StructHandler {
 	}
 
 	public Result readFieldInTheStructAtAddress(final ILocation loc, final int fieldIndex,
-			final Expression structAddress, final CStructOrUnion structType) {
+			final Expression structAddress, final CStructOrUnion structType, final boolean unchecked) {
 		final Expression newPointer = computeStructFieldAddress(loc, fieldIndex, structAddress, structType);
 		final ICType resultType = structType.getFieldTypes()[fieldIndex];
 
-		final ExpressionResult call = mMemoryHandler.getReadCall(newPointer, resultType);
+		final ExpressionResult call = mMemoryHandler.getReadCall(newPointer, resultType, unchecked);
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
 		resultBuilder.addAllExceptLrValue(call);
 		resultBuilder.setLrValue(new RValue(call.getLrValue().getValue(), resultType));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/memoryhandler/ConstructMemcpyOrMemmove.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/memoryhandler/ConstructMemcpyOrMemmove.java
@@ -245,7 +245,7 @@ public final class ConstructMemcpyOrMemmove {
 				final ICType cPrimType = new CPrimitive(cPrim);
 				final Expression srcAcc;
 				{
-					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadCall(currentSrc, cPrimType, true);
+					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadUnchecked(currentSrc, cPrimType);
 					srcAcc = srcAccExpRes.getLrValue().getValue();
 					loopBody.addStatements(srcAccExpRes.getStatements());
 					loopBody.addDeclarations(srcAccExpRes.getDeclarations());
@@ -294,7 +294,7 @@ public final class ConstructMemcpyOrMemmove {
 				final ICType cPointer = new CPointer(new CPrimitive(CPrimitives.VOID));
 				final Expression srcAcc;
 				{
-					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadCall(currentSrc, cPointer, true);
+					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadUnchecked(currentSrc, cPointer);
 					srcAcc = srcAccExpRes.getLrValue().getValue();
 					loopBody.addStatements(srcAccExpRes.getStatements());
 					loopBody.addDeclarations(srcAccExpRes.getDeclarations());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -225,7 +225,8 @@ public class ExpressionResultTransformer {
 		return transform(expr, null, loc, hook, Transformation.SWITCH_TO_RVALUE, Transformation.REX_INT_TO_BOOL);
 	}
 
-	public ExpressionResult switchToRValue(final ExpressionResult expr, final ILocation loc, final IASTNode hook) {
+	private ExpressionResult switchToRValue(final ExpressionResult expr, final ILocation loc, final IASTNode hook,
+			final boolean unchecked) {
 		final LRValue lrVal = expr.getLrValue();
 
 		if (lrVal == null) {
@@ -264,12 +265,8 @@ public class ExpressionResultTransformer {
 
 			final ExpressionResultBuilder erb = new ExpressionResultBuilder().addAllExceptLrValue(expr);
 			final RValue newValue;
-			if (underlyingType instanceof CPrimitive) {
-				final ExpressionResult rex = mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType);
-				newValue = (RValue) rex.getLrValue();
-				erb.addAllExceptLrValue(rex);
-			} else if (underlyingType instanceof CPointer) {
-				final ExpressionResult rex = mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType);
+			if (underlyingType instanceof CPrimitive || underlyingType instanceof CPointer) {
+				final ExpressionResult rex = mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType, unchecked);
 				newValue = (RValue) rex.getLrValue();
 				erb.addAllExceptLrValue(rex);
 			} else if (underlyingType instanceof CArray) {
@@ -278,8 +275,8 @@ public class ExpressionResultTransformer {
 			} else if (underlyingType instanceof CEnum) {
 				throw new AssertionError("handled above");
 			} else if (underlyingType instanceof CStructOrUnion) {
-				final ExpressionResult rex =
-						readStructFromHeap(expr, loc, hlv.getAddress(), (CStructOrUnion) underlyingType, hook);
+				final ExpressionResult rex = readStructFromHeap(expr, loc, hlv.getAddress(),
+						(CStructOrUnion) underlyingType, hook, unchecked);
 				newValue = (RValue) rex.getLrValue();
 				erb.addAllExceptLrValue(rex);
 			} else if (underlyingType instanceof CNamed) {
@@ -298,6 +295,15 @@ public class ExpressionResultTransformer {
 		throw new AssertionError("an LRValue that is not null, and no LocalLValue, RValue or HeapLValue???");
 	}
 
+	public ExpressionResult switchToRValue(final ExpressionResult expr, final ILocation loc, final IASTNode hook) {
+		return switchToRValue(expr, loc, hook, false);
+	}
+
+	public ExpressionResult switchToRValueUnchecked(final ExpressionResult expr, final ILocation loc,
+			final IASTNode hook) {
+		return switchToRValue(expr, loc, hook, true);
+	}
+
 	/**
 	 * Read the contents of a struct (given as a pointer) from the heap recursively (for nested structs) returning a
 	 * StructConstructor.
@@ -307,6 +313,7 @@ public class ExpressionResultTransformer {
 	 * @param loc
 	 * @param structOnHeapAddress
 	 * @param structType
+	 * @param unchecked
 	 * @param mExprTrans
 	 * @param mTypeSizes
 	 * @param mAuxVarInfoBuilder
@@ -316,7 +323,8 @@ public class ExpressionResultTransformer {
 	 *         items inside the StructConstructor correctly
 	 */
 	private ExpressionResult readStructFromHeap(final ExpressionResult old, final ILocation loc,
-			final Expression structOnHeapAddress, final CStructOrUnion structType, final IASTNode hook) {
+			final Expression structOnHeapAddress, final CStructOrUnion structType, final IASTNode hook,
+			final boolean unchecked) {
 
 		final Expression startAddress = structOnHeapAddress;
 		final Expression currentStructBaseAddress = MemoryHandler.getPointerBaseAddress(startAddress, loc);
@@ -348,14 +356,14 @@ public class ExpressionResultTransformer {
 			final LRValue fieldLRVal;
 			if (underlyingType instanceof CPrimitive) {
 				final ExpressionResult fieldRead = (ExpressionResult) mStructHandler.readFieldInTheStructAtAddress(loc,
-						i, structOnHeapAddress, structType);
+						i, structOnHeapAddress, structType, unchecked);
 				fieldLRVal = fieldRead.getLrValue();
 				newStmt.addAll(fieldRead.getStatements());
 				newDecl.addAll(fieldRead.getDeclarations());
 				newAuxVars.addAll(fieldRead.getAuxVars());
 			} else if (underlyingType instanceof CPointer) {
 				final ExpressionResult fieldRead = (ExpressionResult) mStructHandler.readFieldInTheStructAtAddress(loc,
-						i, structOnHeapAddress, structType);
+						i, structOnHeapAddress, structType, unchecked);
 				fieldLRVal = fieldRead.getLrValue();
 				newStmt.addAll(fieldRead.getStatements());
 				newDecl.addAll(fieldRead.getDeclarations());
@@ -363,7 +371,8 @@ public class ExpressionResultTransformer {
 			} else if (underlyingType instanceof CArray) {
 				final Expression arrayPointer =
 						mStructHandler.computeStructFieldAddress(loc, i, structOnHeapAddress, structType);
-				final ExpressionResult xres1 = readArrayFromHeap(old, loc, arrayPointer, (CArray) underlyingType, hook);
+				final ExpressionResult xres1 =
+						readArrayFromHeap(old, loc, arrayPointer, (CArray) underlyingType, hook, unchecked);
 				final ExpressionResult xres = xres1;
 
 				fieldLRVal = xres.getLrValue();
@@ -374,7 +383,7 @@ public class ExpressionResultTransformer {
 			} else if (underlyingType instanceof CEnum) {
 				// like CPrimitive..
 				final ExpressionResult fieldRead = (ExpressionResult) mStructHandler.readFieldInTheStructAtAddress(loc,
-						i, structOnHeapAddress, structType);
+						i, structOnHeapAddress, structType, unchecked);
 				fieldLRVal = fieldRead.getLrValue();
 				newStmt.addAll(fieldRead.getStatements());
 				newDecl.addAll(fieldRead.getDeclarations());
@@ -392,8 +401,8 @@ public class ExpressionResultTransformer {
 				final Expression innerStructAddress =
 						MemoryHandler.constructPointerFromBaseAndOffset(currentStructBaseAddress, offsetSum, loc);
 
-				final ExpressionResult fieldRead =
-						readStructFromHeap(old, loc, innerStructAddress, (CStructOrUnion) underlyingType, hook);
+				final ExpressionResult fieldRead = readStructFromHeap(old, loc, innerStructAddress,
+						(CStructOrUnion) underlyingType, hook, unchecked);
 
 				fieldLRVal = fieldRead.getLrValue();
 				newStmt.addAll(fieldRead.getStatements());
@@ -437,7 +446,7 @@ public class ExpressionResultTransformer {
 	 * @return
 	 */
 	private ExpressionResult readArrayFromHeap(final ExpressionResult old, final ILocation loc,
-			final Expression address, final CArray arrayType, final IASTNode hook) {
+			final Expression address, final CArray arrayType, final IASTNode hook, final boolean unchecked) {
 		final ICType arrayValueType = arrayType.getValueType().getUnderlyingType();
 		if (arrayValueType instanceof CArray) {
 			throw new UnsupportedSyntaxException(loc,
@@ -466,9 +475,9 @@ public class ExpressionResultTransformer {
 					MemoryHandler.constructPointerFromBaseAndOffset(newStartAddressBase, arrayEntryAddressOffset, loc);
 			final ExpressionResult readRex;
 			if (arrayValueType instanceof CStructOrUnion) {
-				readRex = readStructFromHeap(old, loc, readAddress, (CStructOrUnion) arrayValueType, hook);
+				readRex = readStructFromHeap(old, loc, readAddress, (CStructOrUnion) arrayValueType, hook, unchecked);
 			} else {
-				readRex = mMemoryHandler.getReadCall(readAddress, arrayType.getValueType());
+				readRex = mMemoryHandler.getReadCall(readAddress, arrayType.getValueType(), unchecked);
 			}
 			builder.addAllExceptLrValue(readRex);
 			builder.setOrResetLrValue(readRex.getLrValue());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -266,7 +266,9 @@ public class ExpressionResultTransformer {
 			final ExpressionResultBuilder erb = new ExpressionResultBuilder().addAllExceptLrValue(expr);
 			final RValue newValue;
 			if (underlyingType instanceof CPrimitive || underlyingType instanceof CPointer) {
-				final ExpressionResult rex = mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType, unchecked);
+				final ExpressionResult rex =
+						unchecked ? mMemoryHandler.getReadUnchecked(hlv.getAddress(), underlyingType)
+								: mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType);
 				newValue = (RValue) rex.getLrValue();
 				erb.addAllExceptLrValue(rex);
 			} else if (underlyingType instanceof CArray) {
@@ -476,8 +478,10 @@ public class ExpressionResultTransformer {
 			final ExpressionResult readRex;
 			if (arrayValueType instanceof CStructOrUnion) {
 				readRex = readStructFromHeap(old, loc, readAddress, (CStructOrUnion) arrayValueType, hook, unchecked);
+			} else if (unchecked) {
+				readRex = mMemoryHandler.getReadUnchecked(readAddress, arrayType.getValueType());
 			} else {
-				readRex = mMemoryHandler.getReadCall(readAddress, arrayType.getValueType(), unchecked);
+				readRex = mMemoryHandler.getReadCall(readAddress, arrayType.getValueType());
 			}
 			builder.addAllExceptLrValue(readRex);
 			builder.setOrResetLrValue(readRex.getLrValue());


### PR DESCRIPTION
In our C translation, we translate dereferences to calls to Boogie procedures, e.g., `x = a[i];` is translated to:
```
call #t~mem0 := read~int({ base: ~a~0!base, offset: ~a~0!offset + 4 * ~i~0 }, 4);
~x~0 := #t~mem0;
```
where `read~int` has the following signature (for memsafety we have a stronger contract):
```
procedure read~int(#ptr : $Pointer$, #sizeOfReadType : int) returns (#value : int);
ensures #value == #memory_int[#ptr];
```
This read-call is produced by`ExpressionResultTransformer::switchToRValue`.

For ACSL, we attempted to handle this the same way as for C. However, there was the following issue:
This approach with read-calls works for some ACSL statements (e.g., the translation of `//@ assert x == a[i];` looks similar to above). There are however other ACSL statements / expressions, the translation with calls does not work, as it produces not only an expression, but also auxiliary statements (e.g., function contracts, loop invariants, quantifiers in the future).
Therefore I refactored the `MemoryHandler` to provide a method `getUncheckedReadCall` that creates an array access without any calls or additional checks (also used for the translation of `memcpy` and `memmove`) and use this method in `ExpressionResultTransformer::switchToRValueUnchecked` that is now called in `ACSLHandler`.