### PR TITLE
Support quantifiers in ACSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ trunk/examples/concurrent/bpl/weaver-benchmarks/weaver
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Completeness.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Contract.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/ContractStatement.java
+/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Declaration.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Decreases.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Ensures.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Expression.java

--- a/trunk/examples/programs/regression/c/ACSL-quantifierSameName.c
+++ b/trunk/examples/programs/regression/c/ACSL-quantifierSameName.c
@@ -1,0 +1,12 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  unsigned x = 7;
+  //@ assert \forall int x; (long long) x + 1 > x;
+  //@ assert x == 7;
+}

--- a/trunk/examples/programs/regression/c/ACSL-quantifierSimple.c
+++ b/trunk/examples/programs/regression/c/ACSL-quantifierSimple.c
@@ -1,0 +1,12 @@
+// #Safe
+/*
+ * Date: 2025-01-07
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main() {
+  //@ assert \forall unsigned x; x >= 0;
+  //@ assert \exists short x, int y; x == y + 2;
+  //@ assert \forall int x; x <= 4294967295;
+}

--- a/trunk/examples/programs/regression/c/KojakC-Reach-32Bit-Default.epf
+++ b/trunk/examples/programs/regression/c/KojakC-Reach-32Bit-Default.epf
@@ -64,6 +64,7 @@ file_export_version=3.0
 #Sun Nov 08 00:43:17 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.plugins.generator.codecheck/Interpolating\ solver=SMTINTERPOL
+/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.codecheck/Theory\ for\ external\ solver=ALL
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.generator.codecheck=
 /instance/de.uni_freiburg.informatik.ultimate.plugins.generator.codecheck/Timeout\ in\ seconds=1000000
 @de.uni_freiburg.informatik.ultimate.plugins.generator.codecheck=0.0.1

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/acsl/parser/GlobalLocalParser.cup
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/acsl/parser/GlobalLocalParser.cup
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.*;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
@@ -293,10 +294,13 @@ non terminal List<Case> indcases;
 non terminal LogicStatement logic_def, logic_decl;
 non terminal List<LogicStatement> logic_decls;
 non terminal ACSLType type_spec_cv, cast_logic_type;
-non terminal lexpr_list, lexpr_option, rel_list, lexpr_binder, bounded_var, binders,
+non terminal Declaration decl_spec;
+non terminal Declaration[] binders, binders_reentrance;
+non terminal Expression lexpr_binder;
+non terminal lexpr_list, lexpr_option, rel_list, bounded_var,
 			 range,
 			 field_init, array_init, update, field_path_elt, field_init_elt, array_path_elt, array_init_elt,
-			 update_elt, path, path_elt, binders_reentrance, decl_spec, 
+			 update_elt, path, path_elt, 
 			 abs_spec_option, abs_spec,
 			 tabs, abs_spec_bis, ne_logic_type_list,
 			 decl, annotation, post_cond_kind, post_cond, decl_list, beg_code_annotation, 
@@ -451,16 +455,16 @@ lexpr_rel::=
 ;
 
 lexpr_binder::=
- LET bounded_var EQUAL lexpr SEMICOLON lexpr %prec LET 
-| FORALL binders SEMICOLON lexpr  %prec prec_forall
-| EXISTS binders SEMICOLON lexpr  %prec prec_exists
-| LAMBDA binders SEMICOLON lexpr  %prec prec_lambda
+ LET bounded_var EQUAL lexpr SEMICOLON lexpr LET {: RESULT = new NotDefinedExpression(); :} %prec LET
+| FORALL:op binders:b SEMICOLON lexpr:e {: RESULT = new QuantifierExpression(true, b, e); :} %prec prec_forall
+| EXISTS:op binders:b SEMICOLON lexpr:e {: RESULT = new QuantifierExpression(false, b, e); :} %prec prec_exists
+| LAMBDA binders SEMICOLON lexpr {: RESULT = new NotDefinedExpression(); :} %prec prec_lambda
 ;
 
 lexpr_end_rel::=
   lexpr_inner:expr {: RESULT = expr; :} %prec prec_no_rel
-| lexpr_binder:e {: RESULT = setNodeLocationFromSymbols(new NotDefinedExpression(), e$); :}
-| NOT:op lexpr_binder:e {: RESULT = setNodeLocationFromSymbols(new NotDefinedExpression(), op$, e$); :}  
+| lexpr_binder:e {: RESULT = setNodeLocationFromSymbols(e, e$); :}
+| NOT:op lexpr_binder:e {: RESULT = setNodeLocationFromSymbols(new UnaryExpression(UnaryExpression.Operator.LOGICNEG, e), op$, e$); :}  
 ;
 
 rel_list::=
@@ -615,17 +619,17 @@ path_elt::=
 /*** binders ***/
 
 binders::=
- binders_reentrance 
+ binders_reentrance: b {: RESULT = b; :} 
 ;
 
 binders_reentrance::=
- decl_spec 
-| binders_reentrance COMMA decl_spec
-| binders_reentrance COMMA var_spec
+ decl_spec:d {: RESULT = new Declaration[] { d }; :}
+| binders_reentrance:b COMMA decl_spec:d {: RESULT = Stream.concat(Arrays.stream(b), Stream.of(d)).toArray(Declaration[]::new); :}
+| binders_reentrance:b COMMA var_spec {: RESULT = b; :}
 ;
 
 decl_spec::=
- type_spec var_spec 
+ type_spec:t var_spec:v {: RESULT = new Declaration(new ACSLType(t), v); :} 
 ;
 
 var_spec::=

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ACSLPrettyPrinter.java
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ACSLPrettyPrinter.java
@@ -50,6 +50,7 @@ import de.uni_freiburg.informatik.ultimate.model.acsl.ast.IfThenElseExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.IntegerLiteral;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.LoopInvariant;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.OldValueExpression;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.QuantifierExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.RealLiteral;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Requires;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.UnaryExpression;
@@ -125,6 +126,11 @@ public class ACSLPrettyPrinter {
 			return "\\result";
 		case final AtLabelExpression at:
 			return String.format("\\at(%s, %s)", printExpression(at.getExpression()), at.getLabel());
+		case final QuantifierExpression quantifier:
+			final String quantor = quantifier.isUniversal() ? "\\forall" : "\\exists";
+			final String vars = Arrays.stream(quantifier.getVariables())
+					.map(x -> x.getType().getTypeName() + " " + x.getName()).collect(Collectors.joining(", "));
+			return String.format("%s %s; %s", quantor, vars, printExpression(quantifier.getSubformula()));
 		default:
 			// TODO: Add more cases
 			return expression.toString();

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
@@ -269,10 +269,8 @@ Expression ::=
 	| { QuantifierExpression }
 		/** This is true for universal and false for existential quantifier */
 		isUniversal : boolean
-		typeParams  : String[]
+		variables : Declaration[]
 		subformula  : Expression
-		parameters  : String[] 
-		attributes  : String[]
 	| { /** This can be used as call forall parameter, or as if or 
 	     * while condition.  In all other places it is forbidden. */ 
 		WildcardExpression }
@@ -281,3 +279,7 @@ Expression ::=
 ACSLType ::= 
 	typeName : String;
 
+
+Declaration ::=
+	type : ACSLType
+	name : String;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
@@ -121,9 +121,11 @@ import de.uni_freiburg.informatik.ultimate.model.acsl.ast.LoopStatement;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.LoopVariant;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.MallocableExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.OldValueExpression;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.QuantifierExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.RealLiteral;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Requires;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ValidExpression;
+import de.uni_freiburg.informatik.ultimate.util.datastructures.ScopedHashMap;
 
 /**
  * @author Markus Lindenmann
@@ -173,6 +175,8 @@ public class ACSLHandler implements IACSLHandler {
 	private final LocationFactory mLocationFactory;
 	private final CHandler mCHandler;
 	private final CExpressionTranslator mCExpressionTranslator;
+
+	private final ScopedHashMap<String, LRValue> mBoundVariables = new ScopedHashMap<>();
 
 	public ACSLHandler(final boolean witnessInvariantMode, final FlatSymbolTable symboltable,
 			final ExpressionTranslation expressionTranslation, final ITypeHandler typeHandler,
@@ -650,6 +654,10 @@ public class ACSLHandler implements IACSLHandler {
 	@Override
 	public Result visit(final IDispatcher main,
 			final de.uni_freiburg.informatik.ultimate.model.acsl.ast.IdentifierExpression node) {
+		final var boundVar = mBoundVariables.get(node.getIdentifier());
+		if (boundVar != null) {
+			return new ExpressionResult(boundVar);
+		}
 		final ILocation loc = mLocationFactory.createACSLLocation(node);
 		final String id = lookupId(main, node, loc);
 
@@ -707,6 +715,47 @@ public class ACSLHandler implements IACSLHandler {
 		default:
 			throw new IncorrectSyntaxException(loc, "The type of specType should be in some type!");
 		}
+	}
+
+	@Override
+	public Result visit(final IDispatcher main, final QuantifierExpression node) {
+		mBoundVariables.beginScope();
+		final ILocation loc = mLocationFactory.createACSLLocation(node);
+		final List<VarList> quantifiedVars = new ArrayList<>();
+		final List<Expression> typeConstraints = new ArrayList<>();
+		for (final var decl : node.getVariables()) {
+			// For each quantified variable in the ACSL expression, create a corresponding Boogie variable and store it
+			// in the mBoundVariables to be used when handling IdentifierExpressions.
+			final String name = decl.getName();
+			final CType cType = AcslTypeUtils.translateAcslTypeToCType(decl.getType());
+			if (!(cType instanceof CPrimitive)) {
+				throw new UnsupportedSyntaxException(loc, "Only quantified variables of primitive type are supported.");
+			}
+			final DeclarationInformation declInfo = new DeclarationInformation(StorageClass.QUANTIFIED, null);
+			final BoogieType boogieType = mTypeHandler.getBoogieTypeForCType(cType);
+			mBoundVariables.put(name, new LocalLValue(new VariableLHS(loc, boogieType, name, declInfo), cType, false));
+			quantifiedVars.add(new VarList(loc, new String[] { name }, mTypeHandler.cType2AstType(loc, cType)));
+			// Collect the type constraints for the given CType (if any)
+			final var id = ExpressionFactory.constructIdentifierExpression(loc, boogieType, name, declInfo);
+			final var constraint = mExpressionTranslation.getTypeConstraint(loc, id, cType);
+			if (constraint.isPresent()) {
+				typeConstraints.add(constraint.get());
+			}
+		}
+		final ExpressionResult subResult =
+				mExprResultTransformer.rexIntToBool(dispatchSwitch(main, node.getSubformula(), loc), loc);
+		if (!subResult.hasNoSideEffects()) {
+			throw new UnsupportedSyntaxException(loc, "Unable to handle quantified expressions with side-effects.");
+		}
+		// Create a quantifier expression in Boogie
+		// As Boogie uses mathematical integers, we add type constraints inside the quantifier, i.e., we produce
+		// (exists ... typeConstraints && subResult) and (forall ... typeConstraints ==> subResult)
+		final Expression inner = ExpressionFactory.newBinaryExpression(loc,
+				node.isUniversal() ? Operator.LOGICIMPLIES : Operator.LOGICAND,
+				ExpressionFactory.and(loc, typeConstraints), subResult.getLrValue().getValue());
+		final Expression result = ExpressionFactory.quantifier(loc, node.isUniversal(), quantifiedVars, inner);
+		mBoundVariables.endScope();
+		return new ExpressionResult(new RValue(result, new CPrimitive(CPrimitives.BOOL), true));
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/MainDispatcher.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/MainDispatcher.java
@@ -535,7 +535,7 @@ public class MainDispatcher implements IDispatcher {
 				return mAcslHandler.visit(this, (IfThenElseExpression) n);
 			}
 			if (n instanceof QuantifierExpression) {
-				return mAcslHandler.visit(this, n);
+				return mAcslHandler.visit(this, (QuantifierExpression) n);
 			}
 			if (n instanceof WildcardExpression) {
 				return mAcslHandler.visit(this, n);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/BitvectorTranslation.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/BitvectorTranslation.java
@@ -32,6 +32,7 @@ import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
@@ -744,9 +745,9 @@ public class BitvectorTranslation extends ExpressionTranslation {
 	}
 
 	@Override
-	public void addAssumeValueInRangeStatements(final ILocation loc, final Expression expr, final CType ctype,
-			final ExpressionResultBuilder expressionResultBuilder) {
+	public Optional<Expression> getTypeConstraint(final ILocation loc, final Expression expr, final CType cType) {
 		// do nothing. not needed for bitvectors
+		return Optional.empty();
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/ExpressionTranslation.java
@@ -30,6 +30,7 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
 
@@ -353,8 +354,21 @@ public abstract class ExpressionTranslation {
 		return new ExpressionResultBuilder().addAllExceptLrValue(expr).setLrValue(rValue).build();
 	}
 
-	public abstract void addAssumeValueInRangeStatements(ILocation loc, Expression expr, CType ctype,
-			ExpressionResultBuilder expressionResultBuilder);
+	public void addAssumeValueInRangeStatements(final ILocation loc, final Expression expr, final CType ctype,
+			final ExpressionResultBuilder expressionResultBuilder) {
+		final var constraint = getTypeConstraint(loc, expr, ctype);
+		if (constraint.isPresent()) {
+			expressionResultBuilder.addStatement(new AssumeStatement(loc, constraint.get()));
+		}
+	}
+
+	/**
+	 * Returns a constraint for the given {@code cType} that is required for the model of the translated expression
+	 * {@code expr}. If the modelling does not require such a type constraint, the function can return
+	 * {@code Optional.empty()}.
+	 */
+	public abstract Optional<Expression> getTypeConstraint(final ILocation loc, final Expression expr,
+			final CType cType);
 
 	public Expression constructNullPointer(final ILocation loc) {
 		return constructPointerForIntegerValues(loc, BigInteger.ZERO, BigInteger.ZERO);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/IntegerTranslation.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/expressiontranslation/IntegerTranslation.java
@@ -30,13 +30,13 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
 import org.eclipse.cdt.core.dom.ast.IASTUnaryExpression;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Attribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
@@ -419,25 +419,24 @@ public class IntegerTranslation extends ExpressionTranslation {
 	}
 
 	@Override
-	public void addAssumeValueInRangeStatements(final ILocation loc, final Expression expr, final CType cType,
-			final ExpressionResultBuilder expressionResultBuilder) {
+	public Optional<Expression> getTypeConstraint(final ILocation loc, final Expression expr, final CType cType) {
 		if (!mSettings.assumeNondeterministicValuesInRange() || !cType.getUnderlyingType().isIntegerType()) {
 			// only integer types can be out of range
-			return;
+			return Optional.empty();
 		}
 		final CPrimitive cPrimitive = (CPrimitive) CEnum.replaceEnumWithInt(cType.getUnderlyingType());
 		if (mTypeSizes.isUnsigned(cPrimitive)) {
 			// only signed types can be out of range
-			return;
+			return Optional.empty();
 		}
-		expressionResultBuilder.addStatement(constructAssumeInRangeStatement(mTypeSizes, loc, expr, cPrimitive));
+		return Optional.of(constructInRangeExpression(mTypeSizes, loc, expr, cPrimitive));
 	}
 
 	/**
-	 * Returns "assume (minValue <= lrValue && lrValue <= maxValue)"
+	 * Returns "(minValue <= lrValue && lrValue <= maxValue)"
 	 */
-	private AssumeStatement constructAssumeInRangeStatement(final TypeSizes typeSizes, final ILocation loc,
-			final Expression expr, final CPrimitive type) {
+	private Expression constructInRangeExpression(final TypeSizes typeSizes, final ILocation loc, final Expression expr,
+			final CPrimitive type) {
 		final Expression minValue =
 				mTypeSizes.constructLiteralForIntegerType(loc, type, typeSizes.getMinValueOfPrimitiveType(type));
 		final Expression maxValue =
@@ -447,8 +446,7 @@ public class IntegerTranslation extends ExpressionTranslation {
 				constructBinaryComparisonExpression(loc, IASTBinaryExpression.op_lessEqual, minValue, type, expr, type);
 		final Expression smallerMaxValue =
 				constructBinaryComparisonExpression(loc, IASTBinaryExpression.op_lessEqual, expr, type, maxValue, type);
-		return new AssumeStatement(loc,
-				ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, biggerMinInt, smallerMaxValue));
+		return ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, biggerMinInt, smallerMaxValue);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/IACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/IACSLHandler.java
@@ -55,6 +55,7 @@ import de.uni_freiburg.informatik.ultimate.model.acsl.ast.LoopInvariant;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.LoopVariant;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.MallocableExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.OldValueExpression;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.QuantifierExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.RealLiteral;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Requires;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.UnaryExpression;
@@ -143,6 +144,17 @@ public interface IACSLHandler extends IHandler {
 	 * @return a result object
 	 */
 	Result visit(IDispatcher main, IdentifierExpression node);
+
+	/**
+	 * Translates an QuantifierExpression.
+	 *
+	 * @param main
+	 *            a reference to the main IDispatcher
+	 * @param node
+	 *            the node to visit
+	 * @return a result object
+	 */
+	Result visit(IDispatcher main, QuantifierExpression node);
 
 	/**
 	 * Translates an Contract.

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/ExpressionFactory.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/ExpressionFactory.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayAccessExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayStoreExpression;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.Attribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BitVectorAccessExpression;
@@ -51,12 +52,14 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IfThenElseExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IntegerLiteral;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.LeftHandSide;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.QuantifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.RealLiteral;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StringLiteral;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StructAccessExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StructConstructor;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StructLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.VarList;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.WildcardExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieArrayType;
@@ -972,4 +975,9 @@ public class ExpressionFactory {
 		return rat;
 	}
 
+	public static QuantifierExpression quantifier(final ILocation loc, final boolean isUniversal,
+			final List<VarList> quantifiedVars, final Expression subformula) {
+		return new QuantifierExpression(loc, BoogieType.TYPE_BOOL, isUniversal, new String[0],
+				quantifiedVars.toArray(VarList[]::new), new Attribute[0], subformula);
+	}
 }


### PR DESCRIPTION
This PR adds support for quantifiers in ACSL.
* We already had some rules in our grammar to parse quantifiers. These rules just always yielded a `NotDefinedExpression`. There was also a AST object for a `QuantifierExpression` that I just adapted to our needs.
* To translate quantifiers from ACSL to Boogie, I added a new method to `ACSLHandler`. The crucial steps in this translation are that we have to handle the quantified variables in the expression inside the quantifier properly (track the variables in a `ScopedHashMap` and first lookup when handling an `IdentifierExpression`) and that we add type constraints over the quantified variables (ACSL may use bounded types that are translated to an unbounded type in Boogie).

Note that we can only handle quantified expressions, where the inner expressions is side-effect free (which also does not allow any auxiliary statements). Therefore, quantified expressions that contain dereferences are currently not supported, but this should be fixed in #703.