### PR TITLE
ASTBuilder: Generate sealed class hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ trunk/examples/concurrent/bpl/weaver-benchmarks/weaver
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Decreases.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Ensures.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/Expression.java
+/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/FakePointerExpression.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/FieldAccessExpression.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/FreeableExpression.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/FunctionApplication.java

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ACSLPrettyPrinter.java
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ACSLPrettyPrinter.java
@@ -41,6 +41,7 @@ import de.uni_freiburg.informatik.ultimate.model.acsl.ast.CastExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.CodeAnnotStmt;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Ensures;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Expression;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.FakePointerExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.FieldAccessExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.GhostDeclaration;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.GhostUpdate;
@@ -110,6 +111,8 @@ public class ACSLPrettyPrinter {
 		case final BooleanLiteral boolLit -> "\\" + boolLit.getValue();
 		case final CastExpression cast ->
 				"(%s) %s".formatted(cast.getCastedType().getTypeName(), printExpression(cast.getExpression()));
+		case final FakePointerExpression pointer ->
+				"{%s:%s}".formatted(printExpression(pointer.getBase()), printExpression(pointer.getOffset()));
 		case final FieldAccessExpression f -> "(%s).%s".formatted(printExpression(f.getStruct()), f.getField());
 		// TODO FreeableExpression
 		// TODO FunctionApplication

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
@@ -274,6 +274,11 @@ Expression ::=
 	| { /** This can be used as call forall parameter, or as if or 
 	     * while condition.  In all other places it is forbidden. */ 
 		WildcardExpression }
+	| { /** This is used to represent addresses in backtranslated program executions.
+	     *  There is no corresponding grammar rule for the parser. */
+	    FakePointerExpression }
+		base : Expression
+		offset : Expression
 	);
  
 ACSLType ::= 

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Emit.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Emit.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Emits classes etc.
@@ -225,15 +226,35 @@ public class Emit {
 	 *            node.
 	 */
 	public void emitClassDeclaration(final Node node) {
+		final String abstractModifier = node.isAbstract() ? "abstract " : EMPTY_STRING;
 		final String extendsClause = getBaseClass(node).map(name -> " extends " + name).orElse(EMPTY_STRING);
 		final String implementsClause =
 				node.getInterfaces() != null ? " implements " + node.getInterfaces() : EMPTY_STRING;
-		mWriter.println("public " + (node.isAbstract() ? "abstract " : EMPTY_STRING) + "class " + node.getName()
-				+ extendsClause + implementsClause + " {");
+
+		final String sealedModifier;
+		final String permitsClause;
+		if (isSealed(node) && node.isAbstract()) {
+			sealedModifier = "sealed ";
+			permitsClause = " permits " + mGrammar.getNodeTable().values().stream()
+					.filter(n -> node.equals(n.getParent())).map(Node::getName).collect(Collectors.joining(", "));
+		} else if (isSealed(node)) {
+			sealedModifier = "final ";
+			permitsClause = EMPTY_STRING;
+		} else {
+			sealedModifier = node.getParent() != null && isSealed(node.getParent()) ? "non-sealed " : EMPTY_STRING;
+			permitsClause = EMPTY_STRING;
+		}
+
+		mWriter.println("public " + abstractModifier + sealedModifier + "class " + node.getName() + extendsClause
+				+ implementsClause + permitsClause + " {");
 	}
 
 	protected Optional<String> getBaseClass(final Node node) {
 		return Optional.ofNullable(node.getParent()).map(Node::getName);
+	}
+
+	protected boolean isSealed(final Node node) {
+		return true;
 	}
 
 	/**

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Emit.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Emit.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -224,9 +225,15 @@ public class Emit {
 	 *            node.
 	 */
 	public void emitClassDeclaration(final Node node) {
+		final String extendsClause = getBaseClass(node).map(name -> " extends " + name).orElse(EMPTY_STRING);
+		final String implementsClause =
+				node.getInterfaces() != null ? " implements " + node.getInterfaces() : EMPTY_STRING;
 		mWriter.println("public " + (node.isAbstract() ? "abstract " : EMPTY_STRING) + "class " + node.getName()
-				+ (node.getParent() != null ? (" extends " + node.getParent().getName()) : EMPTY_STRING)
-				+ (node.getInterfaces() != null ? (" implements " + node.getInterfaces()) : EMPTY_STRING) + " {");
+				+ extendsClause + implementsClause + " {");
+	}
+
+	protected Optional<String> getBaseClass(final Node node) {
+		return Optional.ofNullable(node.getParent()).map(Node::getName);
 	}
 
 	/**

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/EmitAstWithVisitors.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/EmitAstWithVisitors.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.Predicate;
@@ -104,24 +105,7 @@ public abstract class EmitAstWithVisitors extends Emit {
 
 	@Override
 	public void emitClassDeclaration(final Node node) {
-		final StringBuilder classDecl = new StringBuilder(MIN_SIZE_EMIT_CLASS_DECLARATION);
-		classDecl.append("public ");
-		if (node.isAbstract()) {
-			classDecl.append("abstract ");
-		}
-		classDecl.append("class ").append(node.getName());
-
-		if (node.getParent() != null) {
-			classDecl.append(" extends ").append(node.getParent().getName());
-		} else if (!isNonClassicNode(node)) {
-			classDecl.append(" extends ").append(getRootClassName());
-		}
-
-		if (node.getInterfaces() != null) {
-			classDecl.append(" implements ").append(node.getInterfaces());
-		}
-		classDecl.append(" {");
-		mWriter.println(classDecl.toString());
+		super.emitClassDeclaration(node);
 		if (isNonClassicNode(node)) {
 			return;
 		}
@@ -133,6 +117,18 @@ public abstract class EmitAstWithVisitors extends Emit {
 		mWriter.println(
 				"    private static final java.util.function.Predicate<" + getRootClassName() + "> VALIDATOR = ");
 		mWriter.println("			" + getRootClassName() + ".VALIDATORS.get(" + node.getName() + ".class);");
+	}
+
+	@Override
+	protected Optional<String> getBaseClass(final Node node) {
+		final var baseClass = super.getBaseClass(node);
+		if (baseClass.isPresent()) {
+			return baseClass;
+		}
+		if (isNonClassicNode(node)) {
+			return Optional.empty();
+		}
+		return Optional.of(getRootClassName());
 	}
 
 	@Override

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/EmitAstWithVisitors.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/EmitAstWithVisitors.java
@@ -132,6 +132,11 @@ public abstract class EmitAstWithVisitors extends Emit {
 	}
 
 	@Override
+	protected boolean isSealed(final Node node) {
+		return !isNonClassicNode(node);
+	}
+
+	@Override
 	public void emitNodeHook(final Node node) {
 		if (node.name.equals(getVisitorName())) {
 			emitVisitorHook();

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Grammar.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Grammar.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 /**
  * Represents a grammar.
  */
-public class Grammar {
+public final class Grammar {
     /**
      * The package name of this grammar.
      */

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Node.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Node.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 /**
  * Represents a node.
  */
-public class Node {
+public final class Node {
     /**
      * The name of this node.
      */

--- a/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Parameter.java
+++ b/trunk/source/ASTBuilder/src/de/uni_freiburg/informatik/ultimate/astbuilder/Parameter.java
@@ -5,7 +5,7 @@ package de.uni_freiburg.informatik.ultimate.astbuilder;
 /**
  * Represents a parameter.
  */
-public class Parameter {
+public final class Parameter {
     /**
      * The name of this parameter.
      */

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
@@ -751,20 +751,17 @@ public class ACSLHandler implements IACSLHandler {
 	@Override
 	public Result visit(final IDispatcher main, final Contract node) {
 		final ILocation loc = mLocationFactory.createACSLLocation(node);
-		final ArrayList<Specification> spec = new ArrayList<>();
-		// First we catch the case that a contract is at a FunctionDefinition
-		if (node instanceof IASTFunctionDefinition) {
-			final String msg = "Syntax Error, Contracts on FunctionDefinition are not allowed";
-			throw new IncorrectSyntaxException(loc, msg);
-		}
 
+		final ArrayList<Specification> spec = new ArrayList<>();
 		for (final ContractStatement stmt : node.getContractStmt()) {
 			spec.addAll(Arrays.asList(((ContractResult) main.dispatch(stmt, main.getAcslHook())).getSpecs()));
 		}
+
 		if (node.getBehaviors() != null && node.getBehaviors().length != 0) {
 			final String msg = "Not yet implemented: Behaviour";
 			throw new UnsupportedSyntaxException(loc, msg);
 		}
+
 		// TODO : node.getCompleteness();
 		mSpecType = ACSLHandler.SPEC_TYPE.NOT;
 		return new ContractResult(spec.toArray(new Specification[spec.size()]));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/Boogie2ACSL.java
@@ -847,5 +847,9 @@ public final class Boogie2ACSL {
 		public String toString() {
 			return ACSLPrettyPrinter.print(mExpression);
 		}
+
+		public BacktranslatedExpression asOldExpression() {
+			return new BacktranslatedExpression(new OldValueExpression(mExpression), mCType, mRange);
+		}
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslator.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/CACSL2BoogieBacktranslator.java
@@ -61,8 +61,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.BoogieASTNode;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ForkStatement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.GeneratedBoogieAstTransformer;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.GeneratedBoogieAstVisitor;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.HavocStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.JoinStatement;
@@ -100,8 +98,7 @@ import de.uni_freiburg.informatik.ultimate.core.model.translation.AtomicTraceEle
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IBacktranslatedCFG;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution;
 import de.uni_freiburg.informatik.ultimate.core.model.translation.IProgramExecution.ProgramState;
-import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLTransformer;
-import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLVisitor;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.FakePointerExpression;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.Boogie2ACSL.BacktranslatedExpression;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.DataStructureUtils;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
@@ -573,7 +570,7 @@ public class CACSL2BoogieBacktranslator extends
 			return null;
 		}
 		final Map<BacktranslatedExpression, Collection<BacktranslatedExpression>> translatedStateMap = new HashMap<>();
-		final ProgramState<Expression> compressedProgramState = compressProgramState(programState);
+		final ProgramState<ExpressionOrPointer> compressedProgramState = compressProgramState(programState);
 
 		// Suppress backtranslation warnings for program states
 		// We just skip variables like pointers or aux-vars in the programs states
@@ -581,7 +578,7 @@ public class CACSL2BoogieBacktranslator extends
 		final boolean generateOld = mGenerateBacktranslationWarnings;
 		final boolean warnedOld = mBacktranslationWarned;
 		mGenerateBacktranslationWarnings = false;
-		for (final Expression varName : compressedProgramState.getVariables()) {
+		for (final ExpressionOrPointer varName : compressedProgramState.getVariables()) {
 			translateProgramStateEntry(varName, compressedProgramState, translatedStateMap);
 		}
 		mGenerateBacktranslationWarnings = generateOld;
@@ -590,8 +587,8 @@ public class CACSL2BoogieBacktranslator extends
 
 	}
 
-	private void translateProgramStateEntry(final Expression varName,
-			final ProgramState<Expression> compressedProgramState,
+	private void translateProgramStateEntry(final ExpressionOrPointer varName,
+			final ProgramState<ExpressionOrPointer> compressedProgramState,
 			final Map<BacktranslatedExpression, Collection<BacktranslatedExpression>> translatedStateMap) {
 		// first, translate name
 		final BacktranslatedExpression newVarName = translateExpressionForProgramState(varName);
@@ -599,9 +596,9 @@ public class CACSL2BoogieBacktranslator extends
 			return;
 		}
 		// then, translate values
-		final Collection<Expression> varValues = compressedProgramState.getValues(varName);
+		final Collection<ExpressionOrPointer> varValues = compressedProgramState.getValues(varName);
 		final Collection<BacktranslatedExpression> newVarValues = new ArrayList<>();
-		for (final Expression varValue : varValues) {
+		for (final ExpressionOrPointer varValue : varValues) {
 			final BacktranslatedExpression newVarValue = translateExpressionForProgramState(varValue);
 			if (newVarValue != null) {
 				newVarValues.add(newVarValue);
@@ -618,14 +615,14 @@ public class CACSL2BoogieBacktranslator extends
 	}
 
 	/**
-	 * Replace base and offset with one {@link TemporaryPointerExpression}
+	 * Replace base and offset with one {@link Pointer}
 	 *
 	 * @param programState
 	 *            May not be null
 	 */
-	private ProgramState<Expression> compressProgramState(final ProgramState<Expression> programState) {
+	private ProgramState<ExpressionOrPointer> compressProgramState(final ProgramState<Expression> programState) {
 		final List<Pair<Expression, Collection<Expression>>> oldEntries = new ArrayList<>();
-		final List<Pair<Expression, Collection<Expression>>> newEntries = new ArrayList<>();
+		final List<Pair<ExpressionOrPointer, Collection<ExpressionOrPointer>>> newEntries = new ArrayList<>();
 
 		for (final Expression var : programState.getVariables()) {
 			final Pair<Expression, Collection<Expression>> entry = new Pair<>(var, programState.getValues(var));
@@ -635,27 +632,34 @@ public class CACSL2BoogieBacktranslator extends
 		int x = -1;
 		int y = 0;
 		while (x < y) {
-			// collect all pointer
+			// collect all pointers
 			x = newEntries.size();
 			extractTemporaryPointerExpression(oldEntries, newEntries);
 			y = newEntries.size();
 		}
 
-		newEntries.addAll(oldEntries);
-		final Map<Expression, Collection<Expression>> map = new HashMap<>();
-		for (final Pair<Expression, Collection<Expression>> entry : newEntries) {
-			final Collection<Expression> newValues = entry.getSecond();
-			final Collection<Expression> oldValues = map.put(entry.getFirst(), entry.getSecond());
+		for (final var oldEntry : oldEntries) {
+			final var wrappedValues = oldEntry.getValue().stream().<ExpressionOrPointer> map(WrappedExpression::new)
+					.collect(Collectors.toList());
+			final Pair<ExpressionOrPointer, Collection<ExpressionOrPointer>> wrappedEntry =
+					new Pair<>(new WrappedExpression(oldEntry.getFirst()), wrappedValues);
+			newEntries.add(wrappedEntry);
+		}
+
+		final Map<ExpressionOrPointer, Collection<ExpressionOrPointer>> map = new HashMap<>();
+		for (final Pair<ExpressionOrPointer, Collection<ExpressionOrPointer>> entry : newEntries) {
+			final Collection<ExpressionOrPointer> newValues = entry.getSecond();
+			final Collection<ExpressionOrPointer> oldValues = map.put(entry.getFirst(), entry.getSecond());
 			if (oldValues != null) {
 				newValues.addAll(oldValues);
 			}
 		}
 
-		return new ProgramState<>(map, Expression.class);
+		return new ProgramState<>(map, ExpressionOrPointer.class);
 	}
 
 	private void extractTemporaryPointerExpression(final List<Pair<Expression, Collection<Expression>>> oldEntries,
-			final List<Pair<Expression, Collection<Expression>>> newEntries) {
+			final List<Pair<ExpressionOrPointer, Collection<ExpressionOrPointer>>> newEntries) {
 		for (int i = oldEntries.size() - 1; i >= 0; i--) {
 			final Pair<Expression, Collection<Expression>> entry = oldEntries.get(i);
 
@@ -675,17 +679,16 @@ public class CACSL2BoogieBacktranslator extends
 					if (!isPointerOffsetFor(otherentry.getFirst(), name, isOld)) {
 						continue;
 					}
-					final Expression tmpPointerVar = assemblePointer(entry.getFirst(), otherentry.getFirst(), isOld);
+					final var tmpPointerVar = assemblePointer(entry.getFirst(), otherentry.getFirst(), isOld);
 
 					if (entry.getSecond().size() != 1 || otherentry.getSecond().size() != 1) {
 						reportUnfinishedBacktranslation("Pointers with multiple values");
 					}
 					final var valueBase = DataStructureUtils.getOneAndOnly(entry.getSecond(), "pointer base");
 					final var valueOffset = DataStructureUtils.getOneAndOnly(otherentry.getSecond(), "pointer offset");
-					final TemporaryPointerExpression tmpPointerValue =
-							new TemporaryPointerExpression(entry.getFirst().getLocation(), valueBase, valueOffset);
+					final var tmpPointerValue = new Pointer(entry.getFirst().getLocation(), valueBase, valueOffset);
 
-					final Pair<Expression, Collection<Expression>> newEntry =
+					final Pair<ExpressionOrPointer, Collection<ExpressionOrPointer>> newEntry =
 							new Pair<>(tmpPointerVar, new ArrayList<>());
 					newEntry.getSecond().add(tmpPointerValue);
 					newEntries.add(newEntry);
@@ -725,12 +728,12 @@ public class CACSL2BoogieBacktranslator extends
 		return baseName.substring(0, baseName.length() - SFO.POINTER_BASE.length());
 	}
 
-	private Expression assemblePointer(final Expression base, final Expression offset, final boolean isOld) {
+	private Pointer assemblePointer(final Expression base, final Expression offset, final boolean isOld) {
 		if (isOld) {
-			return new UnaryExpression(base.getLoc(), Operator.OLD,
-					assemblePointer(((UnaryExpression) base).getExpr(), ((UnaryExpression) offset).getExpr(), false));
+			return assemblePointer(((UnaryExpression) base).getExpr(), ((UnaryExpression) offset).getExpr(), false)
+					.asOldExpression();
 		}
-		return new TemporaryPointerExpression(base.getLoc(), base, offset);
+		return new Pointer(base.getLoc(), base, offset);
 	}
 
 	@Override
@@ -912,27 +915,31 @@ public class CACSL2BoogieBacktranslator extends
 		}
 	}
 
-	private BacktranslatedExpression translateExpressionForProgramState(final Expression expression) {
-		// Translate TemporaryPointerExpression properly
-		if (expression instanceof TemporaryPointerExpression) {
-			final TemporaryPointerExpression pointer = (TemporaryPointerExpression) expression;
-			final Expression base = pointer.mBase;
-			if (base instanceof IdentifierExpression) {
-				final IdentifierExpression id = (IdentifierExpression) base;
-				final String name = id.getIdentifier();
-				// If the base is of the form a!base, just translate a accordingly
-				if (name.endsWith(SFO.POINTER_BASE)) {
-					final String originalName = name.substring(0, name.length() - SFO.POINTER_BASE.length() - 1);
-					return translateExpression(new IdentifierExpression(id.getLoc(), id.getType(), originalName,
-							id.getDeclarationInformation()));
-				}
-			}
-			// Otherwise create a value like {base:offset}
-			// This is not a real ACSL-expression, so we wrap it into FakeAcslPointerExpression
-			return new BacktranslatedExpression(
-					new FakeAcslPointerExpression(translateExpression(base), translateExpression(pointer.mOffset)));
+	private BacktranslatedExpression translateExpressionForProgramState(final ExpressionOrPointer expression) {
+		switch (expression) {
+		case final Pointer pointer:
+			final var translated = translatePointer(pointer);
+			return pointer.isOld() ? translated.asOldExpression() : translated;
+		case WrappedExpression(final var expr):
+			return translateExpression(expr);
 		}
-		return translateExpression(expression);
+	}
+
+	private BacktranslatedExpression translatePointer(final Pointer pointer) {
+		if (pointer.base() instanceof final IdentifierExpression id) {
+			final String name = id.getIdentifier();
+			// If the base is of the form a!base, just translate a accordingly
+			if (name.endsWith(SFO.POINTER_BASE)) {
+				final String originalName = name.substring(0, name.length() - SFO.POINTER_BASE.length() - 1);
+				return translateExpression(new IdentifierExpression(id.getLoc(), id.getType(), originalName,
+						id.getDeclarationInformation()));
+			}
+		}
+		// Otherwise create a value like {base:offset}
+		// This is not a real ACSL-expression, so we wrap it into FakePointerExpression
+		return new BacktranslatedExpression(
+				new FakePointerExpression(translateExpression(pointer.base()).getExpression(),
+						translateExpression(pointer.offset()).getExpression()));
 	}
 
 	@Override
@@ -1109,59 +1116,22 @@ public class CACSL2BoogieBacktranslator extends
 		}
 	}
 
-	private static class TemporaryPointerExpression extends Expression {
-
-		private static final long serialVersionUID = 1L;
-		private final Expression mBase;
-		private final Expression mOffset;
-
-		public TemporaryPointerExpression(final ILocation loc, final Expression base, final Expression offset) {
-			super(loc);
-			mBase = base;
-			mOffset = offset;
-		}
-
-		@Override
-		public String toString() {
-			return mBase.toString() + " " + mOffset.toString();
-		}
-
-		@Override
-		public void accept(final GeneratedBoogieAstVisitor visitor) {
-			// nothing to accept here
-		}
-
-		@Override
-		public Expression accept(final GeneratedBoogieAstTransformer visitor) {
-			return null;
-		}
+	private sealed interface ExpressionOrPointer permits WrappedExpression, Pointer {
+		// empty
 	}
 
-	private static class FakeAcslPointerExpression
-			extends de.uni_freiburg.informatik.ultimate.model.acsl.ast.Expression {
-		private final BacktranslatedExpression mBase;
-		private final BacktranslatedExpression mOffset;
+	private record WrappedExpression(Expression expr) implements ExpressionOrPointer {
+		// empty
+	}
 
-		public FakeAcslPointerExpression(final BacktranslatedExpression base, final BacktranslatedExpression offset) {
-			mBase = base;
-			mOffset = offset;
+	private record Pointer(ILocation loc, Expression base, Expression offset, boolean isOld)
+			implements ExpressionOrPointer {
+		public Pointer(final ILocation loc, final Expression base, final Expression offset) {
+			this(loc, base, offset, false);
 		}
 
-		@Override
-		public String toString() {
-			return "{" + mBase + ":" + mOffset + "}";
+		public Pointer asOldExpression() {
+			return new Pointer(loc, base, offset, true);
 		}
-
-		@Override
-		public void accept(final ACSLVisitor visitor) {
-			// nothing to accept here
-
-		}
-
-		@Override
-		public de.uni_freiburg.informatik.ultimate.model.acsl.ast.Expression accept(final ACSLTransformer visitor) {
-			return null;
-		}
-
 	}
 }


### PR DESCRIPTION
This PR changes the `ASTBuilder` such that it marks the generated AST classes as `sealed` (for abstract supertypes such as `Expression`) resp. `final` (for concrete classes such as `IdentifierExpression`).

The intent is to have a precise, complete and closed description of the elements that can make up an AST. As a major consequence, this enables exhaustiveness checks for pattern matching! Code can now switch over all types of e.g. Boogie expressions like this:
```java
switch (expr) {
case IdentifierExpression idExpr -> ...
case BooleanLiteral boolLit -> ...
... (more cases) ...
}
```
**without needing to include a `default` case**, as the compiler can be sure whether or not all cases are handled. This doesn't just get rid of an annoying line of code, it will also have the benefit that if new AST classes are added, the compiler immediately reports all the case distinctions where the new classes must be handled -- rather than silently going to the `default` and crashing (or worse, behaving incorrectly) at runtime.

My hope is that such pattern matching can be particularly useful when (back-)translating between C, ACSL, Boogie and SMT. I was fiddling around in the `IcfgBuilder` code when I had this idea; there are several places there that could benefit from pattern matching.

## Other Changes
To make this change work, I had to get rid of two hand-written classes that extend the Boogie resp. ACSL expressions and were used in backtranslation. One of them is now in the  official ACSL AST (as the backtranslation creates instances that are passed on to other code), the other no longer extends the Boogie AST.

## Limitations
I stopped short of even more pattern-matching support by making the classes records -- this would be a more complex change:
- Records cannot have superclasses (other than `java.lang.Record`). So we would have to replace abstract base classes like `Expression` with (sealed) interfaces. Some functionality could be implemented in those interfaces with default methods, but all fields would have to be generated in each concrete implementation.
- Records can only have immutable fields, and our AST classes have some write-once fields particularly for the `ILocation`. These cannot easily be made final because the object graph is cyclic -- the node points to the location, and the location points to the node.

As there seem to be some plans to support better pattern matching for (non-record) classes in future Java versions, perhaps the goal of better AST pattern matching can then be achieved in an easier way.