### PR TITLE
Add auxiliary attribute to labels

### DIFF
--- a/trunk/examples/programs/regression/bpl/toolDirectives/LabelsWithAttributes.bpl
+++ b/trunk/examples/programs/regression/bpl/toolDirectives/LabelsWithAttributes.bpl
@@ -9,7 +9,7 @@ modifies;
 {
   var x : int;
   assume x == 0;
-  MyLabel  { :keyA "valueA1", "valueA2"} { :auxiliary_label true} { :keyB "valueB"} :
+  MyLabel  { :keyA "valueA1", "valueA2"} { :auxiliary_label } { :keyB "valueB"} :
   assert(x == 0);
 
 }

--- a/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/UnstructureCode.java
+++ b/trunk/source/BoogiePreprocessor/src/de/uni_freiburg/informatik/ultimate/boogie/preprocessor/UnstructureCode.java
@@ -35,6 +35,7 @@ import java.util.ListIterator;
 import java.util.Set;
 import java.util.Stack;
 
+import de.uni_freiburg.informatik.ultimate.boogie.BoogieUtils;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
@@ -144,7 +145,7 @@ public class UnstructureCode extends BaseObserver {
 		mReachable = true;
 		mBreakStack = new Stack<>();
 		// TODO: Add label as "do not backtranslate"?
-		addLabel(new Label(proc.getLocation(), generateLabel()));
+		addLabel(BoogieUtils.constuctAuxiliaryLabel(proc.getLocation(), generateLabel()));
 
 		/* Transform the procedure block */
 		unstructureBlock(body.getBlock());
@@ -210,7 +211,7 @@ public class UnstructureCode extends BaseObserver {
 				 * Create break label unless no break occurred or we reused existing label
 				 */
 				if (!reusedLabel && currentBI.destLabel != null) {
-					addLabel(new Label(s.getLocation(), currentBI.destLabel));
+					addLabel(BoogieUtils.constuctAuxiliaryLabel(s.getLocation(), currentBI.destLabel));
 					mReachable = true;
 				}
 				currentBI.clear();
@@ -280,7 +281,7 @@ public class UnstructureCode extends BaseObserver {
 
 			postCreateStatement(origStmt, new GotoStatement(origStmt.getLocation(), new String[] { body, done }),
 					false);
-			postCreateStatement(origStmt, new Label(origStmt.getLocation(), body), false);
+			postCreateStatement(origStmt, BoogieUtils.constuctAuxiliaryLabel(origStmt.getLocation(), body), false);
 			if (stmt.getCondition() instanceof WildcardExpression) {
 				final AssumeStatement newCondStmt = new AssumeStatement(stmt.getLocation(),
 						new BooleanLiteral(stmt.getCondition().getLocation(), BoogieType.TYPE_BOOL, true));
@@ -299,7 +300,7 @@ public class UnstructureCode extends BaseObserver {
 			mReachable = false;
 
 			if (!(stmt.getCondition() instanceof WildcardExpression)) {
-				postCreateStatement(origStmt, new Label(origStmt.getLocation(), done), false);
+				postCreateStatement(origStmt, BoogieUtils.constuctAuxiliaryLabel(origStmt.getLocation(), done), false);
 				final AssumeStatement negatedCondStmt =
 						new AssumeStatement(stmt.getLocation(), new UnaryExpression(stmt.getCondition().getLocation(),
 								BoogieType.TYPE_BOOL, UnaryExpression.Operator.LOGICNEG, stmt.getCondition()));
@@ -322,7 +323,7 @@ public class UnstructureCode extends BaseObserver {
 			final String elseLabel = generateLabel();
 			postCreateStatement(origStmt, new GotoStatement(stmt.getLocation(), new String[] { thenLabel, elseLabel }),
 					true);
-			postCreateStatement(origStmt, new Label(origStmt.getLocation(), thenLabel), true);
+			postCreateStatement(origStmt, BoogieUtils.constuctAuxiliaryLabel(origStmt.getLocation(), thenLabel), true);
 			if (!(stmt.getCondition() instanceof WildcardExpression)) {
 				postCreateStatementFromCond(origStmt, new AssumeStatement(stmt.getLocation(), stmt.getCondition()),
 						false, true);
@@ -336,7 +337,7 @@ public class UnstructureCode extends BaseObserver {
 						new GotoStatement(origStmt.getLocation(), new String[] { outer.destLabel }), true);
 			}
 			mReachable = true;
-			postCreateStatement(origStmt, new Label(origStmt.getLocation(), elseLabel), true);
+			postCreateStatement(origStmt, BoogieUtils.constuctAuxiliaryLabel(origStmt.getLocation(), elseLabel), true);
 			if (!(stmt.getCondition() instanceof WildcardExpression)) {
 				postCreateStatementFromCond(origStmt,
 						new AssumeStatement(stmt.getLocation(), new UnaryExpression(stmt.getCondition().getLocation(),

--- a/trunk/source/BoogieProcedureInliner/src/de/uni_freiburg/informatik/ultimate/boogie/procedureinliner/BoogieCopyTransformer.java
+++ b/trunk/source/BoogieProcedureInliner/src/de/uni_freiburg/informatik/ultimate/boogie/procedureinliner/BoogieCopyTransformer.java
@@ -120,7 +120,7 @@ public class BoogieCopyTransformer extends BoogieTransformer {
 			yield new AtomicStatement(atomicstmt.getLocation(), newBody);
 		}
 		case final BreakStatement bs -> new BreakStatement(bs.getLocation(), bs.getLabel());
-		case final Label label -> new Label(label.getLocation(), label.getName());
+		case final Label label -> new Label(label.getLocation(), label.getName(), label.getAttributes());
 		case final ReturnStatement rs -> new ReturnStatement(rs.getLocation());
 		case final GotoStatement gs -> new GotoStatement(gs.getLocation(), gs.getLabels());
 		case final ForkStatement forkstmt -> {

--- a/trunk/source/BoogieProcedureInliner/src/de/uni_freiburg/informatik/ultimate/boogie/procedureinliner/InlineVersionTransformer.java
+++ b/trunk/source/BoogieProcedureInliner/src/de/uni_freiburg/informatik/ultimate/boogie/procedureinliner/InlineVersionTransformer.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.uni_freiburg.informatik.ultimate.boogie.BoogieUtils;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation.StorageClass;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
@@ -956,7 +957,7 @@ public class InlineVersionTransformer extends BoogieCopyTransformer {
 			inlinedBody.addAll(flattenStatements(block));
 
 			// insert end label (ReturnStatements are inlined as jumps to this label)
-			final Label returnLabel = new Label(proc.getLocation(), getCurrentReturnLabelId());
+			final Label returnLabel = BoogieUtils.constuctAuxiliaryLabel(proc.getLocation(), getCurrentReturnLabelId());
 			addBacktranslation(returnLabel, null);
 			inlinedBody.add(returnLabel);
 
@@ -1091,7 +1092,8 @@ public class InlineVersionTransformer extends BoogieCopyTransformer {
 		Statement newStat = null;
 		if (stat instanceof Label) {
 			final Label label = (Label) stat;
-			newStat = new Label(label.getLocation(), getNewLabelId(label.getName()), label.getAttributes());
+			newStat = BoogieUtils.constuctAuxiliaryLabel(label.getLocation(), getNewLabelId(label.getName()),
+					label.getAttributes());
 		} else if (stat instanceof GotoStatement) {
 			final GotoStatement gotoStat = (GotoStatement) stat;
 			final String[] labelIds = gotoStat.getLabels();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -147,10 +147,8 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.GotoStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.HavocStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IfStatement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Label;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.LeftHandSide;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.LoopInvariantSpecification;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedAttribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedType;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.PrimitiveType;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
@@ -2026,10 +2024,6 @@ public class CHandler {
 		final ArrayList<Statement> stmt = new ArrayList<>();
 		final ArrayList<Declaration> decl = new ArrayList<>();
 		final List<Overapprox> overappr = new ArrayList<>();
-		final String label = node.getName().toString();
-		// Mark the label with the attribute { :auxiliary_label false}
-		stmt.add(new Label(loc, label,
-				new NamedAttribute[] { BoogieUtils.constructAuxiliaryLabelAttribute(loc, false) }));
 		final Result r = main.dispatch(node.getNestedStatement());
 		if (r instanceof ExpressionResult) {
 			final ExpressionResult res = (ExpressionResult) r;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -147,6 +147,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.GotoStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.HavocStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IfStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.Label;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.LeftHandSide;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.LoopInvariantSpecification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedType;
@@ -2024,6 +2025,8 @@ public class CHandler {
 		final ArrayList<Statement> stmt = new ArrayList<>();
 		final ArrayList<Declaration> decl = new ArrayList<>();
 		final List<Overapprox> overappr = new ArrayList<>();
+		final String label = node.getName().toString();
+		stmt.add(new Label(loc, label));
 		final Result r = main.dispatch(node.getNestedStatement());
 		if (r instanceof ExpressionResult) {
 			final ExpressionResult res = (ExpressionResult) r;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -122,6 +122,7 @@ import org.eclipse.cdt.core.dom.ast.gnu.c.ICASTKnRFunctionDeclarator;
 import org.eclipse.cdt.internal.core.dom.parser.c.ICInternalBinding;
 
 import de.uni_freiburg.informatik.ultimate.boogie.BoogieIdExtractor;
+import de.uni_freiburg.informatik.ultimate.boogie.BoogieUtils;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation.StorageClass;
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
@@ -1521,7 +1522,7 @@ public class CHandler {
 		final String loopLabel = hasContinue ? mNameHandler.getGloballyUniqueIdentifier(SFO.LOOPLABEL) : null;
 		handleLoopBody(loc, main, node.getBody(), loopLabel, resultBuilder, bodyBlock);
 		if (hasContinue) {
-			bodyBlock.add(new Label(loc, loopLabel));
+			bodyBlock.add(BoogieUtils.constuctAuxiliaryLabel(loc, loopLabel));
 		}
 		final ExpressionResult cond = dispatchLoopCondition(main, node.getCondition(), loc);
 		resultBuilder.addDeclarations(cond.getDeclarations());
@@ -1609,7 +1610,7 @@ public class CHandler {
 		final String loopLabel = hasContinue ? mNameHandler.getGloballyUniqueIdentifier(SFO.LOOPLABEL) : null;
 		handleLoopBody(loc, main, node.getBody(), loopLabel, resultBuilder, bodyBlock);
 		if (hasContinue) {
-			bodyBlock.add(new Label(loc, loopLabel));
+			bodyBlock.add(BoogieUtils.constuctAuxiliaryLabel(loc, loopLabel));
 		}
 
 		// Insert the translated iterator at the end of the loop (after the loop label)
@@ -2027,8 +2028,8 @@ public class CHandler {
 		final List<Overapprox> overappr = new ArrayList<>();
 		final String label = node.getName().toString();
 		// Mark the label with the attribute { :auxiliary_label false}
-		stmt.add(new Label(loc, label, new NamedAttribute[] { new NamedAttribute(loc, "auxiliary_label",
-				new Expression[] { ExpressionFactory.createBooleanLiteral(loc, false) }) }));
+		stmt.add(new Label(loc, label,
+				new NamedAttribute[] { BoogieUtils.constructAuxiliaryLabelAttribute(loc, false) }));
 		final Result r = main.dispatch(node.getNestedStatement());
 		if (r instanceof ExpressionResult) {
 			final ExpressionResult res = (ExpressionResult) r;
@@ -2500,7 +2501,7 @@ public class CHandler {
 		}
 		checkForACSL(main, resultBuilder, null, node, true);
 
-		resultBuilder.addStatement(new Label(loc, breakLabelName));
+		resultBuilder.addStatement(BoogieUtils.constuctAuxiliaryLabel(loc, breakLabelName));
 		resultBuilder.addStatements(CTranslationUtil.createHavocsForAuxVars(resultBuilder.getAuxVars()));
 
 		// Use body as hook: This is the scope holder for switch statements! (as controller expression is child of the
@@ -2675,7 +2676,7 @@ public class CHandler {
 		final String loopLabel = hasContinue ? mNameHandler.getGloballyUniqueIdentifier(SFO.LOOPLABEL) : null;
 		final List<Statement> bodyBlock = new ArrayList<>();
 		if (hasContinue) {
-			bodyBlock.add(new Label(loc, loopLabel));
+			bodyBlock.add(BoogieUtils.constuctAuxiliaryLabel(loc, loopLabel));
 		}
 		final ExpressionResult cond = dispatchLoopCondition(main, node.getCondition(), loc);
 		final Expression loopCond;

--- a/trunk/source/ChcToBoogie/src/de/uni_freiburg/informatik/ultimate/plugins/chctoboogie/GenerateGotoBoogieAst.java
+++ b/trunk/source/ChcToBoogie/src/de/uni_freiburg/informatik/ultimate/plugins/chctoboogie/GenerateGotoBoogieAst.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.uni_freiburg.informatik.ultimate.boogie.BoogieUtils;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation;
 import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation.StorageClass;
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
@@ -137,7 +138,7 @@ public class GenerateGotoBoogieAst {
 			// generate the labels
 			// for (final HcPredicateSymbol predSym : mChcInfo.getHornClausesSorted().getDomain()) {
 			for (final HcPredicateSymbol predSym : mChcInfo.getAllReachablePredSymbols()) {
-				final Label label = new Label(loc, mHelper.predSymToMethodName(predSym));
+				final Label label = BoogieUtils.constuctAuxiliaryLabel(loc, mHelper.predSymToMethodName(predSym));
 				final Integer number = predsymCounter;
 				predsymCounter++;
 				predSymbolToLabel.put(predSym, label);

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/BoogieUtils.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/BoogieUtils.java
@@ -26,6 +26,7 @@
  */
 package de.uni_freiburg.informatik.ultimate.boogie;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,23 +36,57 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BreakStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ForkStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.GotoStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.HavocStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IfStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.JoinStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Label;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedAttribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ReturnStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.WhileStatement;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 
 /**
  * Provides static auxiliary methods for Boogie.
  */
 public class BoogieUtils {
 
+	private static final String AUXILIARY_LABEL = "auxiliary_label";
+
 	private BoogieUtils() {
 		// Prevent instantiation of this utility class
+	}
+
+	/**
+	 * Construct the attribute that we use to indicate whether a label is an auxiliary label. Auxiliary labels are
+	 * labels that do not represent labels in the original (input) program but were introduced by our translations.
+	 *
+	 * @param loc
+	 *            {@link ILocation} of the {@link Label} to which this attribute will be added.
+	 */
+	public static NamedAttribute constructAuxiliaryLabelAttribute(final ILocation loc, final boolean isAuxiliary) {
+		return new NamedAttribute(loc, AUXILIARY_LABEL,
+				new Expression[] { ExpressionFactory.createBooleanLiteral(loc, isAuxiliary) });
+	}
+
+	/**
+	 * Construct {@link Label} and add attribute that indicates that this label is an auxiliary label.
+	 */
+	public static Label constuctAuxiliaryLabel(final ILocation loc, final String name) {
+		return new Label(loc, name, new NamedAttribute[] { constructAuxiliaryLabelAttribute(loc, true) });
+	}
+
+	/**
+	 * Construct {@link Label} and append an attribute that indicates that this label is an auxiliary label.
+	 */
+	public static Label constuctAuxiliaryLabel(final ILocation loc, final String name,
+			final NamedAttribute[] attributes) {
+		final NamedAttribute[] newAttributes = Arrays.copyOf(attributes, attributes.length + 1);
+		newAttributes[attributes.length] = constructAuxiliaryLabelAttribute(loc, true);
+		return new Label(loc, name, newAttributes);
 	}
 
 	/**

--- a/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/BoogieUtils.java
+++ b/trunk/source/Library-BoogieAST/src/de/uni_freiburg/informatik/ultimate/boogie/BoogieUtils.java
@@ -67,16 +67,15 @@ public class BoogieUtils {
 	 * @param loc
 	 *            {@link ILocation} of the {@link Label} to which this attribute will be added.
 	 */
-	public static NamedAttribute constructAuxiliaryLabelAttribute(final ILocation loc, final boolean isAuxiliary) {
-		return new NamedAttribute(loc, AUXILIARY_LABEL,
-				new Expression[] { ExpressionFactory.createBooleanLiteral(loc, isAuxiliary) });
+	public static NamedAttribute constructAuxiliaryLabelAttribute(final ILocation loc) {
+		return new NamedAttribute(loc, AUXILIARY_LABEL, new Expression[0]);
 	}
 
 	/**
 	 * Construct {@link Label} and add attribute that indicates that this label is an auxiliary label.
 	 */
 	public static Label constuctAuxiliaryLabel(final ILocation loc, final String name) {
-		return new Label(loc, name, new NamedAttribute[] { constructAuxiliaryLabelAttribute(loc, true) });
+		return new Label(loc, name, new NamedAttribute[] { constructAuxiliaryLabelAttribute(loc) });
 	}
 
 	/**
@@ -85,7 +84,7 @@ public class BoogieUtils {
 	public static Label constuctAuxiliaryLabel(final ILocation loc, final String name,
 			final NamedAttribute[] attributes) {
 		final NamedAttribute[] newAttributes = Arrays.copyOf(attributes, attributes.length + 1);
-		newAttributes[attributes.length] = constructAuxiliaryLabelAttribute(loc, true);
+		newAttributes[attributes.length] = constructAuxiliaryLabelAttribute(loc);
 		return new Label(loc, name, newAttributes);
 	}
 


### PR DESCRIPTION
Add auxiliary attribute to all Boogie labels that are auxiliary labels (an auxiliary label is a label that does not represent a label of the original program but is introduced by our translations).

I ommited `DSITransformer` and `Cookiefy` since I am not familiar with these projects.