### PR TITLE
Let BlockEncoder throw ToolchainCanceledExceptions

### DIFF
--- a/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/BlockEncoder.java
+++ b/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/BlockEncoder.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import de.uni_freiburg.informatik.ultimate.core.lib.exceptions.ToolchainCanceledException;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.BuchiProgramAcceptingStateAnnotation;
-import de.uni_freiburg.informatik.ultimate.core.lib.results.TimeoutResult;
 import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceProvider;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
@@ -188,9 +188,10 @@ public final class BlockEncoder {
 					break;
 				}
 				if (!mServices.getProgressMonitorService().continueProcessing()) {
-					mServices.getResultService().reportResult(Activator.PLUGIN_ID,
-							new TimeoutResult(Activator.PLUGIN_ID, "Timeout during SBE block encoding"));
-					return;
+					final int inputlocations = IcfgUtils.getNumberOfLocations(node);
+					final String message =
+							String.format("applying SBE block encoding to ICFG that has %s locations", inputlocations);
+					throw new ToolchainCanceledException(BlockEncoder.class, message);
 				}
 			}
 			mLogger.info("SBE split " + removedEdges + " edges");
@@ -212,9 +213,10 @@ public final class BlockEncoder {
 			mIterationResult = currentResult.getIcfg();
 
 			if (!mServices.getProgressMonitorService().continueProcessing()) {
-				mServices.getResultService().reportResult(Activator.PLUGIN_ID,
-						new TimeoutResult(Activator.PLUGIN_ID, "Timeout during block encoding"));
-				return;
+				final int inputlocations = IcfgUtils.getNumberOfLocations(node);
+				final String message =
+						String.format("applying block encoding to ICFG that has %s locations", inputlocations);
+				throw new ToolchainCanceledException(BlockEncoder.class, message);
 			}
 
 			if (!optimizeUntilFixpoint || !currentResult.isChanged() || maxIters == 0) {

--- a/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/BlockEncoder.java
+++ b/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/BlockEncoder.java
@@ -38,6 +38,7 @@ import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.BasicIcfg;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.CfgSmtToolkit;
+import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.IcfgUtils;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IIcfg;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdge;
 import de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils.cfg.structure.IcfgEdgeBuilder;


### PR DESCRIPTION
Timeouts should be handled by the ToolchainWalker or by whoever catches the ToolchainCanceledException. If the BlockEncoder just sends a TimeoutResult to the IResultService it is difficult to use this class in other plugins.