### PR TITLE
Fix nondeterminism bug in BlockEncodingV2

### DIFF
--- a/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/encoding/MinimizeStatesMultiEdgeMultiNode.java
+++ b/trunk/source/BlockEncodingV2/src/de/uni_freiburg/informatik/ultimate/plugins/blockencoding/encoding/MinimizeStatesMultiEdgeMultiNode.java
@@ -113,7 +113,7 @@ public class MinimizeStatesMultiEdgeMultiNode extends BaseMinimizeStates {
 
 		final Set<IcfgEdge> toRemove = new HashSet<>();
 		final Set<IcfgLocation> openLocations = new HashSet<>();
-		final Set<EdgeConstructor> constructors = new HashSet<>();
+		final List<EdgeConstructor> constructors = new ArrayList<>();
 		int addE = 0;
 		for (final Pair<IcfgEdge, IcfgEdge> pair : pairs) {
 			final IcfgEdge first = pair.getFirst();


### PR DESCRIPTION
Implemented fix: HashSet<EdgeConstructor> constructors becomes ArrayList<EdgeConstructor>
Considered alternative: Give EdgeConstructor proper hashCode and equals methods. However, it seems to me that MinimizeStatesMultiEdgeMultiNode#getEdgePairs which provides the elements for constructors ensures that there is only one EdgeConstructor per edge pair.