### PR TITLE
Bugfix: Insert continue label before loop

### DIFF
--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -2714,7 +2714,10 @@ public class CHandler {
 		final String loopLabel = hasContinue ? mNameHandler.getGloballyUniqueIdentifier(SFO.LOOPLABEL) : null;
 		final List<Statement> bodyBlock = new ArrayList<>();
 		if (hasContinue) {
-			bodyBlock.add(BoogieUtils.constuctAuxiliaryLabel(loc, loopLabel));
+			// If there is a continue, we need to insert an additional label to jump to.
+			// We insert this label right before the actual loop in order to produce the correct invariant and to check
+			// an existing invariant correctly (if any).
+			resultBuilder.addStatement(BoogieUtils.constuctAuxiliaryLabel(loc, loopLabel));
 		}
 		final ExpressionResult cond = dispatchLoopCondition(main, node.getCondition(), loc);
 		final Expression loopCond;


### PR DESCRIPTION
When translating while loops that have a continue, we need an additional label (since Boogie does not have a continue statement). Previously, this label was inserted at the beginning of the loop. However, since we want calculate the correct invariant also for continues and we also want to check an invariant after a continue, the label is inserted just before the loop.