### PR TITLE
Add setting whether ACSL assertions should be checked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ trunk/examples/concurrent/bpl/weaver-benchmarks/weaver
 /trunk/source/.sonarlint/*
 /trunk/source/*.log
 
+/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/ACSLProblemNode.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/ACSLResultExpression.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/ACSLTransformer.java
 /trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/ACSLType.java

--- a/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
+++ b/trunk/source/ACSLParser/src/de/uni_freiburg/informatik/ultimate/model/acsl/ast/acsl.ast
@@ -261,3 +261,6 @@ ACSLType ::=
 Declaration ::=
 	type : ACSLType
 	name : String;
+
+ACSLProblemNode ::=
+	errorMessage : String;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/ACSLHandler.java
@@ -95,6 +95,7 @@ import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Overapprox
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Spec;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLProblemNode;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLResultExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ArrayAccessExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Assertion;
@@ -950,4 +951,9 @@ public class ACSLHandler implements IACSLHandler {
 						CPointer.voidPointer()));
 	}
 
+	@Override
+	public Result visit(final IDispatcher main, final ACSLProblemNode node) {
+		final ILocation loc = mLocationFactory.createACSLLocation(node);
+		throw new UnsupportedSyntaxException(loc, "Error during parsing of ACSL (" + node.getErrorMessage() + ")");
+	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -2570,7 +2570,7 @@ public class CHandler {
 				throw new UnsupportedOperationException("Not yet implemented " + preS.toString());
 			}
 		}
-		if (!mIsPrerun) {
+		if (!mIsPrerun && mSettings.checkAcsl()) {
 			mAcsl = main.nextACSLStatement();
 
 			final ExpressionResultBuilder acslResultBuilder = new ExpressionResultBuilder();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/MainDispatcher.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/MainDispatcher.java
@@ -113,6 +113,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.IT
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLProblemNode;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLResultExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ArrayAccessExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Assigns;
@@ -327,6 +328,7 @@ public class MainDispatcher implements IDispatcher {
 		case final LoopAssigns loopAss -> mAcslHandler.visit(this, loopAss);
 		case final LoopAnnot loopAnnot -> mAcslHandler.visit(this, loopAnnot);
 		case final NullPointer np -> mAcslHandler.visit(this, np);
+		case final ACSLProblemNode problem -> mAcslHandler.visit(this, problem);
 		default -> mAcslHandler.visit(this, n);
 		};
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TranslationSettings.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TranslationSettings.java
@@ -69,6 +69,7 @@ public final class TranslationSettings {
 	private final String mEntryFunction;
 	private final boolean mCheckErrorFunction;
 	private final boolean mCheckAssertions;
+	private final boolean mCheckAcsl;
 	private final boolean mIsSvcompMemtrackCompatibilityMode;
 	private final boolean mCheckAllocationPurity;
 	private final boolean mCheckMemoryLeakInMain;
@@ -93,6 +94,7 @@ public final class TranslationSettings {
 		mCheckMemoryLeakInMain = ups.getBoolean(CACSLPreferenceInitializer.LABEL_CHECK_MEMORY_LEAK_IN_MAIN);
 
 		mCheckAssertions = ups.getBoolean(CACSLPreferenceInitializer.LABEL_CHECK_ASSERTIONS);
+		mCheckAcsl = ups.getBoolean(CACSLPreferenceInitializer.LABEL_CHECK_ACSL);
 		mEntryFunction = ups.getString(CACSLPreferenceInitializer.MAINPROC_LABEL);
 		mCheckErrorFunction = ups.getBoolean(CACSLPreferenceInitializer.LABEL_ERROR);
 		mSmtBoolArraysWorkaround = ups.getBoolean(CACSLPreferenceInitializer.LABEL_SMT_BOOL_ARRAYS_WORKAROUND);
@@ -137,7 +139,7 @@ public final class TranslationSettings {
 			final boolean checkIfFreedPointerIsValid, final CheckMode checkPointerDerefValidity,
 			final CheckMode checkPointerSubtractionAndComparisonValidity, final MemoryModel memoryModelPreference,
 			final boolean fpToIeeeBvExtension, final boolean smtBoolArraysWorkaround, final String entryFunction,
-			final boolean checkErrorFunction, final boolean checkAssertions,
+			final boolean checkErrorFunction, final boolean checkAssertions, final boolean checkAcsl,
 			final boolean isSvcompMemtrackCompatibilityMode, final boolean checkAllocationPurity,
 			final boolean checkMemoryLeakInMain, final CheckMode checkSignedIntegerBounds, final boolean checkDataRaces,
 			final boolean useConstantArrays, final boolean useStoreChains, final boolean enableFesetround,
@@ -160,6 +162,7 @@ public final class TranslationSettings {
 		mEntryFunction = entryFunction;
 		mCheckErrorFunction = checkErrorFunction;
 		mCheckAssertions = checkAssertions;
+		mCheckAcsl = checkAcsl;
 		mIsSvcompMemtrackCompatibilityMode = isSvcompMemtrackCompatibilityMode;
 		mCheckAllocationPurity = checkAllocationPurity;
 		mCheckMemoryLeakInMain = checkMemoryLeakInMain;
@@ -247,6 +250,10 @@ public final class TranslationSettings {
 		return mCheckAssertions;
 	}
 
+	public boolean checkAcsl() {
+		return mCheckAcsl;
+	}
+
 	public boolean isSvcompMemtrackCompatibilityMode() {
 		return mIsSvcompMemtrackCompatibilityMode;
 	}
@@ -308,7 +315,7 @@ public final class TranslationSettings {
 				mBitvectorTranslation, mOverapproximateFloatingPointOperations, mBitpreciseBitfields, mInRange,
 				mPointerIntegerConversion, mCheckIfFreedPointerIsValid, mCheckPointerDerefValidity,
 				mCheckPointerSubtractionAndComparisonValidity, memoryModel, mFpToIeeeBvExtension,
-				mSmtBoolArraysWorkaround, mEntryFunction, mCheckErrorFunction, mCheckAssertions,
+				mSmtBoolArraysWorkaround, mEntryFunction, mCheckErrorFunction, mCheckAssertions, mCheckAcsl,
 				mIsSvcompMemtrackCompatibilityMode, mCheckAllocationPurity, mCheckMemoryLeakInMain,
 				mCheckSignedIntegerBounds, mCheckDataRaces, mUseConstantArrays, mUseStoreChains, mEnableFesetround,
 				mInitialRoundingMode, mAdaptMemoryModelResolutionOnPointerCasts, mStringOverapproximationThreshold,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/IACSLHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/IACSLHandler.java
@@ -35,6 +35,7 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.IDispatcher;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.Result;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLProblemNode;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLResultExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ArrayAccessExpression;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ast.Assigns;
@@ -350,4 +351,6 @@ public interface IACSLHandler {
 	 * @return a result object
 	 */
 	Result visit(IDispatcher main, ACSLNode node);
+
+	Result visit(IDispatcher main, ACSLProblemNode node);
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/preferences/CACSLPreferenceInitializer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/plugins/generator/cacsl2boogietranslator/preferences/CACSLPreferenceInitializer.java
@@ -64,6 +64,10 @@ public class CACSLPreferenceInitializer extends UltimatePreferenceInitializer {
 					+ "If this assumption does not hold, the analysis becomes unsound — not just for this property, "
 					+ "but for other properties as well. If set to IGNORE, the analyzer performs no checks and makes "
 					+ "no assumptions regarding the validity of memory accesses through pointers or arrays.";
+	public static final String LABEL_CHECK_ACSL = "Check ACSL annotations";
+	private static final String DESC_CHECK_ACSL =
+			"Check if the annotations in ACSL (assert, loop invariant, function contracts) are valid. "
+					+ "In addition, ghost code is also considered.";
 	public static final String LABEL_CHECK_FREE_VALID = "Check if freed pointer was valid";
 	public static final String LABEL_CHECK_MEMORY_LEAK_IN_MAIN =
 			"Check for the main procedure if all allocated memory was freed";
@@ -276,6 +280,7 @@ public class CACSLPreferenceInitializer extends UltimatePreferenceInitializer {
 								PreferenceType.String),
 						new UltimatePreferenceItem<>(LABEL_CHECK_ASSERTIONS, false, DESC_CHECK_ASSERTIONS,
 								PreferenceType.Boolean),
+						new UltimatePreferenceItem<>(LABEL_CHECK_ACSL, true, DESC_CHECK_ACSL, PreferenceType.Boolean),
 						new UltimatePreferenceItem<>(LABEL_CHECK_POINTER_DEREF_VALIDITY, CheckMode.CHECK,
 								DESC_CHECK_POINTER_DEREF_VALIDITY, PreferenceType.Combo, CheckMode.values()),
 						new UltimatePreferenceItem<>(LABEL_CHECK_FREE_VALID, true, PreferenceType.Boolean),

--- a/trunk/source/CDTParser/src/de/uni_freiburg/informatik/ultimate/cdt/CommentParser.java
+++ b/trunk/source/CDTParser/src/de/uni_freiburg/informatik/ultimate/cdt/CommentParser.java
@@ -45,12 +45,11 @@ import org.eclipse.cdt.core.dom.ast.IASTFileLocation;
 
 import de.uni_freiburg.informatik.ultimate.acsl.parser.ACSLSyntaxErrorException;
 import de.uni_freiburg.informatik.ultimate.acsl.parser.Parser;
-import de.uni_freiburg.informatik.ultimate.cdt.parser.Activator;
-import de.uni_freiburg.informatik.ultimate.core.lib.results.SyntaxErrorResult;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
 import de.uni_freiburg.informatik.ultimate.model.acsl.ACSLNode;
+import de.uni_freiburg.informatik.ultimate.model.acsl.ast.ACSLProblemNode;
 
 /**
  * @author Markus Lindenmann
@@ -134,9 +133,10 @@ public class CommentParser {
 						acslList.add(acslNode);
 					}
 				} catch (final ACSLSyntaxErrorException e) {
-					final ACSLNode node = e.getLocation();
-					node.setFileName(comment.getFileLocation().getFileName());
-					reportSyntaxError(node, e.getMessageText());
+					final ACSLProblemNode problem = new ACSLProblemNode(e.getMessageText());
+					problem.setFileName(comment.getContainingFilename());
+					problem.setLocation(e.getLocation().getLocation());
+					acslList.add(problem);
 				} catch (final Exception e) {
 					throw new RuntimeException(e);
 				}
@@ -186,14 +186,6 @@ public class CommentParser {
 			}
 		}
 		return "gstart";
-	}
-
-	private void reportSyntaxError(final ACSLNode node, final String msg) {
-		final ILocation loc = new SimpleAcslLocation(node);
-		final SyntaxErrorResult result = new SyntaxErrorResult(Activator.PLUGIN_NAME, loc, msg);
-		mLogger.warn(msg);
-		mServices.getResultService().reportResult(Activator.PLUGIN_ID, result);
-		mServices.getProgressMonitorService().cancelToolchain();
 	}
 
 	private static final class SimpleAcslLocation implements ILocation {


### PR DESCRIPTION
This PR adds a setting for `CACSL2BoogieTranslator` (in the group "specification") whether ACSL assertions should be checked or not. For compatibility, I enabled this setting by default, as previously ACSL was always checked.
Note: For now, we still parse ACSL even if the setting is disabled. This is an issue, if a comment contains unsupported ACSL (or starts with @ and contains no ACSL at all #667). But disabling parsing could be more complicated, as it is done in `CDTParser` instead of `CACSL2BoogieTranslator`.