### PR TITLE
C translation: Handle incomplete arrays properly

### DIFF
--- a/trunk/examples/programs/regression/c/arrayInitSize.c
+++ b/trunk/examples/programs/regression/c/arrayInitSize.c
@@ -1,0 +1,14 @@
+// #Safe
+/*
+ * Date: 2025-12-12
+ * Author: schuessf@informatik.uni-freiburg.de
+ *
+ */
+
+int main(){
+  int x[] = {1,2,3};
+  if (sizeof(x) != 3 * sizeof(int)) reach_error();
+  
+  int y[5] = {1,2,3};
+  if (sizeof(y) != 5 * sizeof(int)) reach_error();
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CExpressionTranslator.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CExpressionTranslator.java
@@ -218,7 +218,7 @@ public class CExpressionTranslator {
 
 		if (lType instanceof CArray && rType.isArithmeticType()) {
 			// arrays decay to pointers in this case
-			assert !(((CArray) lType).getBound().getCType() instanceof CArray) : "TODO: think about this case";
+			assert !(((CArray) lType).getBoundType() instanceof CArray) : "TODO: think about this case";
 			final ICType valueType = ((CArray) lType).getValueType().getUnderlyingType();
 			left = mExprResultTransformer.performImplicitConversion(left, new CPointer(valueType), loc);
 			lType = left.getLrValue().getCType().getUnderlyingType();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CExpressionTranslator.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CExpressionTranslator.java
@@ -218,7 +218,6 @@ public class CExpressionTranslator {
 
 		if (lType instanceof CArray && rType.isArithmeticType()) {
 			// arrays decay to pointers in this case
-			assert !(((CArray) lType).getBoundType() instanceof CArray) : "TODO: think about this case";
 			final ICType valueType = ((CArray) lType).getValueType().getUnderlyingType();
 			left = mExprResultTransformer.performImplicitConversion(left, new CPointer(valueType), loc);
 			lType = left.getLrValue().getCType().getUnderlyingType();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1993,7 +1993,6 @@ public class CHandler {
 		 * declarator: (e.g. (int [])): then the size depends on the initializer - otherwise: the size is given by the
 		 * CType
 		 */
-		mTypeSizeComputer.constructBytesizeExpression(loc, cType);
 
 		final ExpressionResultBuilder builder = new ExpressionResultBuilder();
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1342,7 +1342,7 @@ public class CHandler {
 			// the innermost type is the value type.
 			ICType arrayType = resType.getCType();
 
-			final CPrimitive arrayIndexCtype = mTypeSizes.getSizeT();
+			final CPrimitive arrayIndexCtype = mExpressionTranslation.getCTypeOfPointerComponents();
 
 			// expression results of from array modifiers
 			final ArrayList<ExpressionResult> expressionResults = new ArrayList<>();
@@ -1359,7 +1359,7 @@ public class CHandler {
 					final ExpressionResult dispatched = (ExpressionResult) main.dispatch(am.getConstantExpression());
 					final ExpressionResult switched = mExprResultTransformer.switchToRValue(dispatched, loc, node);
 					final ExpressionResult converted =
-							mExpressionTranslation.convertIntToInt(loc, switched, mTypeSizes.getSizeT());
+							mExpressionTranslation.convertIntToInt(loc, switched, arrayIndexCtype);
 					expressionResults.add(converted);
 					final RValue rValue = (RValue) converted.getLrValue();
 					bound = rValue.getValue();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1341,8 +1341,7 @@ public class CHandler {
 		if (node instanceof final IASTArrayDeclarator arrDecl) {
 			// the innermost type is the value type.
 			ICType arrayType = resType.getCType();
-
-			final CPrimitive arrayIndexCtype = mExpressionTranslation.getCTypeOfPointerComponents();
+			final CPrimitive boundType = mExpressionTranslation.getCTypeOfPointerComponents();
 
 			// expression results of from array modifiers
 			final ArrayList<ExpressionResult> expressionResults = new ArrayList<>();
@@ -1357,8 +1356,7 @@ public class CHandler {
 					// e.g., a[23] or a[n+1]
 					final ExpressionResult dispatched = (ExpressionResult) main.dispatch(am.getConstantExpression());
 					final ExpressionResult switched = mExprResultTransformer.switchToRValue(dispatched, loc, node);
-					final ExpressionResult converted =
-							mExpressionTranslation.convertIntToInt(loc, switched, arrayIndexCtype);
+					final ExpressionResult converted = mExpressionTranslation.convertIntToInt(loc, switched, boundType);
 					expressionResults.add(converted);
 					final RValue rValue = (RValue) converted.getLrValue();
 					bound = rValue.getValue();
@@ -1372,7 +1370,7 @@ public class CHandler {
 							throw new UnsupportedOperationException("expected IASTEqualsInitializer");
 						}
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) arrDecl.getInitializer());
-						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
+						bound = mTypeSizes.constructLiteralForIntegerType(loc, boundType,
 								BigInteger.valueOf(intSizeFactor));
 					} else if (resType.getCType() instanceof CFunction) {
 						// if we have an array of function pointers,
@@ -1386,7 +1384,7 @@ public class CHandler {
 							throw new UnsupportedOperationException("expected initializer");
 						}
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) fundecl.getInitializer());
-						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
+						bound = mTypeSizes.constructLiteralForIntegerType(loc, boundType,
 								BigInteger.valueOf(intSizeFactor));
 					} else {
 						// we have an incomplete array type without an initializer --
@@ -1397,7 +1395,7 @@ public class CHandler {
 				} else {
 					throw new IncorrectSyntaxException(loc, "wrong array type in declaration");
 				}
-				arrayType = new CArray(bound, arrayIndexCtype, arrayType);
+				arrayType = new CArray(bound, boundType, arrayType);
 			}
 			final ExpressionResult allResults = new ExpressionResultBuilder()
 					.addAllExceptLrValue(expressionResults.toArray(new ExpressionResult[expressionResults.size()]))

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1342,6 +1342,8 @@ public class CHandler {
 			// the innermost type is the value type.
 			ICType arrayType = resType.getCType();
 
+			final CPrimitive arrayIndexCtype = mTypeSizes.getSizeT();
+
 			// expression results of from array modifiers
 			final ArrayList<ExpressionResult> expressionResults = new ArrayList<>();
 
@@ -1349,7 +1351,8 @@ public class CHandler {
 					Arrays.asList(arrDecl.getArrayModifiers()).listIterator(arrDecl.getArrayModifiers().length);
 			while (it.hasPrevious()) {
 				final IASTArrayModifier am = it.previous();
-				final RValue sizeFactor;
+				final Expression bound;
+				final ICType boundType;
 				if (am.getConstantExpression() != null) {
 					// case where we have a number between the brackets,
 					// e.g., a[23] or a[n+1]
@@ -1358,7 +1361,9 @@ public class CHandler {
 					final ExpressionResult converted =
 							mExpressionTranslation.convertIntToInt(loc, switched, mTypeSizes.getSizeT());
 					expressionResults.add(converted);
-					sizeFactor = (RValue) converted.getLrValue();
+					final RValue rValue = (RValue) converted.getLrValue();
+					bound = rValue.getValue();
+					boundType = rValue.getCType();
 				} else if (am.getConstantExpression() == null
 						&& arrDecl.getArrayModifiers()[arrDecl.getArrayModifiers().length - 1] == am) {
 					// the innermost array modifier may be empty, if there is an initializer; like
@@ -1369,6 +1374,9 @@ public class CHandler {
 							throw new UnsupportedOperationException("expected IASTEqualsInitializer");
 						}
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) arrDecl.getInitializer());
+						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
+								BigInteger.valueOf(intSizeFactor));
+						boundType = arrayIndexCtype;
 					} else if (resType.getCType() instanceof CFunction) {
 						// if we have an array of function pointers,
 						// the initializer is stored in the parent node
@@ -1381,26 +1389,20 @@ public class CHandler {
 							throw new UnsupportedOperationException("expected initializer");
 						}
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) fundecl.getInitializer());
+						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
+								BigInteger.valueOf(intSizeFactor));
+						boundType = arrayIndexCtype;
 					} else {
 						// we have an incomplete array type without an initializer --
-						// this may happen in a function parameter..
-						intSizeFactor = CArray.INCOMPLETE_ARRY_MAGIC_NUMBER;
+						// this may happen in a function parameter or as a flexible array in structs
+						bound = null;
+						boundType = arrayIndexCtype;
 					}
-					// Index type of the array. All C expressions that access the array are
-					// converted to this type.
-					// In the past we wanted a type that is large enough for the
-					// CArray.INCOMPLETE_ARRY_MAGIC_NUMBER.
-					// If we work with an unsigned type for pointer components we have to rethink
-					// the use of the magic number.
-					final CPrimitive arrayIndexCtype = mTypeSizes.getSizeT();
-					final Expression sizeExpression = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
-							BigInteger.valueOf(intSizeFactor));
-					sizeFactor = new RValue(sizeExpression, arrayIndexCtype, false, false);
 
 				} else {
 					throw new IncorrectSyntaxException(loc, "wrong array type in declaration");
 				}
-				arrayType = new CArray(sizeFactor, arrayType);
+				arrayType = new CArray(bound, boundType, arrayType);
 			}
 			final ExpressionResult allResults = new ExpressionResultBuilder()
 					.addAllExceptLrValue(expressionResults.toArray(new ExpressionResult[expressionResults.size()]))
@@ -2168,8 +2170,8 @@ public class CHandler {
 		final Expression sizeInBytesExpr = mTypeSizes.constructLiteralForIntegerType(actualLoc,
 				mExpressionTranslation.getCTypeOfPointerComponents(), BigInteger.valueOf(sizeInBytes));
 
-		final RValue dimension = new RValue(sizeInBytesExpr, mExpressionTranslation.getCTypeOfPointerComponents());
-		final CArray arrayType = new CArray(dimension, new CPrimitive(CPrimitives.CHAR));
+		final CArray arrayType = new CArray(sizeInBytesExpr, mExpressionTranslation.getCTypeOfPointerComponents(),
+				new CPrimitive(CPrimitives.CHAR));
 		final CPointer pointerType = new CPointer(new CPrimitive(CPrimitives.CHAR));
 
 		final RValue addressRValue;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1358,8 +1358,7 @@ public class CHandler {
 					final ExpressionResult switched = mExprResultTransformer.switchToRValue(dispatched, loc, node);
 					final ExpressionResult converted = mExpressionTranslation.convertIntToInt(loc, switched, boundType);
 					expressionResults.add(converted);
-					final RValue rValue = (RValue) converted.getLrValue();
-					bound = rValue.getValue();
+					bound = converted.getLrValue().getValue();
 				} else if (am.getConstantExpression() == null
 						&& arrDecl.getArrayModifiers()[arrDecl.getArrayModifiers().length - 1] == am) {
 					// the innermost array modifier may be empty, if there is an initializer; like

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1942,11 +1942,20 @@ public class CHandler {
 		final CDeclaration cDeclaration = declaratorResult.getDeclaration();
 		assert !cDeclaration.hasInitializer() : "unexpected, inspect this case";
 		assert !cDeclaration.isOnHeap() : "unexpected, inspect this case";
-		final ICType cType = cDeclaration.getType().getUnderlyingType();
+		ICType cType = cDeclaration.getType().getUnderlyingType();
 
 		// translate initializer
 		final IASTInitializer initializer = node.getInitializer();
 		final InitializerResult ir = (InitializerResult) main.dispatch(initializer);
+
+		if (cType instanceof final CArray cArray && cType.isIncomplete()) {
+			// C11 6.7.9.22:
+			// If an array of unknown size is initialized, its size is determined by the largest indexed element with an
+			// explicit initializer. The array type is completed at the end of its initializer list.
+			cType = new CArray(mExpressionTranslation.constructLiteralForIntegerType(loc,
+					mExpressionTranslation.getCTypeOfPointerComponents(), BigInteger.valueOf(ir.getList().size())),
+					cArray.getBoundType(), cArray.getValueType());
+		}
 
 		final boolean isAddressTaken = node.getParent() instanceof IASTUnaryExpression
 				&& ((IASTUnaryExpression) node.getParent()).getOperator() == IASTUnaryExpression.op_amper;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1352,7 +1352,6 @@ public class CHandler {
 			while (it.hasPrevious()) {
 				final IASTArrayModifier am = it.previous();
 				final Expression bound;
-				final CPrimitive boundType;
 				if (am.getConstantExpression() != null) {
 					// case where we have a number between the brackets,
 					// e.g., a[23] or a[n+1]
@@ -1363,7 +1362,6 @@ public class CHandler {
 					expressionResults.add(converted);
 					final RValue rValue = (RValue) converted.getLrValue();
 					bound = rValue.getValue();
-					boundType = (CPrimitive) rValue.getCType();
 				} else if (am.getConstantExpression() == null
 						&& arrDecl.getArrayModifiers()[arrDecl.getArrayModifiers().length - 1] == am) {
 					// the innermost array modifier may be empty, if there is an initializer; like
@@ -1376,7 +1374,6 @@ public class CHandler {
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) arrDecl.getInitializer());
 						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
 								BigInteger.valueOf(intSizeFactor));
-						boundType = arrayIndexCtype;
 					} else if (resType.getCType() instanceof CFunction) {
 						// if we have an array of function pointers,
 						// the initializer is stored in the parent node
@@ -1391,18 +1388,16 @@ public class CHandler {
 						intSizeFactor = computeSizeOfInitializer((IASTEqualsInitializer) fundecl.getInitializer());
 						bound = mTypeSizes.constructLiteralForIntegerType(loc, arrayIndexCtype,
 								BigInteger.valueOf(intSizeFactor));
-						boundType = arrayIndexCtype;
 					} else {
 						// we have an incomplete array type without an initializer --
 						// this may happen in a function parameter or as a flexible array in structs
 						bound = null;
-						boundType = arrayIndexCtype;
 					}
 
 				} else {
 					throw new IncorrectSyntaxException(loc, "wrong array type in declaration");
 				}
-				arrayType = new CArray(bound, boundType, arrayType);
+				arrayType = new CArray(bound, arrayIndexCtype, arrayType);
 			}
 			final ExpressionResult allResults = new ExpressionResultBuilder()
 					.addAllExceptLrValue(expressionResults.toArray(new ExpressionResult[expressionResults.size()]))

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1352,7 +1352,7 @@ public class CHandler {
 			while (it.hasPrevious()) {
 				final IASTArrayModifier am = it.previous();
 				final Expression bound;
-				final ICType boundType;
+				final CPrimitive boundType;
 				if (am.getConstantExpression() != null) {
 					// case where we have a number between the brackets,
 					// e.g., a[23] or a[n+1]
@@ -1363,7 +1363,7 @@ public class CHandler {
 					expressionResults.add(converted);
 					final RValue rValue = (RValue) converted.getLrValue();
 					bound = rValue.getValue();
-					boundType = rValue.getCType();
+					boundType = (CPrimitive) rValue.getCType();
 				} else if (am.getConstantExpression() == null
 						&& arrDecl.getArrayModifiers()[arrDecl.getArrayModifiers().length - 1] == am) {
 					// the innermost array modifier may be empty, if there is an initializer; like

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
@@ -72,7 +72,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultBuilder;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResultTransformer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.LocalLValue;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.Result;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.INameHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
@@ -98,7 +97,7 @@ public class CTranslationUtil {
 		CArray currentArrayType = cArrayType;
 
 		for (int i = 0; i < arrayIndex.size(); i++) {
-			final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBound().getCType().getUnderlyingType();
+			final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBoundType().getUnderlyingType();
 			index[i] = typeSizes.constructLiteralForIntegerType(loc, currentIndexType,
 					new BigInteger(arrayIndex.get(i).toString()));
 
@@ -119,7 +118,7 @@ public class CTranslationUtil {
 			final Integer arrayIndex, final TypeSizes typeSizes) {
 		final CArray cArrayType = (CArray) arrayLhsToInitialize.getCType().getUnderlyingType();
 
-		final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBound().getCType();
+		final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBoundType();
 		final Expression index =
 				typeSizes.constructLiteralForIntegerType(loc, currentIndexType, new BigInteger(arrayIndex.toString()));
 
@@ -134,7 +133,7 @@ public class CTranslationUtil {
 	public static boolean isVarlengthArray(final CArray cArrayType, final TypeSizes typeSizes) {
 		CArray currentArrayType = cArrayType;
 		while (true) {
-			if (typeSizes.extractIntegerValue(currentArrayType.getBound()) == null) {
+			if (typeSizes.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getValueType()) == null) {
 				// found a variable length bound
 				return true;
 			}
@@ -149,7 +148,7 @@ public class CTranslationUtil {
 	}
 
 	public static boolean isToplevelVarlengthArray(final CArray cArrayType, final TypeSizes typeSizes) {
-		return typeSizes.extractIntegerValue(cArrayType.getBound()) == null;
+		return typeSizes.extractIntegerValue(cArrayType.getBound(), cArrayType.getBoundType()) == null;
 	}
 
 	public static List<Integer> getConstantDimensionsOfArray(final CArray cArrayType, final TypeSizes typeSizes) {
@@ -160,7 +159,8 @@ public class CTranslationUtil {
 
 		final List<Integer> result = new ArrayList<>();
 		while (true) {
-			result.add(Integer.parseUnsignedInt(typeSizes.extractIntegerValue(currentArrayType.getBound()).toString()));
+			result.add(Integer.parseUnsignedInt(typeSizes
+					.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getBoundType()).toString()));
 
 			final ICType valueType = currentArrayType.getValueType().getUnderlyingType();
 			if (valueType instanceof CArray) {
@@ -193,19 +193,14 @@ public class CTranslationUtil {
 	}
 
 	public static int getConstantFirstDimensionOfArray(final CArray cArrayType, final TypeSizes typeSizes) {
-		final RValue dimRVal = cArrayType.getBound();
-
-		final BigInteger extracted = typeSizes.extractIntegerValue(dimRVal);
+		if (cArrayType.isIncomplete()) {
+			throw new IllegalArgumentException("This array type is incomplete! Cannot extract actual dimensions.");
+		}
+		final BigInteger extracted = typeSizes.extractIntegerValue(cArrayType.getBound(), cArrayType.getBoundType());
 		if (extracted == null) {
 			throw new IllegalArgumentException("only call this for non-varlength first dimension types");
 		}
-
-		if (extracted.equals(BigInteger.valueOf(CArray.INCOMPLETE_ARRY_MAGIC_NUMBER))) {
-			throw new IllegalArgumentException("This array type is incomplete! Cannot extract actual dimensions.");
-		}
-
-		final int dimInt = Integer.parseUnsignedInt(extracted.toString());
-		return dimInt;
+		return Integer.parseUnsignedInt(extracted.toString());
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
@@ -97,7 +97,7 @@ public class CTranslationUtil {
 		CArray currentArrayType = cArrayType;
 
 		for (int i = 0; i < arrayIndex.size(); i++) {
-			final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBoundType().getUnderlyingType();
+			final CPrimitive currentIndexType = cArrayType.getBoundType();
 			index[i] = typeSizes.constructLiteralForIntegerType(loc, currentIndexType,
 					new BigInteger(arrayIndex.get(i).toString()));
 
@@ -118,7 +118,7 @@ public class CTranslationUtil {
 			final Integer arrayIndex, final TypeSizes typeSizes) {
 		final CArray cArrayType = (CArray) arrayLhsToInitialize.getCType().getUnderlyingType();
 
-		final CPrimitive currentIndexType = (CPrimitive) cArrayType.getBoundType();
+		final CPrimitive currentIndexType = cArrayType.getBoundType();
 		final Expression index =
 				typeSizes.constructLiteralForIntegerType(loc, currentIndexType, new BigInteger(arrayIndex.toString()));
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
@@ -130,35 +130,14 @@ public class CTranslationUtil {
 		return new LocalLValue(alhs, cellType, null);
 	}
 
-	public static boolean isVarlengthArray(final CArray cArrayType, final TypeSizes typeSizes) {
-		CArray currentArrayType = cArrayType;
-		while (true) {
-			if (typeSizes.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getBoundType()) == null) {
-				// found a variable length bound
-				return true;
-			}
-			final ICType valueType = currentArrayType.getValueType().getUnderlyingType();
-			if (valueType instanceof CArray) {
-				currentArrayType = (CArray) valueType;
-			} else {
-				// reached at non-array type, found no varlength bound
-				return false;
-			}
-		}
-	}
-
-	public static boolean isToplevelVarlengthArray(final CArray cArrayType, final TypeSizes typeSizes) {
-		return typeSizes.extractIntegerValue(cArrayType.getBound(), cArrayType.getBoundType()) == null;
-	}
-
 	public static List<Integer> getConstantDimensionsOfArray(final CArray cArrayType, final TypeSizes typeSizes) {
-		if (CTranslationUtil.isVarlengthArray(cArrayType, typeSizes)) {
-			throw new IllegalArgumentException("only call this for non-varlength array types");
-		}
 		CArray currentArrayType = cArrayType;
 
 		final List<Integer> result = new ArrayList<>();
 		while (true) {
+			if (currentArrayType.isIncomplete()) {
+				throw new IllegalArgumentException("Cannot get the dimensions of an incomplete array.");
+			}
 			result.add(Integer.parseUnsignedInt(typeSizes
 					.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getBoundType()).toString()));
 
@@ -197,9 +176,6 @@ public class CTranslationUtil {
 			throw new IllegalArgumentException("This array type is incomplete! Cannot extract actual dimensions.");
 		}
 		final BigInteger extracted = typeSizes.extractIntegerValue(cArrayType.getBound(), cArrayType.getBoundType());
-		if (extracted == null) {
-			throw new IllegalArgumentException("only call this for non-varlength first dimension types");
-		}
 		return Integer.parseUnsignedInt(extracted.toString());
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CTranslationUtil.java
@@ -133,7 +133,7 @@ public class CTranslationUtil {
 	public static boolean isVarlengthArray(final CArray cArrayType, final TypeSizes typeSizes) {
 		CArray currentArrayType = cArrayType;
 		while (true) {
-			if (typeSizes.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getValueType()) == null) {
+			if (typeSizes.extractIntegerValue(currentArrayType.getBound(), currentArrayType.getBoundType()) == null) {
 				// found a variable length bound
 				return true;
 			}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CompatibleTypes.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CompatibleTypes.java
@@ -279,8 +279,8 @@ public final class CompatibleTypes {
 		if (array1.isIncomplete() || array2.isIncomplete()) {
 			return true;
 		}
-		final BigInteger bound1 = CTranslationUtil.extractIntegerValue(array1.getBound().getValue());
-		final BigInteger bound2 = CTranslationUtil.extractIntegerValue(array2.getBound().getValue());
+		final BigInteger bound1 = CTranslationUtil.extractIntegerValue(array1.getBound());
+		final BigInteger bound2 = CTranslationUtil.extractIntegerValue(array2.getBound());
 		return bound1 == null || bound2 == null || bound1.equals(bound2);
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
@@ -553,7 +553,7 @@ public class TypeHandler implements ITypeHandler {
 			 * note: we are using nested Boogie array types (thus the Boogie ArrayType we use will always have a
 			 * one-element array for the index types
 			 */
-			final ASTType indexType = cType2AstType(loc, cArrayType.getBound().getCType());
+			final ASTType indexType = cType2AstType(loc, cArrayType.getBoundType());
 			final ASTType valueType = cType2AstType(loc, cArrayType.getValueType());
 			final BoogieArrayType boogieType =
 					BoogieType.createArrayType(0, new BoogieType[] { (BoogieType) indexType.getBoogieType() },

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
@@ -249,7 +249,6 @@ public class ArrayHandler {
 			// do not check anything
 			return;
 		}
-
 		final Expression inRange;
 		// 2015-09-21 Matthias:
 		// This check will fail in the bitvector translation if the typesize

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
@@ -182,13 +182,14 @@ public class ArrayHandler {
 			// current index.
 			final LeftHandSide oldInnerArrayLHS = ((LocalLValue) leftlrValue).getLhs();
 
-			final RValue bound = lhsArrayType.getBound();
+			final Expression bound = lhsArrayType.getBound();
+			final ICType boundType = lhsArrayType.getBoundType();
 
 			// The following is not in the standard, since there everything
 			// is defined via pointers. However, we have to make the subscript
 			// compatible to the type of the dimension of the array
 			final ExpressionResult convertedSubscript =
-					mExpressionTranslation.convertIntToInt(loc, subscript, (CPrimitive) bound.getCType());
+					mExpressionTranslation.convertIntToInt(loc, subscript, (CPrimitive) boundType);
 			final RValue index = (RValue) convertedSubscript.getLrValue();
 			final ArrayLHS newInnerArrayLHS;
 			if (oldInnerArrayLHS instanceof ArrayLHS) {
@@ -207,7 +208,7 @@ public class ArrayHandler {
 			final LocalLValue lValue = new LocalLValue(newInnerArrayLHS, resultCType, false, false, null);
 			result.addAllExceptLrValue(array, convertedSubscript);
 			result.setLrValue(lValue);
-			addArrayBoundsCheckForCurrentIndex(loc, index, bound, result);
+			addArrayBoundsCheckForCurrentIndex(loc, index, bound, boundType, result);
 			return result.build();
 		}
 		if (leftlrValue instanceof RValue) {
@@ -242,11 +243,13 @@ public class ArrayHandler {
 	 *            {@link Expression} that represents the dimension that corresponds to the index
 	 */
 	private void addArrayBoundsCheckForCurrentIndex(final ILocation loc, final RValue currentIndex,
-			final RValue currentDimension, final ExpressionResultBuilder exprResult) {
+			final Expression currentDimension, final ICType currentBoundType,
+			final ExpressionResultBuilder exprResult) {
 		if (mSettings.checkPointerDerefValidity() == CheckMode.IGNORE) {
 			// do not check anything
 			return;
 		}
+
 		final Expression inRange;
 		// 2015-09-21 Matthias:
 		// This check will fail in the bitvector translation if the typesize
@@ -260,8 +263,8 @@ public class ArrayHandler {
 		final Expression nonNegative = mExpressionTranslation.constructBinaryComparisonExpression(loc,
 				IASTBinaryExpression.op_lessEqual, zero, indexType, currentIndex.getValue(), indexType);
 		final Expression notTooBig = mExpressionTranslation.constructBinaryComparisonExpression(loc,
-				IASTBinaryExpression.op_lessThan, currentIndex.getValue(), indexType, currentDimension.getValue(),
-				(CPrimitive) currentDimension.getCType().getUnderlyingType());
+				IASTBinaryExpression.op_lessThan, currentIndex.getValue(), indexType, currentDimension,
+				(CPrimitive) currentBoundType.getUnderlyingType());
 		inRange = ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, nonNegative, notTooBig);
 		switch (mSettings.checkPointerDerefValidity()) {
 		case CHECK:

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ArrayHandler.java
@@ -183,13 +183,13 @@ public class ArrayHandler {
 			final LeftHandSide oldInnerArrayLHS = ((LocalLValue) leftlrValue).getLhs();
 
 			final Expression bound = lhsArrayType.getBound();
-			final ICType boundType = lhsArrayType.getBoundType();
+			final CPrimitive boundType = lhsArrayType.getBoundType();
 
 			// The following is not in the standard, since there everything
 			// is defined via pointers. However, we have to make the subscript
 			// compatible to the type of the dimension of the array
 			final ExpressionResult convertedSubscript =
-					mExpressionTranslation.convertIntToInt(loc, subscript, (CPrimitive) boundType);
+					mExpressionTranslation.convertIntToInt(loc, subscript, boundType);
 			final RValue index = (RValue) convertedSubscript.getLrValue();
 			final ArrayLHS newInnerArrayLHS;
 			if (oldInnerArrayLHS instanceof ArrayLHS) {
@@ -243,7 +243,7 @@ public class ArrayHandler {
 	 *            {@link Expression} that represents the dimension that corresponds to the index
 	 */
 	private void addArrayBoundsCheckForCurrentIndex(final ILocation loc, final RValue currentIndex,
-			final Expression currentDimension, final ICType currentBoundType,
+			final Expression currentDimension, final CPrimitive currentBoundType,
 			final ExpressionResultBuilder exprResult) {
 		if (mSettings.checkPointerDerefValidity() == CheckMode.IGNORE) {
 			// do not check anything
@@ -262,9 +262,9 @@ public class ArrayHandler {
 		final Expression zero = mTypeSizes.constructLiteralForIntegerType(loc, indexType, BigInteger.ZERO);
 		final Expression nonNegative = mExpressionTranslation.constructBinaryComparisonExpression(loc,
 				IASTBinaryExpression.op_lessEqual, zero, indexType, currentIndex.getValue(), indexType);
-		final Expression notTooBig = mExpressionTranslation.constructBinaryComparisonExpression(loc,
-				IASTBinaryExpression.op_lessThan, currentIndex.getValue(), indexType, currentDimension,
-				(CPrimitive) currentBoundType.getUnderlyingType());
+		final Expression notTooBig =
+				mExpressionTranslation.constructBinaryComparisonExpression(loc, IASTBinaryExpression.op_lessThan,
+						currentIndex.getValue(), indexType, currentDimension, currentBoundType);
 		inRange = ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, nonNegative, notTooBig);
 		switch (mSettings.checkPointerDerefValidity()) {
 		case CHECK:

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1220,6 +1220,9 @@ public class InitializationHandler {
 		if (targetCType instanceof final CArray array) {
 			cellType = array.getValueType();
 			if (array.isIncomplete()) {
+				// C11 6.7.9.22:
+				// If an array of unknown size is initialized, its size is determined by the largest indexed element
+				// with an explicit initializer. The array type is completed at the end of its initializer list.
 				bound = initializerResults.size();
 				array.complete(mExpressionTranslation.constructLiteralForIntegerType(loc,
 						(CPrimitive) array.getBoundType(), BigInteger.valueOf(bound)));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1219,9 +1219,12 @@ public class InitializationHandler {
 		ICType cellType = null;
 		if (targetCType instanceof final CArray array) {
 			cellType = array.getValueType();
-			bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
-			if (CTranslationUtil.isToplevelVarlengthArray(array, mTypeSizes)) {
-				throw new UnsupportedOperationException("varlength not yet supported here");
+			if (array.isIncomplete()) {
+				bound = initializerResults.size();
+				array.complete(mExpressionTranslation.constructLiteralForIntegerType(loc,
+						(CPrimitive) array.getBoundType(), BigInteger.valueOf(bound)));
+			} else {
+				bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
 			}
 		} else {
 			bound = ((CStructOrUnion) targetCType).getFieldCount();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1030,7 +1030,7 @@ public class InitializationHandler {
 				return BigInteger.ZERO;
 			}
 			final BigInteger innerCount = countNumberOfPrimitiveElementInType(cArray.getValueType(), hook);
-			final BigInteger bound = mTypeSizes.extractIntegerValue(cArray.getBound());
+			final BigInteger bound = mTypeSizes.extractIntegerValue(cArray.getBound(), cArray.getBoundType());
 			return innerCount.multiply(bound);
 		}
 		throw new AssertionError("Cannot count the primitive elements in type " + cType.getClass().getSimpleName());

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1219,16 +1219,7 @@ public class InitializationHandler {
 		ICType cellType = null;
 		if (targetCType instanceof final CArray array) {
 			cellType = array.getValueType();
-			if (array.isIncomplete()) {
-				// C11 6.7.9.22:
-				// If an array of unknown size is initialized, its size is determined by the largest indexed element
-				// with an explicit initializer. The array type is completed at the end of its initializer list.
-				bound = initializerResults.size();
-				array.complete(mExpressionTranslation.constructLiteralForIntegerType(loc, array.getBoundType(),
-						BigInteger.valueOf(bound)));
-			} else {
-				bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
-			}
+			bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
 		} else {
 			bound = ((CStructOrUnion) targetCType).getFieldCount();
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1220,6 +1220,9 @@ public class InitializationHandler {
 		if (targetCType instanceof final CArray array) {
 			cellType = array.getValueType();
 			bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
+			if (CTranslationUtil.isToplevelVarlengthArray(array, mTypeSizes)) {
+				throw new UnsupportedOperationException("varlength not yet supported here");
+			}
 		} else {
 			bound = ((CStructOrUnion) targetCType).getFieldCount();
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1224,8 +1224,8 @@ public class InitializationHandler {
 				// If an array of unknown size is initialized, its size is determined by the largest indexed element
 				// with an explicit initializer. The array type is completed at the end of its initializer list.
 				bound = initializerResults.size();
-				array.complete(mExpressionTranslation.constructLiteralForIntegerType(loc,
-						(CPrimitive) array.getBoundType(), BigInteger.valueOf(bound)));
+				array.complete(mExpressionTranslation.constructLiteralForIntegerType(loc, array.getBoundType(),
+						BigInteger.valueOf(bound)));
 			} else {
 				bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
 			}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -536,9 +536,6 @@ public class InitializationHandler {
 		 * Iterate over all array indices and assign the corresponding array cell; In the sophisticated case, only cells
 		 * explicitly mentioned by the initializer are updated here. Otherwise all cells are updated
 		 */
-		if (CTranslationUtil.isToplevelVarlengthArray(cArrayType, mTypeSizes)) {
-			throw new UnsupportedOperationException("handling varlength arrays not implemented for this case");
-		}
 		final int bound = CTranslationUtil.getConstantFirstDimensionOfArray(cArrayType, mTypeSizes);
 
 		for (int i = 0; i < bound; i++) {
@@ -1220,9 +1217,6 @@ public class InitializationHandler {
 		if (targetCType instanceof final CArray array) {
 			cellType = array.getValueType();
 			bound = CTranslationUtil.getConstantFirstDimensionOfArray(array, mTypeSizes);
-			if (CTranslationUtil.isToplevelVarlengthArray(array, mTypeSizes)) {
-				throw new UnsupportedOperationException("varlength not yet supported here");
-			}
 		} else {
 			bound = ((CStructOrUnion) targetCType).getFieldCount();
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -1981,6 +1981,10 @@ public class MemoryHandler {
 				stmt.add(ExpressionTranslation.modelUnsupportedFeature(loc,
 						"write for union with floats in the HoenickeLindenmann_Original Memory Structure"));
 			}
+			if (fieldType.getUnderlyingType() instanceof CArray && fieldType.isIncomplete()) {
+				// Assignment of structs ignores flexible arrays, https://en.cppreference.com/w/c/language/struct
+				continue;
+			}
 
 			final Offset fieldOffset = mTypeSizeAndOffsetComputer.constructOffsetForField(loc, valueType, fieldId);
 			if (fieldOffset.isBitfieldOffset()) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -1933,7 +1933,7 @@ public class MemoryHandler {
 					"we need to generalize this to nested and/or variable length arrays");
 		}
 
-		final BigInteger dimBigInteger = mTypeSizes.extractIntegerValue(valueType.getBound());
+		final BigInteger dimBigInteger = mTypeSizes.extractIntegerValue(valueType.getBound(), valueType.getBoundType());
 		if (dimBigInteger == null) {
 			throw new UnsupportedSyntaxException(loc, "variable length arrays not yet supported by this method");
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizeAndOffsetComputer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizeAndOffsetComputer.java
@@ -56,7 +56,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CStructOrUnion;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CStructOrUnion.StructOrUnion;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
@@ -207,7 +206,7 @@ public class TypeSizeAndOffsetComputer {
 
 	private SizeTValue constructSizeTValueArray(final ILocation loc, final CArray cArray) {
 		final SizeTValue valueSize = computeSize(loc, cArray.getValueType());
-		final SizeTValue factor = extractSizeTValue(cArray.getBound());
+		final SizeTValue factor = extractSizeTValue(cArray.getBound(), cArray.getBoundType());
 
 		final SizeTValue size = (new SizeTValueAggregatorMultiply()).aggregate(loc, Arrays.asList(valueSize, factor));
 		if (!mPreferConstantsOverValues) {
@@ -311,12 +310,12 @@ public class TypeSizeAndOffsetComputer {
 		return new Axiom(loc, new Attribute[0], isNonNegative);
 	}
 
-	private SizeTValue extractSizeTValue(final RValue rvalue) {
-		final BigInteger value = mTypeSizes.extractIntegerValue(rvalue);
+	private SizeTValue extractSizeTValue(final Expression bound, final ICType boundType) {
+		final BigInteger value = mTypeSizes.extractIntegerValue(bound, boundType);
 		if (value != null) {
 			return new SizeTValueInteger(value);
 		}
-		return new SizeTValueExpression(rvalue.getValue());
+		return new SizeTValueExpression(bound);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -51,7 +51,7 @@ public final class CArray implements ICType {
 	/**
 	 * Array bound. Note that we use nesting of array types for multidimensional array types
 	 */
-	private final Expression mBound;
+	private Expression mBound;
 	private final ICType mBoundType;
 	private final ICType mValueType;
 
@@ -85,6 +85,13 @@ public final class CArray implements ICType {
 	 */
 	public ICType getValueType() {
 		return mValueType;
+	}
+
+	public void complete(final Expression bound) {
+		if (!isIncomplete()) {
+			throw new AssertionError("only incomplete arrays can be completed");
+		}
+		mBound = bound;
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -49,10 +49,13 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.C
  */
 public final class CArray implements ICType {
 	/**
-	 * Array bound. Note that we use nesting of array types for multidimensional array types
+	 * Array bound. We use null to indicate that an array has a variable length.
 	 */
 	private final Expression mBound;
 	private final CPrimitive mBoundType;
+	/**
+	 * Type of the array value. We use nesting of array types for multidimensional array types.
+	 */
 	private final ICType mValueType;
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -51,7 +51,7 @@ public final class CArray implements ICType {
 	/**
 	 * Array bound. Note that we use nesting of array types for multidimensional array types
 	 */
-	private Expression mBound;
+	private final Expression mBound;
 	private final CPrimitive mBoundType;
 	private final ICType mValueType;
 
@@ -85,13 +85,6 @@ public final class CArray implements ICType {
 	 */
 	public ICType getValueType() {
 		return mValueType;
-	}
-
-	public void complete(final Expression bound) {
-		if (mBound != null) {
-			throw new AssertionError("only incomplete arrays can be completed");
-		}
-		mBound = bound;
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -52,7 +52,7 @@ public final class CArray implements ICType {
 	 * Array bound. Note that we use nesting of array types for multidimensional array types
 	 */
 	private Expression mBound;
-	private final ICType mBoundType;
+	private final CPrimitive mBoundType;
 	private final ICType mValueType;
 
 	/**
@@ -63,7 +63,7 @@ public final class CArray implements ICType {
 	 * @param valueType
 	 *            the type of the array.
 	 */
-	public CArray(final Expression bound, final ICType boundType, final ICType valueType) {
+	public CArray(final Expression bound, final CPrimitive boundType, final ICType valueType) {
 		mBound = bound;
 		mBoundType = boundType;
 		mValueType = valueType;
@@ -76,7 +76,7 @@ public final class CArray implements ICType {
 		return mBound;
 	}
 
-	public ICType getBoundType() {
+	public CPrimitive getBoundType() {
 		return mBoundType;
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -31,7 +31,6 @@
  */
 package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c;
 
-import java.math.BigInteger;
 import java.util.Objects;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
@@ -40,7 +39,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IntegerLiteral;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.CTranslationUtil;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 
 /**
  * Array type (see C11 6.2.5.20.1)
@@ -50,17 +48,11 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
  * @author Alexander Nutz (nutz@informatik.uni-freiburg.de)
  */
 public final class CArray implements ICType {
-
-	/**
-	 * Size that we use to indicate that an array has a variable length.
-	 */
-	public static final int INCOMPLETE_ARRY_MAGIC_NUMBER = -1234567;
-
 	/**
 	 * Array bound. Note that we use nesting of array types for multidimensional array types
 	 */
-	private final RValue mBound;
-
+	private final Expression mBound;
+	private final ICType mBoundType;
 	private final ICType mValueType;
 
 	/**
@@ -71,16 +63,21 @@ public final class CArray implements ICType {
 	 * @param valueType
 	 *            the type of the array.
 	 */
-	public CArray(final RValue bound, final ICType valueType) {
+	public CArray(final Expression bound, final ICType boundType, final ICType valueType) {
 		mBound = bound;
+		mBoundType = boundType;
 		mValueType = valueType;
 	}
 
 	/**
 	 * @return the dimensions
 	 */
-	public RValue getBound() {
+	public Expression getBound() {
 		return mBound;
+	}
+
+	public ICType getBoundType() {
+		return mBoundType;
 	}
 
 	/**
@@ -95,7 +92,7 @@ public final class CArray implements ICType {
 		final StringBuilder id = new StringBuilder("ARRAY#");
 		final StringBuilder dimString = new StringBuilder("_");
 
-		final Expression dim = mBound.getValue();
+		final Expression dim = mBound;
 		if (dim instanceof BinaryExpression || dim instanceof UnaryExpression) {
 			// 2015-11-08 Matthias: Use C representation or introduce a factory
 			// for types.
@@ -122,16 +119,12 @@ public final class CArray implements ICType {
 
 	@Override
 	public boolean isIncomplete() {
-		final BigInteger boundValue = CTranslationUtil.extractIntegerValue(mBound.getValue());
-		if (boundValue == null) {
-			return true;
-		}
-		return BigInteger.valueOf(INCOMPLETE_ARRY_MAGIC_NUMBER).equals(boundValue);
+		return mBound == null || CTranslationUtil.extractIntegerValue(mBound) == null;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(mBound, mValueType);
+		return Objects.hash(mBound, mBoundType, mValueType);
 	}
 
 	@Override
@@ -139,11 +132,12 @@ public final class CArray implements ICType {
 		if (this == obj) {
 			return true;
 		}
-		if (obj == null || getClass() != obj.getClass()) {
+		if (!super.equals(obj) || getClass() != obj.getClass()) {
 			return false;
 		}
 		final CArray other = (CArray) obj;
-		return Objects.equals(mBound, other.mBound) && Objects.equals(mValueType, other.mValueType);
+		return Objects.equals(mBound, other.mBound) && Objects.equals(mBoundType, other.mBoundType)
+				&& Objects.equals(mValueType, other.mValueType);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -88,7 +88,7 @@ public final class CArray implements ICType {
 	}
 
 	public void complete(final Expression bound) {
-		if (!isIncomplete()) {
+		if (mBound != null) {
 			throw new AssertionError("only incomplete arrays can be completed");
 		}
 		mBound = bound;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java
@@ -139,7 +139,7 @@ public final class CArray implements ICType {
 		if (this == obj) {
 			return true;
 		}
-		if (!super.equals(obj) || getClass() != obj.getClass()) {
+		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
 		final CArray other = (CArray) obj;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -444,16 +444,21 @@ public class ExpressionResultTransformer {
 					"we need to generalize this to nested and/or variable length arrays");
 		}
 
-		final BigInteger boundBigInteger =
-				mTypeSizes.extractIntegerValue(arrayType.getBound(), arrayType.getBoundType());
-		if (boundBigInteger == null) {
-			throw new UnsupportedSyntaxException(loc, "variable length arrays not yet supported by this method");
-		}
-		final int bound = boundBigInteger.intValue();
 		final AuxVarInfo newArrayAuxvar = mAuxVarInfoBuilder.constructAuxVarInfo(loc, arrayType, SFO.AUXVAR.ARRAYCOPY);
-		final LRValue resultValue = new RValue(newArrayAuxvar.getExp(), arrayType);
 		ExpressionResultBuilder builder = new ExpressionResultBuilder();
 		builder.addAuxVarWithDeclaration(newArrayAuxvar);
+		builder.setLrValue(new RValue(newArrayAuxvar.getExp(), arrayType));
+
+		if (arrayType.isIncomplete()) {
+			// TODO Frank 2023-11-14: This is just a workaround! We just return a non-deterministic value here, because
+			// we need it for structs with flexible arrays. The value is not used, we just need to be type-consistent
+			// and should not crash.
+			return builder.build();
+		}
+
+		final BigInteger boundBigInteger =
+				mTypeSizes.extractIntegerValue(arrayType.getBound(), arrayType.getBoundType());
+		final int bound = boundBigInteger.intValue();
 
 		final Expression valueTypeSize = mMemoryHandler.calculateSizeOf(loc, arrayValueType);
 		final int typeSize =
@@ -484,7 +489,6 @@ public class ExpressionResultTransformer {
 			builder = new ExpressionResultBuilder().addAllExceptLrValue(assRex).setLrValue(assRex.getLrValue());
 
 		}
-		builder.setOrResetLrValue(resultValue);
 		return builder.build();
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -338,8 +338,6 @@ public class ExpressionResultTransformer {
 		final ArrayList<Expression> fieldValues = new ArrayList<>();
 
 		for (int i = 0; i < fieldIds.length; i++) {
-			fieldIdentifiers.add(fieldIds[i]);
-
 			final ICType underlyingType;
 			if (fieldTypes[i] instanceof final CNamed cNamed) {
 				underlyingType = cNamed.getUnderlyingType();
@@ -364,6 +362,10 @@ public class ExpressionResultTransformer {
 				newDecl.addAll(fieldRead.getDeclarations());
 				newAuxVars.addAll(fieldRead.getAuxVars());
 			} else if (underlyingType instanceof final CArray cArray) {
+				if (cArray.isIncomplete()) {
+					// Assignment of structs ignores flexible arrays, https://en.cppreference.com/w/c/language/struct
+					continue;
+				}
 				final Expression arrayPointer =
 						mStructHandler.computeStructFieldAddress(loc, i, structOnHeapAddress, structType);
 				final ExpressionResult xres1 = readArrayFromHeap(old, loc, arrayPointer, cArray, hook, unchecked);
@@ -405,6 +407,7 @@ public class ExpressionResultTransformer {
 				throw new UnsupportedSyntaxException(loc, "..");
 			}
 
+			fieldIdentifiers.add(fieldIds[i]);
 			if (fieldLRVal instanceof RValue) {
 				fieldValues.add(fieldLRVal.getValue());
 			} else if (fieldLRVal instanceof final HeapLValue hlv) {
@@ -444,21 +447,17 @@ public class ExpressionResultTransformer {
 					"we need to generalize this to nested and/or variable length arrays");
 		}
 
+		final BigInteger boundBigInteger =
+				mTypeSizes.extractIntegerValue(arrayType.getBound(), arrayType.getBoundType());
+		if (boundBigInteger == null) {
+			throw new UnsupportedSyntaxException(loc, "variable length arrays not yet supported by this method");
+		}
+		final int bound = boundBigInteger.intValue();
+
 		final AuxVarInfo newArrayAuxvar = mAuxVarInfoBuilder.constructAuxVarInfo(loc, arrayType, SFO.AUXVAR.ARRAYCOPY);
 		final LRValue resultValue = new RValue(newArrayAuxvar.getExp(), arrayType);
 		ExpressionResultBuilder builder = new ExpressionResultBuilder();
 		builder.addAuxVarWithDeclaration(newArrayAuxvar);
-
-		if (arrayType.isIncomplete()) {
-			// TODO Frank 2023-11-14: This is just a workaround! We just return a non-deterministic value here, because
-			// we need it for structs with flexible arrays. The value is not used, we just need to be type-consistent
-			// and should not crash.
-			return builder.setLrValue(resultValue).build();
-		}
-
-		final BigInteger boundBigInteger =
-				mTypeSizes.extractIntegerValue(arrayType.getBound(), arrayType.getBoundType());
-		final int bound = boundBigInteger.intValue();
 
 		final Expression valueTypeSize = mMemoryHandler.calculateSizeOf(loc, arrayValueType);
 		final int typeSize =
@@ -654,9 +653,11 @@ public class ExpressionResultTransformer {
 		final BoogieType newBoogieType = mTypeHandler.getBoogieTypeForCType(targetCType);
 
 		if (CompatibleTypes.areCompatible(newType, oldType) && !newType.equals(new CPrimitive(CPrimitives.BOOL))
-				&& oldBoogieType.equals(newBoogieType)) {
+				&& (oldBoogieType.equals(newBoogieType) || newType instanceof CStructOrUnion)) {
 			// types are already identical -- nothing to do
 			// For _Bool we always do the conversion to ensure that the resulting value is 0 or 1
+			// If the C types are compatible struct types, ignore the Boogie types as they might differ because of
+			// flexible arrays.
 			return expr;
 		}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -444,7 +444,8 @@ public class ExpressionResultTransformer {
 					"we need to generalize this to nested and/or variable length arrays");
 		}
 
-		final BigInteger boundBigInteger = mTypeSizes.extractIntegerValue(arrayType.getBound());
+		final BigInteger boundBigInteger =
+				mTypeSizes.extractIntegerValue(arrayType.getBound(), arrayType.getBoundType());
 		if (boundBigInteger == null) {
 			throw new UnsupportedSyntaxException(loc, "variable length arrays not yet supported by this method");
 		}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -445,15 +445,15 @@ public class ExpressionResultTransformer {
 		}
 
 		final AuxVarInfo newArrayAuxvar = mAuxVarInfoBuilder.constructAuxVarInfo(loc, arrayType, SFO.AUXVAR.ARRAYCOPY);
+		final LRValue resultValue = new RValue(newArrayAuxvar.getExp(), arrayType);
 		ExpressionResultBuilder builder = new ExpressionResultBuilder();
 		builder.addAuxVarWithDeclaration(newArrayAuxvar);
-		builder.setLrValue(new RValue(newArrayAuxvar.getExp(), arrayType));
 
 		if (arrayType.isIncomplete()) {
 			// TODO Frank 2023-11-14: This is just a workaround! We just return a non-deterministic value here, because
 			// we need it for structs with flexible arrays. The value is not used, we just need to be type-consistent
 			// and should not crash.
-			return builder.build();
+			return builder.setLrValue(resultValue).build();
 		}
 
 		final BigInteger boundBigInteger =
@@ -489,6 +489,7 @@ public class ExpressionResultTransformer {
 			builder = new ExpressionResultBuilder().addAllExceptLrValue(assRex).setLrValue(assRex.getLrValue());
 
 		}
+		builder.setOrResetLrValue(resultValue);
 		return builder.build();
 	}
 


### PR DESCRIPTION
In C, an incomplete array refers to an array type whose size is not yet specified. A common special case are incomplete array members in struct (called flexible arrays) are ignored in the `sizeof` computation. While this behavior is already supported in Ultimate (see commit 2a975d2), the check for whether an array is incomplete is currently quite hacky. It relies on the magic number [`INCOMPLETE_ARRY_MAGIC_NUMBER`](https://github.com/ultimate-pa/ultimate/blob/dev/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/container/c/CArray.java#L57). We mark a `CArray` type as incomplete when its size equals this magic number.

This approach works for integer translation, since array sizes can't be negative. However, it fails in the bitvector translation, where arithmetic is always unsigned. In that case, a wraparound occurs, and the result never matches `INCOMPLETE_ARRY_MAGIC_NUMBER`. Therefore, some of our Nightly tests (e.g., [`flexible_array.c`](https://github.com/ultimate-pa/ultimate/blob/dev/trunk/examples/programs/regression/c/flexible_array.c)) currently fail. The same issue also leads to incorrect behavior when allocating memory for incomplete arrays.

This PR removes the use of the magic number `INCOMPLETE_ARRY_MAGIC_NUMBER`. Instead, `CArray` now includes an explicit field for the bound (an expression) that may be `null`. An incomplete array becomes complete when it is initialized, based on the length of its initializer (see C11 6.7.9.22). This should fix the known issues with incomplete arrays, including those in the bitvector translation.