### PR TITLE
Add workaround for misparsed casts

### DIFF
--- a/trunk/examples/programs/regression/c/castLibraryType.c
+++ b/trunk/examples/programs/regression/c/castLibraryType.c
@@ -11,6 +11,5 @@
 
 int main() {
   int x = __VERIFIER_nondet_int();
-  long long y = (size_t)(x);
-  if (y < 0) reach_error();
+  if ((size_t)(x) < 0) reach_error();
 }

--- a/trunk/examples/programs/regression/c/castLibraryType.c
+++ b/trunk/examples/programs/regression/c/castLibraryType.c
@@ -1,0 +1,16 @@
+//#Safe
+/* 
+ * Test where the parser misparses the cast to a function call (as the includes are ignored).
+ * 
+ * Author: schuessf@informatik.uni-freiburg.de
+ * Date: 2025-12-15
+ * 
+ */
+
+#include <stdint.h>
+
+int main() {
+  int x = __VERIFIER_nondet_int();
+  long long y = (size_t)(x);
+  if (y < 0) reach_error();
+}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1121,7 +1121,7 @@ public class CHandler {
 			// creates a void expression for null RValues
 			final Expression newExpression = ExpressionFactory.createVoidDummyExpression(loc);
 			final RValue rVal = new RValue(newExpression, new CPrimitive(CPrimitives.VOID));
-			builder.resetLrValue(rVal);
+			builder.setLrValue(rVal);
 		}
 		final ExpressionResult exprResultReady =
 				mExprResultTransformer.makeRepresentationReadyForConversion(builder.build(), loc, type, node);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1115,24 +1115,24 @@ public class CHandler {
 	}
 
 	private Result handleCast(final ICType type, final IASTNode node, final ExpressionResult exprResult) {
-		final ExpressionResultBuilder builder = new ExpressionResultBuilder(exprResult);
 		final ILocation loc = mLocationFactory.createCLocation(node);
-		if (!exprResult.hasLRValue()) {
+		final ExpressionResult exprResultReady;
+		if (exprResult.hasLRValue()) {
+			exprResultReady = mExprResultTransformer.rexBoolToInt(
+					mExprResultTransformer.makeRepresentationReadyForConversion(exprResult, loc, type, node), loc);
+		} else {
 			// creates a void expression for null RValues
 			final Expression newExpression = ExpressionFactory.createVoidDummyExpression(loc);
 			final RValue rVal = new RValue(newExpression, new CPrimitive(CPrimitives.VOID));
-			builder.setLrValue(rVal);
+			exprResultReady = new ExpressionResultBuilder(exprResult).setLrValue(rVal).build();
 		}
-		final ExpressionResult exprResultReady =
-				mExprResultTransformer.makeRepresentationReadyForConversion(builder.build(), loc, type, node);
 		checkUnsupportedPointerCast(exprResultReady, loc, type);
 
 		if (mSettings.isAdaptMemoryStructureResolutionOnPointerCasts() && mIsPrerun) {
 			checkIfNecessaryMemoryStructureAdaption(loc, type, exprResultReady);
 		}
 
-		return mExprResultTransformer
-				.performImplicitConversion(mExprResultTransformer.rexBoolToInt(exprResultReady, loc), type, loc);
+		return mExprResultTransformer.performImplicitConversion(exprResultReady, type, loc);
 	}
 
 	private void checkIfNecessaryMemoryStructureAdaption(final ILocation loc, final ICType castTargetType,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/CHandler.java
@@ -1099,8 +1099,6 @@ public class CHandler {
 	}
 
 	public Result visit(final IDispatcher main, final IASTCastExpression node) {
-		final ILocation loc = mLocationFactory.createCLocation(node);
-
 		// TODO: check validity of cast?
 
 		final TypesResult resTypes = (TypesResult) main.dispatch(node.getTypeId().getDeclSpecifier());
@@ -1111,24 +1109,30 @@ public class CHandler {
 		mCurrentDeclaredTypes.pop();
 
 		final ExpressionResult expr = (ExpressionResult) main.dispatch(node.getOperand());
-		ExpressionResult exprWithType = new ExpressionResultBuilder().addAllSideEffects(declResult)
-				.addAllExceptLrValue(expr).setLrValue(expr.getLrValue()).build();
+		final ExpressionResult exprWithType =
+				new ExpressionResultBuilder().addAllSideEffects(declResult).addAllIncludingLrValue(expr).build();
+		return handleCast(newCType, node, exprWithType);
+	}
 
-		if (!exprWithType.hasLRValue()) {
+	private Result handleCast(final ICType type, final IASTNode node, final ExpressionResult exprResult) {
+		final ExpressionResultBuilder builder = new ExpressionResultBuilder(exprResult);
+		final ILocation loc = mLocationFactory.createCLocation(node);
+		if (!exprResult.hasLRValue()) {
 			// creates a void expression for null RValues
 			final Expression newExpression = ExpressionFactory.createVoidDummyExpression(loc);
 			final RValue rVal = new RValue(newExpression, new CPrimitive(CPrimitives.VOID));
-			exprWithType = new ExpressionResultBuilder().addAllExceptLrValue(exprWithType).setLrValue(rVal).build();
+			builder.resetLrValue(rVal);
 		}
-		exprWithType = mExprResultTransformer.makeRepresentationReadyForConversion(exprWithType, loc, newCType, node);
-		checkUnsupportedPointerCast(exprWithType, loc, newCType);
+		final ExpressionResult exprResultReady =
+				mExprResultTransformer.makeRepresentationReadyForConversion(builder.build(), loc, type, node);
+		checkUnsupportedPointerCast(exprResultReady, loc, type);
 
 		if (mSettings.isAdaptMemoryStructureResolutionOnPointerCasts() && mIsPrerun) {
-			checkIfNecessaryMemoryStructureAdaption(loc, newCType, exprWithType);
+			checkIfNecessaryMemoryStructureAdaption(loc, type, exprResultReady);
 		}
 
-		exprWithType = mExprResultTransformer.rexBoolToInt(exprWithType, loc);
-		return mExprResultTransformer.performImplicitConversion(exprWithType, newCType, loc);
+		return mExprResultTransformer
+				.performImplicitConversion(mExprResultTransformer.rexBoolToInt(exprResultReady, loc), type, loc);
 	}
 
 	private void checkIfNecessaryMemoryStructureAdaption(final ILocation loc, final ICType castTargetType,
@@ -1727,12 +1731,29 @@ public class CHandler {
 				throw new UnsupportedSyntaxException(loc, "Thread local variables are not supported yet.");
 			}
 		}
+		// WOKAROUND: On non-preprocessed files, casts may be accidentally misparsed as function calls, if the type is
+		// defined in some include (e.g., size_t) that we currently don't handle, if the expression is also in
+		// parentheses. In that case we just handle the handle the "function call" in the AST just as a cast.
+		final ICType castType = getTypeOfMisparsedCast(node);
+		if (castType != null) {
+			return handleCast(castType, node, (ExpressionResult) main.dispatch(node.getArguments()[0]));
+		}
 		final Result standardFunction = mLibraryModelHandler.translateStandardFunction(main, node);
 		if (standardFunction != null) {
 			return standardFunction;
 		}
 		return mFunctionHandler.handleFunctionCallExpression(main, loc, functionName, node.getArguments(),
 				mMemoryHandler);
+	}
+
+	private ICType getTypeOfMisparsedCast(final IASTFunctionCallExpression node) {
+		if (node.getArguments().length == 1
+				&& node.getFunctionNameExpression() instanceof final IASTUnaryExpression unary
+				&& unary.getOperator() == IASTUnaryExpression.op_bracketedPrimary
+				&& unary.getOperand() instanceof final IASTIdExpression id) {
+			return mTypeHandler.getLibraryType(id.getName().toString());
+		}
+		return null;
 	}
 
 	public Result visit(final IDispatcher main, final IASTFunctionDefinition node) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
@@ -858,6 +858,11 @@ public class TypeHandler implements ITypeHandler {
 		mLibraryTypes.putAll(libraryTypes);
 	}
 
+	@Override
+	public ICType getLibraryType(final String name) {
+		return mLibraryTypes.get(name);
+	}
+
 	public static boolean isCharArray(final ICType cTypeRaw) {
 		return cTypeRaw.getUnderlyingType() instanceof final CArray cArrayType
 				&& cArrayType.getValueType().getUnderlyingType() instanceof final CPrimitive cPrimitive

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/ITypeHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/ITypeHandler.java
@@ -190,5 +190,7 @@ public interface ITypeHandler {
 
 	void addLibraryTypes(Map<String, ICType> libraryTypes);
 
+	ICType getLibraryType(String name);
+
 	IMemoryPointer getMemoryPointer();
 }


### PR DESCRIPTION
Recently, we added some support for non-preprocessed files wrt. system includes. To do so, our implementations of `ILibraryModel` contain definitions of macros, functions and types defined in those includes, modeled in Boogie. However, we don't actually handle the includes, therefore they are unknown to the CDT parser. While this works fine for most of the cases, a cast with a type only defined in a system header, where the expression to be casted (such as `(size_t) (x)`) is actually parsed as a function call. Therefore, we may crash when handling this "function call", since the function name (i.e., the actual type name) is not known.

As a workaround, this PR identifies such "function calls" that are misparsed casts (i.e., function calls, where the "name" is a type in our library models that is in brackets) and handles them the same way as casts are usually handled. To do so, the code for handling casts was slightly refactored and simplified.