### PR TITLE
Some memory model simplifications

### DIFF
--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/TypeHandler.java
@@ -865,7 +865,6 @@ public class TypeHandler implements ITypeHandler {
 						|| cPrimitive.getType() == CPrimitives.SCHAR);
 	}
 
-	@Override
 	public IMemoryPointer getMemoryPointer() {
 		return mMemoryPointer;
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -253,6 +253,11 @@ public interface IMemoryAdressing {
 			final RequiredMemoryModelFeatures requiredFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
-	Expression getValidArray(final ILocation loc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	/**
+	 * Constructs a boolean expression that, when evaluated at the end of a procedure invocation, results in
+	 * {@code true} iff no memory is allocated that was not already allocated at the beginning of the invocation.
+	 */
+	Expression constructMemoryNeutralityCheckExpr(final ILocation loc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -35,7 +35,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
@@ -140,16 +139,6 @@ public interface IMemoryAdressing {
 			final BigInteger integerConstant);
 
 	/**
-	 * Constructs the specifications that the pointer base address is valid.
-	 *
-	 * @return The specifications.
-	 */
-	List<Specification> constructPointerValidityCheck(final ILocation loc, final String ptrName,
-			final String procedureName, final CheckMode mode,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
-
-	/**
 	 * Constructs the pointer base validity check expression.
 	 *
 	 * @return The expression.
@@ -163,9 +152,8 @@ public interface IMemoryAdressing {
 	 *
 	 * @return The specifications.
 	 */
-	List<Specification> constructPointerTargetFullyAllocatedCheck(final ILocation loc, final Expression size,
-			final String ptrName, final String procedureName, final CheckMode mode,
-			final Boolean isBitVectorTranslation, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	Expression constructPointerTargetFullyAllocatedCheckExpr(final ILocation loc, Expression ptr, final Expression size,
+			final boolean isBitVectorTranslation, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -161,8 +161,8 @@ public interface IMemoryAdressing {
 	 *
 	 * @return The statements.
 	 */
-	List<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
-			final boolean isPointerCheckRequired, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	List<Expression> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -38,7 +38,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizeAndOffsetComputer.Offset;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
@@ -120,14 +119,6 @@ public interface IMemoryAdressing {
 	 * @return The step size.
 	 */
 	BigInteger getFixedAddressCounterCountingStep(final Expression size);
-
-	/**
-	 * Returns the address for a field in a struct.
-	 *
-	 * @return The address.
-	 */
-	Expression constructAddressForStructField(final ILocation loc, final Expression baseAddress,
-			final Offset fieldOffset, final CPrimitive sizeT);
 
 	/**
 	 * Adds an integer to a pointer.

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -193,14 +193,6 @@ public interface IMemoryAdressing {
 	Expression addExpressionToPointer(final ILocation loc, final Expression ptrExpr, final Expression expr);
 
 	/**
-	 * Returns a pointer to the last character of a string.
-	 *
-	 * @return The pointer.
-	 */
-	Expression getLastCharOfString(final ILocation loc, final CPrimitive sizeT, final IdentifierExpression len,
-			final IdentifierExpression returnValue);
-
-	/**
 	 * Creates the assume statement used in the handling of strchr.
 	 *
 	 * @return The statement.

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -45,7 +45,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.CheckMode;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
@@ -208,16 +207,6 @@ public interface IMemoryAdressing {
 	 */
 	AssumeStatement constructStrChrAssumeStatement(final ILocation loc, final Expression tmpExpr,
 			final Expression argSPtr, final Expression nullPtrExpr,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
-
-	/**
-	 * Constructs assert / assume statements for ptr memsafety checks.
-	 *
-	 * @return The statements.
-	 */
-	List<Statement> constructMemSafeStatementsForPointerExpression(final ILocation loc, final Expression ptr,
-			final CheckMode pointerBaseValid, final CheckMode pointerTargetFullyAllocated,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryAdressing.java
@@ -29,7 +29,6 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
@@ -38,14 +37,13 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryManagementStrategy.AllocationProcedureSpec;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * The interface defining the functions for the different memory addressing schemes.
@@ -70,20 +68,29 @@ public interface IMemoryAdressing {
 	List<MemoryModelDeclarations> getMetaDataDeclarations();
 
 	/**
-	 * Constructs a list of expressions that are used in the specifications of malloc.
+	 * Constructs the specification of malloc.
 	 *
-	 * @return The expressions.
+	 * @return a record representing the specification
 	 */
-	List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(ILocation tuLoc,
-			MemoryArea memoryArea, RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	AllocationProcedureSpec constructMallocSpecification(ILocation tuLoc, MemoryArea memoryArea,
+			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
 	/**
-	 * Constructs a list of expressions that are used in the specifications of dealloc.
+	 * Constructs the specification of dealloc.
 	 *
-	 * @return The expressions.
+	 * @return a record representing the specification
 	 */
-	List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(ILocation tuLoc,
+	AllocationProcedureSpec constructDeallocSpecification(ILocation tuLoc,
+			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
+
+	/**
+	 * Constructs the specification of allocInit.
+	 *
+	 * @return a record representing the specification
+	 */
+	AllocationProcedureSpec constructAllocInitSpecification(ILocation tuLoc,
 			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
@@ -95,15 +102,6 @@ public interface IMemoryAdressing {
 	List<Statement> constructUltimateInitStatements(ILocation loc,
 			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler, BigInteger fixedAddressCounter);
-
-	/**
-	 * Constructs the expressions used in the specifications for allocInit.
-	 *
-	 * @return The expressions.
-	 */
-	List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(ILocation tuLoc,
-			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
 	/**
 	 * Add or subtracts a pointer and an integer.

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryManagementStrategy.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryManagementStrategy.java
@@ -27,15 +27,17 @@
 package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
+import de.uni_freiburg.informatik.ultimate.boogie.ast.EnsuresSpecification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * This interface defines the functions for different memory management strategies. E.g. counting up, counting down, or
@@ -45,20 +47,29 @@ import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
  */
 public interface IMemoryManagementStrategy {
 	/**
-	 * Constructs a list of expressions that are used in the specifications of malloc.
+	 * Constructs the specification of malloc.
 	 *
-	 * @return The expressions.
+	 * @return a record representing the specification
 	 */
-	List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(ILocation tuLoc,
-			MemoryArea memoryArea, RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	AllocationProcedureSpec constructMallocSpecification(ILocation tuLoc, MemoryArea memoryArea,
+			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
 	/**
-	 * Constructs a list of expressions that are used in the specifications of dealloc.
+	 * Constructs the specification of dealloc.
 	 *
-	 * @return The expressions.
+	 * @return a record representing the specification
 	 */
-	List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(ILocation tuLoc,
+	AllocationProcedureSpec constructDeallocSpecification(ILocation tuLoc,
+			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
+
+	/**
+	 * Constructs the specification for allocInit.
+	 *
+	 * @return a record representing the specification
+	 */
+	AllocationProcedureSpec constructAllocInitSpecification(ILocation tuLoc,
 			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
 
@@ -72,11 +83,49 @@ public interface IMemoryManagementStrategy {
 			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler, BigInteger fixedAddressCounter);
 
 	/**
-	 * Constructs the expressions used in the specifications for allocInit.
+	 * Encapsulates the specification for an allocation procedure.
 	 *
-	 * @return The expressions.
+	 * Currently, we do not allow allocation procedures to have "requires" clauses.
+	 *
+	 * @param ensures
+	 *            the "ensures" clauses for the procedure
+	 * @param freeEnsures
+	 *            the "free ensures" clauses for the procedure
+	 * @param modifies
+	 *            the set of modified global variables of the procedure
 	 */
-	List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(ILocation tuLoc,
-			RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			MemoryModelDeclarationsHandler memoryModelDeclarationsHandler);
+	record AllocationProcedureSpec(List<Expression> ensures, List<Expression> freeEnsures, Set<VariableLHS> modifies) {
+		/**
+		 * Convenience constructor for specs that do not have "free ensures" clauses.
+		 */
+		AllocationProcedureSpec(final List<Expression> ensures, final Set<VariableLHS> modifies) {
+			this(ensures, Collections.emptyList(), modifies);
+		}
+
+		public AllocationProcedureSpec {
+			Objects.requireNonNull(ensures);
+			Objects.requireNonNull(freeEnsures);
+			Objects.requireNonNull(modifies);
+		}
+
+		/**
+		 * Constructs "requires" resp. "free requires" clauses from the expressions stored in this specification.
+		 *
+		 * Note: Do not forget to handle the "modifies" clauses separately!
+		 *
+		 * @param loc
+		 *            the location for the specification clauses
+		 * @return the list of clauses
+		 */
+		List<EnsuresSpecification> constructSpecificationClauses(final ILocation loc) {
+			final var result = new ArrayList<EnsuresSpecification>();
+			for (final Expression ens : ensures) {
+				result.add(new EnsuresSpecification(loc, false, ens));
+			}
+			for (final Expression freeEns : freeEnsures) {
+				result.add(new EnsuresSpecification(loc, true, freeEns));
+			}
+			return result;
+		}
+	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryStructure.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/IMemoryStructure.java
@@ -40,8 +40,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 public interface IMemoryStructure {
 	String getReadProcedureName(final CPrimitives primitive);
 
-	String getUncheckedReadProcedureName(final CPrimitives primitive);
-
 	String getWriteProcedureName(final CPrimitives primitive);
 
 	String getUncheckedWriteProcedureName(final CPrimitives primitive);
@@ -49,8 +47,6 @@ public interface IMemoryStructure {
 	String getInitWriteProcedureName(final CPrimitives primitive);
 
 	String getReadPointerProcedureName();
-
-	String getUncheckedReadPointerProcedureName();
 
 	String getWritePointerProcedureName();
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/InitializationHandler.java
@@ -1089,8 +1089,8 @@ public class InitializationHandler {
 		final CStructOrUnion cStructType = (CStructOrUnion) baseAddress.getCType().getUnderlyingType();
 		final var fieldOffset = mTypeSetAndOffsetComputer.constructOffsetForField(loc, cStructType, fieldIndex);
 
-		final Expression newPointer = mMemoryHandler.constructAddressForStructField(loc, baseAddress.getAddress(),
-				fieldOffset, mTypeSetAndOffsetComputer.getSizeT());
+		final Expression newPointer =
+				mMemoryHandler.constructAddressForStructField(loc, baseAddress.getAddress(), fieldOffset);
 
 		return LRValueFactory.constructHeapLValue(mTypeHandler, newPointer, cStructType.getFieldTypes()[fieldIndex],
 				null);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
@@ -45,7 +45,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.FunctionDeclarations;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.TranslationSettings;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizeAndOffsetComputer.Offset;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.ExpressionTranslation;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitives;
@@ -98,17 +97,6 @@ public class MemoryAddressing1D extends MemoryAdressingBase<MemoryPointer1D> {
 	@Override
 	public BigInteger getFixedAddressCounterCountingStep(final Expression size) {
 		return mTypeSizes.extractIntegerValue(size, new CPrimitive(CPrimitives.LONG));
-	}
-
-	@Override
-	public Expression constructAddressForStructField(final ILocation loc, final Expression baseAddress,
-			final Offset fieldOffset, final CPrimitive sizeT) {
-
-		final Expression pointerBase = mMemoryPointer.getPointerAddress(baseAddress, loc);
-		final Expression sum = mExpressionTranslation.constructArithmeticExpression(loc, IASTBinaryExpression.op_plus,
-				pointerBase, sizeT, fieldOffset.getAddressOffsetAsExpression(loc), sizeT);
-
-		return mMemoryPointer.createPointerFromBase(sum, loc);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
@@ -207,12 +207,4 @@ public class MemoryAddressing1D extends MemoryAdressingBase<MemoryPointer1D> {
 
 		return stmts;
 	}
-
-	@Override
-	public Expression getValidArray(final ILocation loc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		throw new UnsupportedOperationException(
-				"The valid array is not part of the metadata values from the 1D Addressing");
-
-	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
@@ -147,16 +147,6 @@ public class MemoryAddressing1D extends MemoryAdressingBase<MemoryPointer1D> {
 	}
 
 	@Override
-	public Expression getLastCharOfString(final ILocation loc, final CPrimitive sizeT, final IdentifierExpression len,
-			final IdentifierExpression returnValue) {
-		final var lenMinusOne = mExpressionTranslation.constructArithmeticIntegerExpression(loc,
-				IASTBinaryExpression.op_minus, mExpressionTranslation.applyWraparound(loc, sizeT, len), sizeT,
-				mTypeSizes.constructLiteralForIntegerType(loc, sizeT, BigInteger.ONE), sizeT);
-
-		return mMemoryPointer.createPointerFromBase(lenMinusOne, loc);
-	}
-
-	@Override
 	public AssumeStatement constructStrChrAssumeStatement(final ILocation loc, final Expression tmpExpr,
 			final Expression argSPtr, final Expression nullPtrExpr,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing1D.java
@@ -209,14 +209,6 @@ public class MemoryAddressing1D extends MemoryAdressingBase<MemoryPointer1D> {
 	}
 
 	@Override
-	public Expression constructPointerValidityCheckExpr(final ILocation loc, final Expression ptr,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		throw new UnsupportedOperationException("The pointer validity check is not available with the 1D Addressing");
-
-	}
-
-	@Override
 	public Expression getValidArray(final ILocation loc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		throw new UnsupportedOperationException(

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -46,6 +46,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.FunctionDeclarations;
@@ -415,8 +416,12 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 	}
 
 	@Override
-	public Expression getValidArray(final ILocation loc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public Expression constructMemoryNeutralityCheckExpr(final ILocation loc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return MemoryMetadataDefault2D.getValidArray(loc, requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		final Expression validArray =
+				MemoryMetadataDefault2D.getValidArray(loc, requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		return ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ, validArray,
+				ExpressionFactory.constructUnaryExpression(loc, UnaryExpression.Operator.OLD, validArray));
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -32,7 +32,6 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
@@ -202,14 +201,10 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 	}
 
 	@Override
-	public List<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
-			final boolean isPointerCheckRequired, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public List<Expression> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		assert pointerToBeFreed.getCType().getUnderlyingType() instanceof CPointer;
-
-		if (!isPointerCheckRequired) {
-			return Collections.emptyList();
-		}
 
 		final var cTypeOfPointerComponent = mExpressionTranslation.getCTypeOfPointerComponents();
 
@@ -225,7 +220,7 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 		final Expression addrBase = mMemoryPointer.getPointerAddress(pointerToBeFreed.getValue(), loc);
 		final Expression[] idcFree = { addrBase };
 
-		final List<Statement> result = new ArrayList<>();
+		final List<Expression> result = new ArrayList<>();
 
 		/*
 		 * creating the specification according to C99:7.20.3.2-2: The free function causes the space pointed to by ptr
@@ -234,32 +229,27 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 		 * realloc function, or if the space has been deallocated by a call to free or realloc, the behavior is
 		 * undefined.
 		 */
-		final Check check = new Check(Spec.MEMORY_FREE);
 
-		// assert (~addr!offset == 0);
-		final AssertStatement offsetZero = new AssertStatement(loc,
-				ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ, addrOffset, zeroNumericExpr));
-		check.annotate(offsetZero);
+		// ~addr!offset == 0;
+		final Expression offsetZero =
+				ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ, addrOffset, zeroNumericExpr);
 		result.add(offsetZero);
 
 		// assert (~addr!base < #StackHeapBarrier);
 		final Expression inHeapArea =
 				mExpressionTranslation.constructBinaryComparisonIntegerExpression(loc, IASTBinaryExpression.op_lessThan,
 						addrBase, cTypeOfPointerComponent, stackHeapBarrier, cTypeOfPointerComponent);
-		final AssertStatement assertInHeapArea = new AssertStatement(loc, inHeapArea);
-		check.annotate(assertInHeapArea);
-		result.add(assertInHeapArea);
+		result.add(inHeapArea);
 
 		// ~addr!base == 0
 		final Expression isNullPtr =
 				ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ, addrBase, zeroNumericExpr);
 
-		// requires ~addr!base == 0 || #valid[~addr!base];
+		// ~addr!base == 0 || #valid[~addr!base];
 		final Expression addrIsValid = mBooleanArrayHelper
 				.compareWithTrue(ExpressionFactory.constructNestedArrayAccessExpression(loc, valid, idcFree));
-		final AssertStatement baseValid = new AssertStatement(loc,
-				ExpressionFactory.newBinaryExpression(loc, Operator.LOGICOR, isNullPtr, addrIsValid));
-		check.annotate(baseValid);
+		final Expression baseValid =
+				ExpressionFactory.newBinaryExpression(loc, Operator.LOGICOR, isNullPtr, addrIsValid);
 		result.add(baseValid);
 
 		return result;
@@ -280,7 +270,6 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 						mTypeSizeAndOffsetComputer.getSizeT(), integerExpr, mTypeSizeAndOffsetComputer.getSizeT());
 
 		return mMemoryPointer.constructPointerFromBaseAndOffset(baseExpr, offsetMinus, loc);
-
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -56,10 +56,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
-import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Check;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Spec;
-import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.CheckMode;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.PointerIntegerConversion;
 
 /**
@@ -149,6 +146,7 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 				ExpressionFactory.constructNestedArrayAccessExpression(loc, lengthArray, new Expression[] { ptrBase });
 		final Expression sum =
 				constructPointerBinaryArithmeticExpression(loc, IASTBinaryExpression.op_plus, size, ptrOffset);
+		// TODO 2026-01-01: Should this be IASTBinaryExpression.op_lessThan ?
 		Expression leq = constructPointerBinaryComparisonExpression(loc, IASTBinaryExpression.op_lessEqual, sum, aae);
 
 		final Expression zeroNumericLiteral =
@@ -346,64 +344,6 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 				mExpressionTranslation.getCTypeOfPointerComponents(), BigInteger.ZERO);
 
 		return mMemoryPointer.constructPointerFromBaseAndOffset(mMemoryPointer.getPointerAddress(ptr, loc), zero, loc);
-	}
-
-	@Override
-	public List<Statement> constructMemSafeStatementsForPointerExpression(final ILocation loc, final Expression ptr,
-			final CheckMode pointerBaseValid, final CheckMode pointerTargetFullyAllocated,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		final List<Statement> result = new ArrayList<>();
-
-		if (pointerBaseValid != CheckMode.IGNORE) {
-
-			// valid[s.base]
-			final Expression validBase = constructPointerValidityCheckExpr(loc, ptr, requiredMemoryModelFeatures,
-					memoryModelDeclarationsHandler);
-			final var stmt = statementDependentOnCheck(loc, pointerBaseValid, validBase);
-			result.add(stmt);
-		}
-
-		if (pointerTargetFullyAllocated != CheckMode.IGNORE) {
-			// s.offset < length[s.base])
-			final Expression ptrOffset = mMemoryPointer.pointerOffset(ptr, loc);
-			final Expression ptrBase = mMemoryPointer.getPointerAddress(ptr, loc);
-
-			final Expression lengthArray = MemoryMetadataDefault2D.getLengthArray(loc, requiredMemoryModelFeatures,
-					memoryModelDeclarationsHandler);
-
-			final Expression aae = ExpressionFactory.constructNestedArrayAccessExpression(loc, lengthArray,
-					new Expression[] { ptrBase });
-
-			final Expression offsetSmallerLength =
-					constructPointerBinaryComparisonExpression(loc, IASTBinaryExpression.op_lessThan, ptrOffset, aae);
-
-			// s.offset >= 0;
-			final var zeroExpr = mTypeSizes.constructLiteralForIntegerType(loc,
-					mExpressionTranslation.getCTypeOfPointerComponents(), BigInteger.ZERO);
-
-			final Expression offsetNonnegative = constructPointerBinaryComparisonExpression(loc,
-					IASTBinaryExpression.op_greaterEqual, ptrOffset, zeroExpr);
-
-			final Expression aAndB = ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, offsetSmallerLength,
-					offsetNonnegative);
-
-			final var stmt = statementDependentOnCheck(loc, pointerTargetFullyAllocated, aAndB);
-			result.add(stmt);
-		}
-		return result;
-	}
-
-	private static Statement statementDependentOnCheck(final ILocation loc, final CheckMode check,
-			final Expression expr) {
-		if (check == CheckMode.CHECK) {
-			final AssertStatement assertion = new AssertStatement(loc, expr);
-			final Check chk = new Check(Spec.MEMORY_DEREFERENCE);
-			chk.annotate(assertion);
-			return assertion;
-		}
-		assert check == CheckMode.ASSUME : "missed a case?";
-		return new AssumeStatement(loc, expr);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -50,7 +50,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.FunctionDeclarations;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizeAndOffsetComputer.Offset;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.ExpressionTranslation;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
@@ -107,19 +106,6 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 	@Override
 	public BigInteger getFixedAddressCounterCountingStep(final Expression size) {
 		return BigInteger.ONE;
-	}
-
-	@Override
-	public Expression constructAddressForStructField(final ILocation loc, final Expression baseAddress,
-			final Offset fieldOffset, final CPrimitive sizeT) {
-
-		final Expression pointerBase = mMemoryPointer.getPointerAddress(baseAddress, loc);
-		final Expression pointerOffset = mMemoryPointer.pointerOffset(baseAddress, loc);
-
-		final Expression sum = mExpressionTranslation.constructArithmeticExpression(loc, IASTBinaryExpression.op_plus,
-				pointerOffset, sizeT, fieldOffset.getAddressOffsetAsExpression(loc), sizeT);
-
-		return mMemoryPointer.constructPointerFromBaseAndOffset(pointerBase, sum, loc);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -37,8 +37,6 @@ import java.util.List;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
 
-import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation;
-import de.uni_freiburg.informatik.ultimate.boogie.DeclarationInformation.StorageClass;
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.StatementFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayAccessExpression;
@@ -46,11 +44,8 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.RequiresSpecification;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
@@ -141,44 +136,12 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 	}
 
 	@Override
-	public List<Specification> constructPointerValidityCheck(final ILocation loc, final String ptrName,
-			final String procedureName, final CheckMode mode,
+	public Expression constructPointerTargetFullyAllocatedCheckExpr(final ILocation loc, final Expression ptr,
+			final Expression size, final boolean isBitVectorTranslation,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		if (mode == CheckMode.IGNORE) {
-			return Collections.emptyList();
-		}
-
-		final Expression ptrExpr =
-				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogiePointerType(), ptrName,
-						new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureName));
-		final Expression isValid = constructPointerValidityCheckExpr(loc, ptrExpr, requiredMemoryModelFeatures,
-				memoryModelDeclarationsHandler);
-
-		final boolean isFreeRequires = mode == CheckMode.CHECK ? false : true;
-
-		final RequiresSpecification spec = new RequiresSpecification(loc, isFreeRequires, isValid);
-		final Check check = new Check(Spec.MEMORY_DEREFERENCE);
-		check.annotate(spec);
-		return Collections.singletonList(spec);
-	}
-
-	@Override
-	public List<Specification> constructPointerTargetFullyAllocatedCheck(final ILocation loc, final Expression size,
-			final String ptrName, final String procedureName, final CheckMode mode,
-			final Boolean isBitVectorTranslation, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-
-		if (mode == CheckMode.IGNORE) {
-			return Collections.emptyList();
-		}
-
-		final Expression ptrExpr =
-				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogiePointerType(), ptrName,
-						new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureName));
-
-		final Expression ptrBase = mMemoryPointer.getPointerAddress(ptrExpr, loc);
-		final Expression ptrOffset = mMemoryPointer.pointerOffset(ptrExpr, loc);
+		final Expression ptrBase = mMemoryPointer.getPointerAddress(ptr, loc);
+		final Expression ptrOffset = mMemoryPointer.pointerOffset(ptr, loc);
 		final CPrimitive cTypeOfPointerComponent = mExpressionTranslation.getCTypeOfPointerComponents();
 
 		final Expression lengthArray = MemoryMetadataDefault2D.getLengthArray(loc, requiredMemoryModelFeatures,
@@ -206,14 +169,7 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 			leq = ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.LOGICAND, leq, noOverFlowInSum);
 		}
 
-		final Expression offsetInAllocatedRange =
-				ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.LOGICAND, leq, offsetGeqZero);
-
-		final boolean isFreeRequires = mode == CheckMode.CHECK ? false : true;
-		final RequiresSpecification spec = new RequiresSpecification(loc, isFreeRequires, offsetInAllocatedRange);
-		final Check check = new Check(Spec.MEMORY_DEREFERENCE);
-		check.annotate(spec);
-		return Collections.singletonList(spec);
+		return ExpressionFactory.newBinaryExpression(loc, BinaryExpression.Operator.LOGICAND, leq, offsetGeqZero);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAddressing2D.java
@@ -284,17 +284,6 @@ public class MemoryAddressing2D extends MemoryAdressingBase<MemoryPointer2D> {
 	}
 
 	@Override
-	public Expression getLastCharOfString(final ILocation loc, final CPrimitive sizeT, final IdentifierExpression len,
-			final IdentifierExpression returnValue) {
-		final var lenMinusOne = mExpressionTranslation.constructArithmeticIntegerExpression(loc,
-				IASTBinaryExpression.op_minus, mExpressionTranslation.applyWraparound(loc, sizeT, len), sizeT,
-				mTypeSizes.constructLiteralForIntegerType(loc, sizeT, BigInteger.ONE), sizeT);
-
-		return mMemoryPointer.constructPointerFromBaseAndOffset(mMemoryPointer.getPointerAddress(returnValue, loc),
-				lenMinusOne, loc);
-	}
-
-	@Override
 	public AssumeStatement constructStrChrAssumeStatement(final ILocation loc, final Expression tmpExpr,
 			final Expression argSPtr, final Expression nullPtrExpr,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -113,9 +113,6 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 			} else {
 				throw new UnsupportedOperationException("Unknown pointer type " + mMemoryPointer.getClass());
 			}
-		default:
-			throw new UnsupportedOperationException(
-					"Pointer-Integer conversion not yet implemented " + pointerIntegerMode);
 		};
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -27,7 +27,6 @@
 package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -53,7 +52,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.CheckMode;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.PointerIntegerConversion;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
@@ -232,19 +230,6 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 		throw new UnsupportedOperationException(
 				"The check if the freed pointer is valid is not compatible with the selected: " + this.getClass()
 						+ "  addressing mode!");
-	}
-
-	@Override
-	public List<Statement> constructMemSafeStatementsForPointerExpression(final ILocation loc, final Expression ptr,
-			final CheckMode pointerBaseValid, final CheckMode pointerTargetFullyAllocated,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		if (pointerBaseValid == CheckMode.IGNORE && pointerTargetFullyAllocated == CheckMode.IGNORE) {
-			return Collections.emptyList();
-		}
-
-		throw new UnsupportedOperationException(
-				"The MemSafety checks are not compatible with the selected: " + this.getClass() + "  addressing mode!");
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -28,7 +28,6 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Set;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
 
@@ -36,9 +35,9 @@ import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.FunctionDeclarations;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryManagementStrategy.AllocationProcedureSpec;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.ExpressionTranslation;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.IPointerIntegerConversion;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.expressiontranslation.NonBijectiveMapping1D;
@@ -53,8 +52,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.PointerIntegerConversion;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * Abstract base class for implementing specific memory addressing schemes based on a memory pointer representation.
@@ -135,18 +132,26 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 	}
 
 	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(final ILocation tuLoc,
-			final MemoryArea memoryArea, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructMallocSpecification(final ILocation tuLoc, final MemoryArea memoryArea,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryManagementStrategy.constructMallocSpecificationExpressions(tuLoc, memoryArea,
-				requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		return mMemoryManagementStrategy.constructMallocSpecification(tuLoc, memoryArea, requiredMemoryModelFeatures,
+				memoryModelDeclarationsHandler);
 	}
 
 	@Override
-	public List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(
-			final ILocation tuLoc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructDeallocSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryManagementStrategy.constructDeallocSpecificationExpressions(tuLoc, requiredMemoryModelFeatures,
+		return mMemoryManagementStrategy.constructDeallocSpecification(tuLoc, requiredMemoryModelFeatures,
+				memoryModelDeclarationsHandler);
+	}
+
+	@Override
+	public AllocationProcedureSpec constructAllocInitSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
+		return mMemoryManagementStrategy.constructAllocInitSpecification(tuLoc, requiredMemoryModelFeatures,
 				memoryModelDeclarationsHandler);
 	}
 
@@ -156,14 +161,6 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler, final BigInteger fixedAddressCounter) {
 		return mMemoryManagementStrategy.constructUltimateInitStatements(loc, requiredMemoryModelFeatures,
 				memoryModelDeclarationsHandler, fixedAddressCounter);
-	}
-
-	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(final ILocation tuLoc,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryManagementStrategy.constructAllocInitSpecificationExpressions(tuLoc, requiredMemoryModelFeatures,
-				memoryModelDeclarationsHandler);
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -224,14 +224,10 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 	}
 
 	@Override
-	public List<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
-			final boolean isPointerCheckRequired, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public List<Expression> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		assert pointerToBeFreed.getCType().getUnderlyingType() instanceof CPointer;
-
-		if (!isPointerCheckRequired) {
-			return Collections.emptyList();
-		}
 
 		throw new UnsupportedOperationException(
 				"The check if the freed pointer is valid is not compatible with the selected: " + this.getClass()

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -36,7 +36,6 @@ import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
@@ -210,30 +209,21 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 	}
 
 	@Override
-	public List<Specification> constructPointerValidityCheck(final ILocation loc, final String ptrName,
-			final String procedureName, final CheckMode mode,
+	public Expression constructPointerValidityCheckExpr(final ILocation loc, final Expression ptr,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		if (mode == CheckMode.IGNORE) {
-			return Collections.emptyList();
-		}
-
 		throw new UnsupportedOperationException("The pointer base validity check is not compatible with the selected: "
 				+ this.getClass() + " addressing mode!");
 	}
 
 	@Override
-	public List<Specification> constructPointerTargetFullyAllocatedCheck(final ILocation loc, final Expression size,
-			final String ptrName, final String procedureName, final CheckMode mode,
-			final Boolean isBitVectorTranslation, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public Expression constructPointerTargetFullyAllocatedCheckExpr(final ILocation loc, final Expression ptr,
+			final Expression size, final boolean isBitVectorTranslation,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		if (mode == CheckMode.IGNORE) {
-			return Collections.emptyList();
-		}
-
 		throw new UnsupportedOperationException(
 				"The target pointer fully allocated check is not compatible with the selected: " + this.getClass()
-						+ "  " + "addressing mode!");
+						+ "  addressing mode!");
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryAdressingBase.java
@@ -240,6 +240,14 @@ public abstract class MemoryAdressingBase<T extends IMemoryPointer> implements I
 						+ "  addressing mode!");
 	}
 
+	@Override
+	public Expression constructMemoryNeutralityCheckExpr(final ILocation loc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
+		throw new UnsupportedOperationException("The check for memory neutrality is not compatible with the selected: "
+				+ this.getClass() + " addressing mode!");
+	}
+
 	/**
 	 * Creates a valid expression representing a pointer subtractions of a pointer component. The component is either
 	 * base or offset.

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -2720,11 +2720,6 @@ public class MemoryHandler {
 		return mMemoryModel.createFunctionPointer(loc, offset);
 	}
 
-	public final Expression lastCharOfString(final ILocation loc, final CPrimitive sizeT,
-			final IdentifierExpression len, final IdentifierExpression returnValue) {
-		return mMemoryModel.lastCharOfString(loc, sizeT, len, returnValue);
-	}
-
 	public final Expression initialPointerFromPointer(final ILocation loc, final Expression ptr) {
 		return mMemoryModel.initialPointerFromPointer(loc, ptr);
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -74,6 +74,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.LoopInvariantSpecification
 import de.uni_freiburg.informatik.ultimate.boogie.ast.NamedAttribute;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Procedure;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.QuantifierExpression;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.RequiresSpecification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StructAccessExpression;
@@ -120,8 +121,11 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.INameHandler;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
+import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Check;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.annotation.Overapprox;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.Spec;
+import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.CheckMode;
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.MemoryStructure;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.LinkedScopedHashMap;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
@@ -1751,13 +1755,13 @@ public class MemoryHandler {
 	 * memory at the base address of the pointer. Furthermore, we check that the offset is greater than or equal to
 	 * zero.
 	 *
-	 * In case mPointerBaseValidity is CHECK, we construct the requires specification
+	 * In case {@code mSettings.checkPointerDerefValidity()} is CHECK, we construct the requires specification
 	 * <code>requires (#size + #ptr!offset <= #length[#ptr!base] && 0 <= #ptr!offset)</code>.
 	 *
-	 * In case mPointerBaseValidity is CHECK, we construct the <b>free</b> requires specification
-	 * <code>free requires (#size + #ptr!offset <= #length[#ptr!base] && 0 <= #ptr!offset)</code>.
+	 * In case {@code mSettings.checkPointerDerefValidity()} is ASSUME, we construct the <b>free</b> requires
+	 * specification <code>free requires (#size + #ptr!offset <= #length[#ptr!base] && 0 <= #ptr!offset)</code>.
 	 *
-	 * In case mPointerBaseValidity is IGNORE, we construct nothing.
+	 * In case {@code mSettings.checkPointerDerefValidity()} is IGNORE, we construct nothing.
 	 *
 	 * @param loc
 	 *            location of translation unit
@@ -1769,17 +1773,36 @@ public class MemoryHandler {
 	 */
 	public List<Specification> constructPointerTargetFullyAllocatedCheck(final ILocation loc, final Expression size,
 			final String ptrName, final String procedureName) {
-		return mMemoryModel.constructPointerTargetFullyAllocatedCheck(loc, size, ptrName, procedureName,
-				mSettings.checkPointerDerefValidity(), mSettings.isBitvectorTranslation(), mRequiredMemoryModelFeatures,
+		final var mode = mSettings.checkPointerDerefValidity();
+		if (mode == CheckMode.IGNORE) {
+			return Collections.emptyList();
+		}
+
+		final Expression ptrExpr =
+				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogiePointerType(), ptrName,
+						new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureName));
+
+		final Expression offsetInAllocatedRange = mMemoryModel.constructPointerTargetFullyAllocatedCheckExpr(loc,
+				ptrExpr, size, mSettings.isBitvectorTranslation(), mRequiredMemoryModelFeatures,
 				mMemoryModelDeclarationsHandler);
+
+		final boolean isFreeRequires = mode == CheckMode.ASSUME;
+		final RequiresSpecification spec = new RequiresSpecification(loc, isFreeRequires, offsetInAllocatedRange);
+		final Check check = new Check(Spec.MEMORY_DEREFERENCE);
+		check.annotate(spec);
+		return Collections.singletonList(spec);
 	}
 
 	/**
-	 * Construct specification that the pointer base address is valid. In case
-	 * {@link #getPointerBaseValidityCheckMode()} is ASSERTandASSUME, we add the requires specification
-	 * <code>requires #valid[#ptr!base]</code>. In case {@link #getPointerBaseValidityCheckMode()} is ASSERTandASSUME,
-	 * we add the <b>free</b> requires specification <code>free requires #valid[#ptr!base]</code>. In case
-	 * {@link #getPointerBaseValidityCheckMode()} is IGNORE, we add nothing.
+	 * Construct specification that the pointer base address is valid.
+	 *
+	 * In case {@code mSettings.checkPointerDerefValidity()} is CHECK, we add the requires specification
+	 * <code>requires #valid[#ptr!base]</code>.
+	 *
+	 * In case {@code mSettings.checkPointerDerefValidity()} is ASSUME, we add the <b>free</b> requires specification
+	 * <code>free requires #valid[#ptr!base]</code>.
+	 *
+	 * In case {@code mSettings.checkPointerDerefValidity()} is IGNORE, we add nothing.
 	 *
 	 * @param loc
 	 *            location of translation unit
@@ -1791,8 +1814,24 @@ public class MemoryHandler {
 	 */
 	public List<Specification> constructPointerBaseValidityCheck(final ILocation loc, final String ptrName,
 			final String procedureName) {
-		return mMemoryModel.constructPointerBaseValidityCheck(loc, ptrName, procedureName,
-				mSettings.checkPointerDerefValidity(), mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		final var mode = mSettings.checkPointerDerefValidity();
+		if (mode == CheckMode.IGNORE) {
+			return Collections.emptyList();
+		}
+
+		final Expression ptrExpr =
+				ExpressionFactory.constructIdentifierExpression(loc, mTypeHandler.getBoogiePointerType(), ptrName,
+						new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureName));
+
+		final Expression isValid = mMemoryModel.constructPointerBaseValidityCheckExpr(loc, ptrExpr,
+				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+
+		final boolean isFreeRequires = mode == CheckMode.ASSUME;
+
+		final RequiresSpecification spec = new RequiresSpecification(loc, isFreeRequires, isValid);
+		final Check check = new Check(Spec.MEMORY_DEREFERENCE);
+		check.annotate(spec);
+		return Collections.singletonList(spec);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -2664,14 +2664,41 @@ public class MemoryHandler {
 
 	/**
 	 * Construct assert statements that do memsafety checks for {@link pointerValue} if the corresponding settings are
-	 * active. settings concerned are: - "Pointer base address is valid at dereference" - "Pointer to allocated memory
-	 * at dereference"
+	 * active.
 	 */
 	public List<Statement> constructMemsafetyChecksForPointerExpression(final ILocation loc,
 			final Expression pointerValue) {
-		return mMemoryModel.constructMemSafeStatementsForPointerExpression(loc, pointerValue,
-				mSettings.checkPointerDerefValidity(), mSettings.checkPointerDerefValidity(),
+		final var mode = mSettings.checkPointerDerefValidity();
+		if (mode == CheckMode.IGNORE) {
+			return Collections.emptyList();
+		}
+
+		final List<Statement> result = new ArrayList<>();
+
+		final Expression validBase = mMemoryModel.constructPointerBaseValidityCheckExpr(loc, pointerValue,
 				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		result.add(statementDependentOnCheck(loc, mode, validBase));
+
+		final Expression zero = mExpressionTranslation.constructLiteralForIntegerType(loc,
+				mExpressionTranslation.getCTypeOfPointerComponents(), BigInteger.ZERO);
+		final Expression pointerTargetFullyAllocated = mMemoryModel.constructPointerTargetFullyAllocatedCheckExpr(loc,
+				pointerValue, zero, mSettings.isBitvectorTranslation(), mRequiredMemoryModelFeatures,
+				mMemoryModelDeclarationsHandler);
+		result.add(statementDependentOnCheck(loc, mode, pointerTargetFullyAllocated));
+
+		return result;
+	}
+
+	private static Statement statementDependentOnCheck(final ILocation loc, final CheckMode check,
+			final Expression expr) {
+		if (check == CheckMode.CHECK) {
+			final AssertStatement assertion = new AssertStatement(loc, expr);
+			final Check chk = new Check(Spec.MEMORY_DEREFERENCE);
+			chk.annotate(assertion);
+			return assertion;
+		}
+		assert check == CheckMode.ASSUME : "missed a case?";
+		return new AssumeStatement(loc, expr);
 	}
 
 	public List<Statement> ultimateInitStatements(final ILocation loc) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -663,9 +663,9 @@ public class MemoryHandler {
 	 *            the address to read from.
 	 * @param resultType
 	 *            the CType of the pointer
-	 * @return an ExpressionResult consisting only of a array access to the memory array.
+	 * @return an array access to the memory array.
 	 */
-	public ExpressionResult getReadUnchecked(final Expression address, final ICType resultType) {
+	public Expression getReadUnchecked(final Expression address, final ICType resultType) {
 		final int byteSize;
 		if (resultType instanceof CPointer) {
 			byteSize = mTypeSizes.getSizeOfPointer();
@@ -675,8 +675,7 @@ public class MemoryHandler {
 			throw new AssertionError("We only support reading primitive or pointer types");
 		}
 		final ILocation loc = address.getLocation();
-		return new ExpressionResult(new RValue(
-				readFromHeap(loc, determineMemoryArrayForType(resultType), address, resultType, byteSize), resultType));
+		return readFromHeap(loc, determineMemoryArrayForType(resultType), address, resultType, byteSize);
 	}
 
 	private String determineReadProcedure(final ICType resultType, final ILocation loc) throws AssertionError {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -864,8 +864,11 @@ public class MemoryHandler {
 	}
 
 	public Expression constructAddressForStructField(final ILocation loc, final Expression baseAddress,
-			final Offset fieldOffset, final CPrimitive type) {
-		return mMemoryModel.constructAddressForStructField(loc, baseAddress, fieldOffset, type);
+			final Offset fieldOffset) {
+		if (fieldOffset.isBitfieldOffset()) {
+			throw new UnsupportedOperationException("Bitfield read");
+		}
+		return mMemoryModel.addExpressionToPointer(loc, baseAddress, fieldOffset.getAddressOffsetAsExpression(loc));
 	}
 
 	public void beginScope() {
@@ -2037,8 +2040,7 @@ public class MemoryHandler {
 				throw new UnsupportedOperationException("Bitfield write");
 			}
 
-			final Expression newPointer = mMemoryModel.constructAddressForStructField(loc, startAddress, fieldOffset,
-					mExpressionTranslation.getCTypeOfPointerComponents());
+			final Expression newPointer = constructAddressForStructField(loc, startAddress, fieldOffset);
 
 			final HeapLValue fieldHlv = LRValueFactory.constructHeapLValue(mTypeHandler, newPointer, fieldType, null);
 			final StructAccessExpression sae = ExpressionFactory.constructStructAccessExpression(loc, value, fieldId);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -302,8 +302,8 @@ public class MemoryHandler {
 			declarations
 					.add(constructMemoryArrayDeclaration(tuLoc, heapDataArray.getName(), heapDataArray.getASTType()));
 			// create and add read and write procedure
-			declarations.addAll(constructWriteProcedures(main, tuLoc, heapDataArrays, heapDataArray));
-			declarations.addAll(constructReadProcedures(main, tuLoc, heapDataArray));
+			constructWriteProcedures(main, tuLoc, heapDataArrays, heapDataArray);
+			constructReadProcedures(main, tuLoc, heapDataArray);
 		}
 
 		// add store function (to be able to assign subarrays at pointer base addresses)
@@ -328,11 +328,11 @@ public class MemoryHandler {
 			declareDataOnHeapInitFunction(mMemoryModel.getPointerHeapArray());
 		}
 
-		declarations.addAll(declareDeallocation(main, tuLoc));
+		declareDeallocation(main, tuLoc);
 
 		if (mRequiredMemoryModelFeatures.getRequiredMemoryStructureDeclarations()
 				.contains(MemoryModelDeclarations.ULTIMATE_ALLOC_STACK)) {
-			declarations.addAll(declareMalloc(main, mTypeHandler, tuLoc, MemoryArea.STACK));
+			declareMalloc(main, mTypeHandler, tuLoc, MemoryArea.STACK);
 		}
 
 		if (mRequiredMemoryModelFeatures.getRequiredMemoryStructureDeclarations()
@@ -342,7 +342,7 @@ public class MemoryHandler {
 
 		if (mRequiredMemoryModelFeatures.getRequiredMemoryStructureDeclarations()
 				.contains(MemoryModelDeclarations.ULTIMATE_ALLOC_HEAP)) {
-			declarations.addAll(declareMalloc(main, mTypeHandler, tuLoc, MemoryArea.HEAP));
+			declareMalloc(main, mTypeHandler, tuLoc, MemoryArea.HEAP);
 		}
 
 		if (mRequiredMemoryModelFeatures.getRequiredMemoryStructureDeclarations()
@@ -1445,26 +1445,19 @@ public class MemoryHandler {
 		return new VariableDeclaration(loc, new Attribute[0], new VarList[] { varList });
 	}
 
-	private List<Declaration> constructWriteProcedures(final CHandler main, final ILocation loc,
+	private void constructWriteProcedures(final CHandler main, final ILocation loc,
 			final Collection<HeapDataArray> heapDataArrays, final HeapDataArray heapDataArray) {
-		final List<Declaration> result = new ArrayList<>();
 		for (final ReadWriteDefinition rda : mMemoryModel.getReadWriteDefinitionForHeapDataArray(heapDataArray,
 				mRequiredMemoryModelFeatures)) {
-			final Collection<Procedure> writeDeclaration =
-					constructWriteProcedure(main, loc, heapDataArrays, heapDataArray, rda);
-			result.addAll(writeDeclaration);
+			constructWriteProcedure(main, loc, heapDataArrays, heapDataArray, rda);
 		}
-		return result;
 	}
 
-	private List<Declaration> constructReadProcedures(final CHandler main, final ILocation loc,
-			final HeapDataArray heapDataArray) {
-		final List<Declaration> result = new ArrayList<>();
+	private void constructReadProcedures(final CHandler main, final ILocation loc, final HeapDataArray heapDataArray) {
 		for (final ReadWriteDefinition rda : mMemoryModel.getReadWriteDefinitionForHeapDataArray(heapDataArray,
 				mRequiredMemoryModelFeatures)) {
-			result.addAll(constructSingleReadProcedure(main, loc, heapDataArray, rda));
+			constructSingleReadProcedure(main, loc, heapDataArray, rda);
 		}
-		return result;
 	}
 
 	private VariableDeclaration declarePthreadsForkCount(final ILocation loc) {
@@ -1499,7 +1492,7 @@ public class MemoryHandler {
 	 * @param rda
 	 * @return
 	 */
-	private Collection<Procedure> constructWriteProcedure(final CHandler main, final ILocation loc,
+	private void constructWriteProcedure(final CHandler main, final ILocation loc,
 			final Collection<HeapDataArray> heapDataArrays, final HeapDataArray heapDataArray,
 			final ReadWriteDefinition rda) {
 		if (rda.alsoUncheckedWrite()) {
@@ -1509,7 +1502,6 @@ public class MemoryHandler {
 			constructSingleWriteProcedure(main, loc, heapDataArrays, heapDataArray, rda, HeapWriteMode.SELECT);
 		}
 		constructSingleWriteProcedure(main, loc, heapDataArrays, heapDataArray, rda, HeapWriteMode.STORE_CHECKED);
-		return Collections.emptySet();
 	}
 
 	private void constructSingleWriteProcedure(final CHandler main, final ILocation loc,
@@ -1671,8 +1663,8 @@ public class MemoryHandler {
 	 *            whether we should construct an unchecked read procedure (i.e. one that omits validity checks)
 	 * @return
 	 */
-	private List<Procedure> constructSingleReadProcedure(final CHandler main, final ILocation loc,
-			final HeapDataArray hda, final ReadWriteDefinition rda) {
+	private void constructSingleReadProcedure(final CHandler main, final ILocation loc, final HeapDataArray hda,
+			final ReadWriteDefinition rda) {
 		// specification for memory reads
 		final String returnValue = "#value";
 		final ASTType valueAstType = rda.getASTType();
@@ -1718,8 +1710,6 @@ public class MemoryHandler {
 
 		mProcedureManager.addSpecificationsToCurrentProcedure(sread);
 		mProcedureManager.endCustomProcedure(main, readProcedureName);
-
-		return Collections.emptyList();
 	}
 
 	private Expression readFromHeap(final ILocation loc, final HeapDataArray hda, final Expression address,
@@ -1852,19 +1842,6 @@ public class MemoryHandler {
 	}
 
 	/**
-	 * Compare a pointer component (base or offset) to another expression.
-	 *
-	 * @param op
-	 *            One of the comparison operators defined in {@link IASTBinaryExpression}.
-	 */
-	private Expression constructPointerBinaryComparisonExpression(final ILocation loc, final int op,
-			final Expression left, final Expression right) {
-		return mExpressionTranslation.constructBinaryComparisonExpression(loc, op, left,
-				mExpressionTranslation.getCTypeOfPointerComponents(), right,
-				mExpressionTranslation.getCTypeOfPointerComponents());
-	}
-
-	/**
 	 * Generate <code>procedure ULTIMATE.dealloc(~addr:$Pointer$) returns()</code>'s declaration and implementation.
 	 * This procedure should be used for deallocations where do not want to check if given memory area is valid (because
 	 * we already know this) which is the case, e.g., for arrays that we store on the heap or for alloca.
@@ -1874,8 +1851,7 @@ public class MemoryHandler {
 	 *
 	 * @return declaration and implementation of procedure <code>Ultimate_dealloc</code>
 	 */
-	private List<Declaration> declareDeallocation(final CHandler main, final ILocation tuLoc) {
-
+	private void declareDeallocation(final CHandler main, final ILocation tuLoc) {
 		final Procedure deallocDeclaration = new Procedure(tuLoc, new Attribute[0],
 				MemoryModelDeclarations.ULTIMATE_DEALLOC.getName(), new String[0],
 				new VarList[] {
@@ -1890,7 +1866,6 @@ public class MemoryHandler {
 		mProcedureManager.addSpecificationsToCurrentProcedure(specification.constructSpecificationClauses(tuLoc));
 
 		mProcedureManager.endCustomProcedure(main, MemoryModelDeclarations.ULTIMATE_DEALLOC.getName());
-		return Collections.emptyList();
 	}
 
 	/**
@@ -1903,8 +1878,8 @@ public class MemoryHandler {
 	 *
 	 * @return declaration and implementation of procedure <code>~malloc</code>
 	 */
-	private ArrayList<Declaration> declareMalloc(final CHandler main, final ITypeHandler typeHandler,
-			final ILocation tuLoc, final MemoryArea memArea) {
+	private void declareMalloc(final CHandler main, final ITypeHandler typeHandler, final ILocation tuLoc,
+			final MemoryArea memArea) {
 		final MemoryModelDeclarations alloc = memArea.getMemoryStructureDeclaration();
 		final ASTType intType = typeHandler.cType2AstType(tuLoc, mExpressionTranslation.getCTypeOfPointerComponents());
 		final Procedure allocDeclaration = new Procedure(tuLoc, new Attribute[0], alloc.getName(), new String[0],
@@ -1919,9 +1894,7 @@ public class MemoryHandler {
 		mProcedureManager.addModifiedGlobalsToCurrentProcedure(specification.modifies());
 		mProcedureManager.addSpecificationsToCurrentProcedure(specification.constructSpecificationClauses(tuLoc));
 
-		final ArrayList<Declaration> result = new ArrayList<>();
 		mProcedureManager.endCustomProcedure(main, alloc.getName());
-		return result;
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -1931,11 +1931,10 @@ public class MemoryHandler {
 	 */
 	private void declareAllocInit(final CHandler main, final ITypeHandler typeHandler, final ILocation tuLoc) {
 		final String procedureIdentifier = MemoryModelDeclarations.ULTIMATE_ALLOC_INIT.getName();
-		final String pointerBaseIdentifier = "ptrBase";
 		final ASTType intType = typeHandler.cType2AstType(tuLoc, mExpressionTranslation.getCTypeOfPointerComponents());
 
 		final Procedure allocDeclaration = new Procedure(tuLoc, new Attribute[0], procedureIdentifier, new String[0],
-				new VarList[] { new VarList(tuLoc, new String[] { SFO.SIZE, pointerBaseIdentifier }, intType) },
+				new VarList[] { new VarList(tuLoc, new String[] { SFO.SIZE, SFO.ALLOCINIT_PTRBASE }, intType) },
 				new VarList[0], new Specification[0], null);
 
 		mProcedureManager.beginCustomProcedure(main, tuLoc, procedureIdentifier, allocDeclaration);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -512,12 +512,12 @@ public class MemoryHandler {
 	}
 
 	/**
-	 * @param loc
-	 *            location of translation unit
-	 * @return new IdentifierExpression that represents the <em>#valid array</em>
+	 * Constructs a boolean expression that, when evaluated at the end of a procedure invocation, results in
+	 * {@code true} iff no memory is allocated that was not already allocated at the beginning of the invocation.
 	 */
-	public Expression getValidArray(final ILocation loc) {
-		return mMemoryModel.getValidArray(loc, mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+	public Expression constructMemoryNeutralityCheckExpr(final ILocation loc) {
+		return mMemoryModel.constructMemoryNeutralityCheckExpr(loc, mRequiredMemoryModelFeatures,
+				mMemoryModelDeclarationsHandler);
 	}
 
 	public Expression getMemoryRaceArray(final ILocation loc) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -55,6 +55,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.StatementFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ASTType;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.ArrayType;
+import de.uni_freiburg.informatik.ultimate.boogie.ast.AssertStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AtomicStatement;
@@ -531,9 +532,22 @@ public class MemoryHandler {
 				mMemoryModelDeclarationsHandler);
 	}
 
-	public Collection<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed) {
-		return mMemoryModel.getChecksForFreeCall(loc, pointerToBeFreed, mSettings.checkIfFreedPointerIsValid(),
+	public List<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed) {
+		if (!mSettings.checkIfFreedPointerIsValid()) {
+			return Collections.emptyList();
+		}
+
+		final List<Expression> checkExpressions = mMemoryModel.getChecksForFreeCall(loc, pointerToBeFreed,
 				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		final List<Statement> statements =
+				checkExpressions.stream().<Statement> map(expr -> new AssertStatement(loc, expr)).toList();
+
+		final Check check = new Check(Spec.MEMORY_FREE);
+		for (final Statement stmt : statements) {
+			check.annotate(stmt);
+		}
+
+		return statements;
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -77,7 +77,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.QuantifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.StructAccessExpression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.StructConstructor;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VarList;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableDeclaration;
@@ -907,9 +906,8 @@ public class MemoryHandler {
 	 * caution or improve this method.
 	 */
 	public boolean isNullPointerLiteral(final Expression expr) {
-
-		if (expr instanceof StructConstructor) {
-			return mMemoryPointer.isNullPointer(expr);
+		if (mMemoryPointer.isNullPointer(expr)) {
+			return true;
 		}
 
 		final BigInteger integerValue = mTypeSizes.extractIntegerValue(expr, new CPrimitive(CPrimitives.LONG));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryHandler.java
@@ -95,6 +95,7 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.C
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.DataRaceChecker;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.FunctionDeclarations;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.TranslationSettings;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryManagementStrategy.AllocationProcedureSpec;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.MemoryStructureBase.ReadWriteDefinition;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizeAndOffsetComputer.Offset;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.memoryhandler.ConstructMemcpyOrMemmove;
@@ -130,7 +131,6 @@ import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietransla
 import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.MemoryStructure;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.LinkedScopedHashMap;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * @author Markus Lindenmann
@@ -1884,18 +1884,11 @@ public class MemoryHandler {
 		mProcedureManager.beginCustomProcedure(main, tuLoc, MemoryModelDeclarations.ULTIMATE_DEALLOC.getName(),
 				deallocDeclaration);
 
-		final List<Triple<Expression, Set<VariableLHS>, Boolean>> deallocSpecificationExpressions =
-				mMemoryModel.constructDeallocSpecificationExpressions(tuLoc, mRequiredMemoryModelFeatures,
-						mMemoryModelDeclarationsHandler);
+		final AllocationProcedureSpec specification = mMemoryModel.constructDeallocSpecification(tuLoc,
+				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		mProcedureManager.addModifiedGlobalsToCurrentProcedure(specification.modifies());
+		mProcedureManager.addSpecificationsToCurrentProcedure(specification.constructSpecificationClauses(tuLoc));
 
-		final List<Specification> deallocSpecifications = new ArrayList<>();
-
-		for (final Triple<Expression, Set<VariableLHS>, Boolean> triple : deallocSpecificationExpressions) {
-			deallocSpecifications.add(mProcedureManager.constructEnsuresSpecification(tuLoc, triple.getThird(),
-					triple.getFirst(), triple.getSecond()));
-		}
-
-		mProcedureManager.addSpecificationsToCurrentProcedure(deallocSpecifications);
 		mProcedureManager.endCustomProcedure(main, MemoryModelDeclarations.ULTIMATE_DEALLOC.getName());
 		return Collections.emptyList();
 	}
@@ -1921,18 +1914,10 @@ public class MemoryHandler {
 
 		mProcedureManager.beginCustomProcedure(main, tuLoc, alloc.getName(), allocDeclaration);
 
-		final List<Pair<Expression, Set<VariableLHS>>> mallocSpecificationExpressions =
-				mMemoryModel.constructMallocSpecificationExpressions(tuLoc, memArea, mRequiredMemoryModelFeatures,
-						mMemoryModelDeclarationsHandler);
-
-		final List<Specification> mallocSpecifications = new ArrayList<>();
-
-		for (final Pair<Expression, Set<VariableLHS>> pair : mallocSpecificationExpressions) {
-			mallocSpecifications.add(
-					mProcedureManager.constructEnsuresSpecification(tuLoc, false, pair.getFirst(), pair.getSecond()));
-		}
-
-		mProcedureManager.addSpecificationsToCurrentProcedure(mallocSpecifications);
+		final AllocationProcedureSpec specification = mMemoryModel.constructMallocSpecification(tuLoc, memArea,
+				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		mProcedureManager.addModifiedGlobalsToCurrentProcedure(specification.modifies());
+		mProcedureManager.addSpecificationsToCurrentProcedure(specification.constructSpecificationClauses(tuLoc));
 
 		final ArrayList<Declaration> result = new ArrayList<>();
 		mProcedureManager.endCustomProcedure(main, alloc.getName());
@@ -1955,17 +1940,11 @@ public class MemoryHandler {
 
 		mProcedureManager.beginCustomProcedure(main, tuLoc, procedureIdentifier, allocDeclaration);
 
-		final var allocInitSpecificationExpressions = mMemoryModel.constructAllocInitSpecificationExpressions(tuLoc,
+		final AllocationProcedureSpec specification = mMemoryModel.constructAllocInitSpecification(tuLoc,
 				mRequiredMemoryModelFeatures, mMemoryModelDeclarationsHandler);
+		mProcedureManager.addModifiedGlobalsToCurrentProcedure(specification.modifies());
+		mProcedureManager.addSpecificationsToCurrentProcedure(specification.constructSpecificationClauses(tuLoc));
 
-		final List<Specification> allocInitSpecifications = new ArrayList<>();
-
-		for (final Pair<Expression, Set<VariableLHS>> pair : allocInitSpecificationExpressions) {
-			allocInitSpecifications.add(
-					mProcedureManager.constructEnsuresSpecification(tuLoc, false, pair.getFirst(), pair.getSecond()));
-		}
-
-		mProcedureManager.addSpecificationsToCurrentProcedure(allocInitSpecifications);
 		mProcedureManager.endCustomProcedure(main, procedureIdentifier);
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -79,10 +79,6 @@ public class MemoryModel {
 		return mMemoryStructure.getReadProcedureName(primitive);
 	}
 
-	public String getUncheckedReadProcedureName(final CPrimitives primitive) {
-		return mMemoryStructure.getUncheckedReadProcedureName(primitive);
-	}
-
 	public String getWriteProcedureName(final CPrimitives primitive) {
 		return mMemoryStructure.getWriteProcedureName(primitive);
 	}
@@ -97,10 +93,6 @@ public class MemoryModel {
 
 	public String getReadPointerProcedureName() {
 		return mMemoryStructure.getReadPointerProcedureName();
-	}
-
-	public String getUncheckedReadPointerProcedureName() {
-		return mMemoryStructure.getUncheckedReadPointerProcedureName();
 	}
 
 	public String getWritePointerProcedureName() {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -35,7 +35,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
@@ -238,24 +237,11 @@ public class MemoryModel {
 	}
 
 	/**
-	 * Constructs the specifications that the pointer base address is valid.
-	 *
-	 * @return The specifications.
-	 */
-	public List<Specification> constructPointerBaseValidityCheck(final ILocation loc, final String ptrName,
-			final String procedureName, final CheckMode mode,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructPointerValidityCheck(loc, ptrName, procedureName, mode,
-				requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
-	}
-
-	/**
 	 * Constructs the pointer base validity check expression.
 	 *
 	 * @return The expression.
 	 */
-	Expression constructPointerBaseValidityCheckExpr(final ILocation loc, final Expression ptr,
+	public Expression constructPointerBaseValidityCheckExpr(final ILocation loc, final Expression ptr,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		return mMemoryAddressing.constructPointerValidityCheckExpr(loc, ptr, requiredMemoryModelFeatures,
@@ -267,12 +253,12 @@ public class MemoryModel {
 	 *
 	 * @return The specifications.
 	 */
-	public List<Specification> constructPointerTargetFullyAllocatedCheck(final ILocation loc, final Expression size,
-			final String ptrName, final String procedureName, final CheckMode mode,
-			final Boolean isBitVectorTranslation, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public Expression constructPointerTargetFullyAllocatedCheckExpr(final ILocation loc, final Expression ptr,
+			final Expression size, final boolean isBitVectorTranslation,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructPointerTargetFullyAllocatedCheck(loc, size, ptrName, procedureName, mode,
-				isBitVectorTranslation, requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		return mMemoryAddressing.constructPointerTargetFullyAllocatedCheckExpr(loc, ptr, size, isBitVectorTranslation,
+				requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -47,7 +47,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.plugins.generator.cacsl2boogietranslator.preferences.CACSLPreferenceInitializer.CheckMode;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
 import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
@@ -341,19 +340,6 @@ public class MemoryModel {
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		return mMemoryAddressing.constructStrChrAssumeStatement(loc, tmpExpr, argSPtr, nullPtrExpr,
 				requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
-	}
-
-	/**
-	 * Constructs assert / assume statements for ptr memsafety checks.
-	 *
-	 * @return The statements.
-	 */
-	public List<Statement> constructMemSafeStatementsForPointerExpression(final ILocation loc, final Expression ptr,
-			final CheckMode pointerBaseValid, final CheckMode pointerTargetFullyAllocated,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructMemSafeStatementsForPointerExpression(loc, ptr, pointerBaseValid,
-				pointerTargetFullyAllocated, requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -266,11 +266,11 @@ public class MemoryModel {
 	 *
 	 * @return The statements.
 	 */
-	List<Statement> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
-			final boolean isPointerCheckRequired, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	List<Expression> getChecksForFreeCall(final ILocation loc, final RValue pointerToBeFreed,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.getChecksForFreeCall(loc, pointerToBeFreed, isPointerCheckRequired,
-				requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		return mMemoryAddressing.getChecksForFreeCall(loc, pointerToBeFreed, requiredMemoryModelFeatures,
+				memoryModelDeclarationsHandler);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -311,16 +311,6 @@ public class MemoryModel {
 	}
 
 	/**
-	 * Returns a pointer to the last character of a string.
-	 *
-	 * @return The pointer.
-	 */
-	public Expression lastCharOfString(final ILocation loc, final CPrimitive sizeT, final IdentifierExpression len,
-			final IdentifierExpression returnValue) {
-		return mMemoryAddressing.getLastCharOfString(loc, sizeT, len, returnValue);
-	}
-
-	/**
 	 * Returns a pointer with the same base address but an offset of 0.
 	 *
 	 * @return A pointer with offset 0.

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -29,7 +29,6 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssumeStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
@@ -38,6 +37,7 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.IdentifierExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
+import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryManagementStrategy.AllocationProcedureSpec;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.MemoryStructureBase.ReadWriteDefinition;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
@@ -46,8 +46,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.contai
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.ExpressionResult;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.result.RValue;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * The memory model consisting of a MemoryAdressing and a MemoryStructure.
@@ -142,28 +140,38 @@ public class MemoryModel {
 	}
 
 	/**
-	 * Constructs the expressions used in the specifications for malloc.
+	 * Constructs the specification of malloc.
 	 *
-	 * @return A list of a pair consisting of an expression and a set of the global variables that must be added to the
-	 *         modifies clause.
+	 * @return a record representing the specification
 	 */
-	public List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(final ILocation tuLoc,
-			final MemoryArea memoryArea, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructMallocSpecification(final ILocation tuLoc, final MemoryArea memoryArea,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructMallocSpecificationExpressions(tuLoc, memoryArea, requiredMemoryModelFeatures,
+		return mMemoryAddressing.constructMallocSpecification(tuLoc, memoryArea, requiredMemoryModelFeatures,
 				memoryModelDeclarationsHandler);
 	}
 
 	/**
-	 * Constructs the expressions used in the specifications for dealloc.
+	 * Constructs the specification of dealloc.
 	 *
-	 * @return A list of a pair consisting of an expression and a set of the global variables that must be added to the
-	 *         modifies clause.
+	 * @return a record representing the specification
 	 */
-	public List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(
-			final ILocation tuLoc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructDeallocSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructDeallocSpecificationExpressions(tuLoc, requiredMemoryModelFeatures,
+		return mMemoryAddressing.constructDeallocSpecification(tuLoc, requiredMemoryModelFeatures,
+				memoryModelDeclarationsHandler);
+	}
+
+	/**
+	 * Constructs the specification of allocInit.
+	 *
+	 * @return a record representing the specification
+	 */
+	public AllocationProcedureSpec constructAllocInitSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
+		return mMemoryAddressing.constructAllocInitSpecification(tuLoc, requiredMemoryModelFeatures,
 				memoryModelDeclarationsHandler);
 	}
 
@@ -177,18 +185,6 @@ public class MemoryModel {
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler, final BigInteger fixedAddressCounter) {
 		return mMemoryAddressing.constructUltimateInitStatements(loc, requiredMemoryModelFeatures,
 				memoryModelDeclarationsHandler, fixedAddressCounter);
-	}
-
-	/**
-	 * Constructs the expressions used in the specifications for allocInit.
-	 *
-	 * @return The expressions.
-	 */
-	public List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(final ILocation tuLoc,
-			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
-			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.constructAllocInitSpecificationExpressions(tuLoc, requiredMemoryModelFeatures,
-				memoryModelDeclarationsHandler);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -39,7 +39,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.MemoryStructureBase.ReadWriteDefinition;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.TypeSizeAndOffsetComputer.Offset;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitives;
@@ -210,19 +209,6 @@ public class MemoryModel {
 	 */
 	public BigInteger fixedAddressCounterCountingStep(final Expression size) {
 		return mMemoryAddressing.getFixedAddressCounterCountingStep(size);
-	}
-
-	/**
-	 * Returns the address for struct field.
-	 *
-	 * @return The address.
-	 */
-	public Expression constructAddressForStructField(final ILocation loc, final Expression baseAddress,
-			final Offset fieldOffset, final CPrimitive sizeT) {
-		if (fieldOffset.isBitfieldOffset()) {
-			throw new UnsupportedOperationException("Bitfield read");
-		}
-		return mMemoryAddressing.constructAddressForStructField(loc, baseAddress, fieldOffset, sizeT);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryModel.java
@@ -388,9 +388,11 @@ public class MemoryModel {
 				memoryModelDeclarationsHandler);
 	}
 
-	public Expression getValidArray(final ILocation loc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public Expression constructMemoryNeutralityCheckExpr(final ILocation loc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return mMemoryAddressing.getValidArray(loc, requiredMemoryModelFeatures, memoryModelDeclarationsHandler);
+		return mMemoryAddressing.constructMemoryNeutralityCheckExpr(loc, requiredMemoryModelFeatures,
+				memoryModelDeclarationsHandler);
 	}
 
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer1D.java
@@ -147,15 +147,10 @@ public final class MemoryPointer1D extends MemoryPointerBase {
 		final Expression pointerRelation = constructPointerComponentRelation(loc, op, left.getLrValue().getValue(),
 				right.getLrValue().getValue(), SFO.POINTER_BASE, expressionTranslation);
 
-		switch (mPointerSubtractionAndComparisonValidityCheckMode) {
-		case CHECK:
-		case ASSUME:
-			return ExpressionFactory.createBooleanLiteral(loc, true);
-		case IGNORE:
-			return pointerRelation;
-		default:
-			throw new AssertionError("unknown value");
-		}
+		return switch (mPointerSubtractionAndComparisonValidityCheckMode) {
+		case CHECK, ASSUME -> ExpressionFactory.createBooleanLiteral(loc, true);
+		case IGNORE -> pointerRelation;
+		};
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer1D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer1D.java
@@ -167,12 +167,8 @@ public final class MemoryPointer1D extends MemoryPointerBase {
 
 	@Override
 	public boolean isNullPointer(final Expression ptr) {
-		final StructConstructor sc = (StructConstructor) ptr;
-		if (sc.getFieldValues().length == 1 && sc.getFieldIdentifiers()[0].equals(SFO.POINTER_BASE)
-				&& BigInteger.ZERO.equals(CTranslationUtil.extractIntegerValue(sc.getFieldValues()[0]))) {
-			return true;
-		}
-
-		return false;
+		return ptr instanceof final StructConstructor sc && sc.getFieldValues().length == 1
+				&& sc.getFieldIdentifiers()[0].equals(SFO.POINTER_BASE)
+				&& BigInteger.ZERO.equals(CTranslationUtil.extractIntegerValue(sc.getFieldValues()[0]));
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
@@ -118,8 +118,8 @@ public final class MemoryPointer2D extends MemoryPointerBase {
 	 * @return The offset.
 	 */
 	public Expression pointerOffset(final Expression pointer, final ILocation loc) {
-		if (pointer instanceof StructConstructor) {
-			return ((StructConstructor) pointer).getFieldValues()[1];
+		if (pointer instanceof final StructConstructor sc) {
+			return sc.getFieldValues()[1];
 		}
 		return ExpressionFactory.constructStructAccessExpression(loc, pointer, SFO.POINTER_OFFSET);
 	}

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
@@ -144,18 +144,13 @@ public final class MemoryPointer2D extends MemoryPointerBase {
 		final Expression offsetRelation = constructPointerComponentRelation(loc, op, left.getLrValue().getValue(),
 				right.getLrValue().getValue(), SFO.POINTER_OFFSET, expressionTranslation);
 
-		switch (mPointerSubtractionAndComparisonValidityCheckMode) {
-		case CHECK:
-		case ASSUME:
-			return offsetRelation;
-		case IGNORE:
-			// use conjunction
-			return ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, baseEquality, offsetRelation);
-		// TODO: Do not use conjunction. Use nondeterministic value if baseEquality does not hold.
-		default:
-			throw new AssertionError("unknown value");
-		}
+		return switch (mPointerSubtractionAndComparisonValidityCheckMode) {
+		case CHECK, ASSUME -> offsetRelation;
 
+		// use conjunction
+		// TODO: Do not use conjunction. Use nondeterministic value if baseEquality does not hold.
+		case IGNORE -> ExpressionFactory.newBinaryExpression(loc, Operator.LOGICAND, baseEquality, offsetRelation);
+		};
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryPointer2D.java
@@ -167,14 +167,10 @@ public final class MemoryPointer2D extends MemoryPointerBase {
 
 	@Override
 	public boolean isNullPointer(final Expression ptr) {
-		final StructConstructor sc = (StructConstructor) ptr;
-		if (sc.getFieldValues().length == 2 && sc.getFieldIdentifiers()[0].equals(SFO.POINTER_BASE)
+		return ptr instanceof final StructConstructor sc && sc.getFieldValues().length == 2
+				&& sc.getFieldIdentifiers()[0].equals(SFO.POINTER_BASE)
 				&& sc.getFieldIdentifiers()[1].equals(SFO.POINTER_OFFSET)
 				&& BigInteger.ZERO.equals(CTranslationUtil.extractIntegerValue(sc.getFieldValues()[0]))
-				&& BigInteger.ZERO.equals(CTranslationUtil.extractIntegerValue(sc.getFieldValues()[1]))) {
-			return true;
-		}
-
-		return false;
+				&& BigInteger.ZERO.equals(CTranslationUtil.extractIntegerValue(sc.getFieldValues()[1]));
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureBase.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureBase.java
@@ -75,11 +75,6 @@ public abstract class MemoryStructureBase implements IMemoryStructure {
 	}
 
 	@Override
-	public final String getUncheckedReadProcedureName(final CPrimitives primitive) {
-		return READ_PROCEDURE_PREFIX + UNCHECKED_PREFIX + getProcedureSuffix(primitive);
-	}
-
-	@Override
 	public final String getWriteProcedureName(final CPrimitives primitive) {
 		return WRITE_PROCEDURE_PREFIX + getProcedureSuffix(primitive);
 	}
@@ -98,12 +93,6 @@ public abstract class MemoryStructureBase implements IMemoryStructure {
 	public final String getReadPointerProcedureName() {
 		final HeapDataArray hda = mPointerArray;
 		return READ_PROCEDURE_PREFIX + hda.getName();
-	}
-
-	@Override
-	public final String getUncheckedReadPointerProcedureName() {
-		final HeapDataArray hda = mPointerArray;
-		return READ_PROCEDURE_PREFIX + UNCHECKED_PREFIX + hda.getName();
 	}
 
 	@Override

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureFactory.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureFactory.java
@@ -52,19 +52,17 @@ public class MemoryStructureFactory {
 					+ " is only available in using the bitprecise translation");
 		}
 
-		switch (memoryStructurePreference) {
+		return switch (memoryStructurePreference) {
 		case HoenickeLindenmann_1ByteResolution:
 		case HoenickeLindenmann_2ByteResolution:
 		case HoenickeLindenmann_4ByteResolution:
 		case HoenickeLindenmann_8ByteResolution:
-			return new MemoryStructureSingleBitprecise(memoryStructurePreference.getByteSize(), typeSizes, typeHandler);
+			yield new MemoryStructureSingleBitprecise(memoryStructurePreference.getByteSize(), typeSizes, typeHandler);
 		case HoenickeLindenmann_Original:
 			if (settings.isBitvectorTranslation()) {
-				return new MemoryStructureMultiBitprecise(typeSizes, typeHandler);
+				yield new MemoryStructureMultiBitprecise(typeSizes, typeHandler);
 			}
-			return new MemoryStructureUnbounded(typeSizes, typeHandler);
-		default:
-			throw new UnsupportedOperationException(memoryStructurePreference + " is an invalid memory structure.");
-		}
+			yield new MemoryStructureUnbounded(typeSizes, typeHandler);
+		};
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureMultiBitprecise.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/MemoryStructureMultiBitprecise.java
@@ -59,16 +59,11 @@ public class MemoryStructureMultiBitprecise extends MemoryStructureBase {
 
 	@Override
 	public HeapDataArray getDataHeapArray(final CPrimitives primitive) {
-		switch (primitive.getPrimitiveCategory()) {
-		case FLOATTYPE:
-			return getDataHeapArrayForGivenGeneralType(primitive, mSize2HeapFloatingArray);
-		case INTTYPE:
-			return getDataHeapArrayForGivenGeneralType(primitive, mSize2HeapIntegerArray);
-		case VOID:
-			throw new AssertionError("void on the heap???");
-		default:
-			throw new AssertionError("unknown primitive category");
-		}
+		return switch (primitive.getPrimitiveCategory()) {
+		case FLOATTYPE -> getDataHeapArrayForGivenGeneralType(primitive, mSize2HeapFloatingArray);
+		case INTTYPE -> getDataHeapArrayForGivenGeneralType(primitive, mSize2HeapIntegerArray);
+		case VOID -> throw new AssertionError("void on the heap???");
+		};
 	}
 
 	private HeapDataArray getDataHeapArrayForGivenGeneralType(final CPrimitives primitive,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/NonDetStrategy2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/NonDetStrategy2D.java
@@ -236,7 +236,6 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 	public AllocationProcedureSpec constructAllocInitSpecification(final ILocation tuLoc,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		final var pointerBaseIdentifier = "ptrBase";
 		final var procedureIdentifier = MemoryModelDeclarations.ULTIMATE_ALLOC_INIT.getName();
 
 		final var trueExpr = mBooleanArrayHelper.constructTrue();
@@ -248,7 +247,7 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 				SFO.SIZE, new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureIdentifier));
 
 		final var ptrBase = ExpressionFactory.constructIdentifierExpression(tuLoc,
-				mTypeHandler.getBoogieTypeForPointerComponents(), pointerBaseIdentifier,
+				mTypeHandler.getBoogieTypeForPointerComponents(), SFO.ALLOCINIT_PTRBASE,
 				new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureIdentifier));
 
 		// ensures #valid[ptrBase] == true;

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/NonDetStrategy2D.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/NonDetStrategy2D.java
@@ -53,12 +53,10 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.e
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * This strategy is the default strategy for the 2D-memory addressing scheme. The generic parameter is used to ensure
- * that this strategy is only instanciated within the 2D addressing class because it is not compatible with other modes.
+ * that this strategy is only instantiated within the 2D addressing class because it is not compatible with other modes.
  * Memory addresses get a non-deterministic value, which is not used yet.
  *
  * @author Jan Körner
@@ -77,8 +75,8 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 	}
 
 	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(final ILocation tuLoc,
-			final MemoryArea memoryArea, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructMallocSpecification(final ILocation tuLoc, final MemoryArea memoryArea,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 
 		final var memoryAreaName = memoryArea.getMemoryStructureDeclaration().getName();
@@ -104,7 +102,7 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 
 		final var resBaseExpr = ExpressionFactory.constructStructAccessExpression(tuLoc, resultExpr, SFO.POINTER_BASE);
 
-		final ArrayList<Pair<Expression, Set<VariableLHS>>> expressions = new ArrayList<>();
+		final ArrayList<Expression> expressions = new ArrayList<>();
 
 		// old(#valid)[#res!base] == false
 		final var freshLocationCurrentlyNotValidExpr = ExpressionFactory.newBinaryExpression(tuLoc, Operator.COMPEQ,
@@ -112,32 +110,30 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 						ExpressionFactory.constructUnaryExpression(tuLoc, UnaryExpression.Operator.OLD, validArrayExpr),
 						new Expression[] { resBaseExpr }),
 				falseExpr);
-
-		expressions.add(new Pair<>(freshLocationCurrentlyNotValidExpr, Collections.emptySet()));
+		expressions.add(freshLocationCurrentlyNotValidExpr);
 
 		// #valid == old(#valid)[#res!base := true]
 		final var validUpdateExpr =
 				MemoryModelExpressionHelper.ensuresArrayUpdate(tuLoc, trueExpr, resBaseExpr, validArrayExpr);
-		expressions.add(new Pair<>(validUpdateExpr,
-				Collections.singleton((VariableLHS) CTranslationUtil.convertExpressionToLHS(validArrayExpr))));
+		expressions.add(validUpdateExpr);
 
 		// #res!offset == 0
 		final var offsetEqualZeroExpr = ExpressionFactory.newBinaryExpression(tuLoc, Operator.COMPEQ,
 				mMemoryAddressing.mMemoryPointer.pointerOffset(resultExpr, tuLoc), zeroNumericValueExpr);
-		expressions.add(new Pair<>(offsetEqualZeroExpr, Collections.emptySet()));
+		expressions.add(offsetEqualZeroExpr);
 
 		// #res!base != 0
 		final var baseNotEqualZeroExpr = baseNotEqualZeroExpr(tuLoc, resultExpr, zeroNumericValueExpr);
-		expressions.add(new Pair<>(baseNotEqualZeroExpr, Collections.emptySet()));
+		expressions.add(baseNotEqualZeroExpr);
 
 		if (memoryArea == MemoryArea.STACK) {
 			// #StackHeapBarrier < res!base
 			final var baseGreaterThanBarrierExpr = baseGreaterThanBarrier(tuLoc, stackHeapBarrierExpr, resultExpr);
-			expressions.add(new Pair<>(baseGreaterThanBarrierExpr, Collections.emptySet()));
+			expressions.add(baseGreaterThanBarrierExpr);
 		} else if (memoryArea == MemoryArea.HEAP) {
 			// res!base < #StackHeapBarrier
 			final var baseSmallerThanBarrierExpr = baseSmallerThanBarrier(tuLoc, stackHeapBarrierExpr, resultExpr);
-			expressions.add(new Pair<>(baseSmallerThanBarrierExpr, Collections.emptySet()));
+			expressions.add(baseSmallerThanBarrierExpr);
 		}
 
 		// #length == old(#length)[#res!base := ~size]
@@ -148,15 +144,16 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 										tuLoc, ExpressionFactory.constructUnaryExpression(tuLoc,
 												UnaryExpression.Operator.OLD, lengthArrayExpr),
 										new Expression[] { resBaseExpr }, sizeExpr));
-		expressions.add(new Pair<>(lengthUpdateExpr,
-				Collections.singleton((VariableLHS) CTranslationUtil.convertExpressionToLHS(lengthArrayExpr))));
+		expressions.add(lengthUpdateExpr);
 
-		return expressions;
+		final var validArrayLHS = (VariableLHS) CTranslationUtil.convertExpressionToLHS(validArrayExpr);
+		final var lengthArrayLHS = (VariableLHS) CTranslationUtil.convertExpressionToLHS(lengthArrayExpr);
+		return new AllocationProcedureSpec(expressions, Set.of(validArrayLHS, lengthArrayLHS));
 	}
 
 	@Override
-	public List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(
-			final ILocation tuLoc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructDeallocSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 
 		final var falseExpr = mBooleanArrayHelper.constructFalse();
@@ -178,8 +175,8 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 		final Expression updateValidArrayExpr =
 				ExpressionFactory.newBinaryExpression(tuLoc, Operator.COMPEQ, validArrayExpr, arrayStoreExpr);
 
-		return Collections.singletonList(new Triple<>(updateValidArrayExpr,
-				Collections.singleton((VariableLHS) CTranslationUtil.convertExpressionToLHS(validArrayExpr)), true));
+		return new AllocationProcedureSpec(Collections.emptyList(), List.of(updateValidArrayExpr),
+				Collections.singleton((VariableLHS) CTranslationUtil.convertExpressionToLHS(validArrayExpr)));
 	}
 
 	@Override
@@ -236,7 +233,7 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 	}
 
 	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(final ILocation tuLoc,
+	public AllocationProcedureSpec constructAllocInitSpecification(final ILocation tuLoc,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		final var pointerBaseIdentifier = "ptrBase";
@@ -254,18 +251,15 @@ public class NonDetStrategy2D<T extends MemoryAddressing2D> extends MemoryManage
 				mTypeHandler.getBoogieTypeForPointerComponents(), pointerBaseIdentifier,
 				new DeclarationInformation(StorageClass.PROC_FUNC_INPARAM, procedureIdentifier));
 
-		final ArrayList<Pair<Expression, Set<VariableLHS>>> expressions = new ArrayList<>();
 		// ensures #valid[ptrBase] == true;
 		final var validPtrBaseExpr =
 				MemoryModelExpressionHelper.ensuresArrayHasValue(tuLoc, trueExpr, ptrBase, validArrayExpr);
-		expressions.add(new Pair<>(validPtrBaseExpr, Collections.emptySet()));
 
 		// ensures #length[ptrBase] == size;
 		final var lengthPtrBaseSize =
 				MemoryModelExpressionHelper.ensuresArrayHasValue(tuLoc, size, ptrBase, lengthArrayExpr);
-		expressions.add(new Pair<>(lengthPtrBaseSize, Collections.emptySet()));
 
-		return expressions;
+		return new AllocationProcedureSpec(List.of(validPtrBaseExpr, lengthPtrBaseSize), Collections.emptySet());
 	}
 
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ProcedureManager.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ProcedureManager.java
@@ -453,7 +453,11 @@ public class ProcedureManager {
 		return new EnsuresSpecification(loc, isFree, formula);
 	}
 
-	public void addSpecificationsToCurrentProcedure(final List<Specification> specs) {
+	public void addModifiedGlobalsToCurrentProcedure(final Set<VariableLHS> modifiedGlobals) {
+		mCurrentProcedureInfo.addModifiedGlobals(modifiedGlobals);
+	}
+
+	public void addSpecificationsToCurrentProcedure(final List<? extends Specification> specs) {
 		assert !isGlobalScope();
 		final BoogieProcedureInfo procInfo = mCurrentProcedureInfo;
 		final Procedure oldDecl = procInfo.getDeclaration();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ProcedureManager.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/ProcedureManager.java
@@ -44,9 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import de.uni_freiburg.informatik.ultimate.boogie.BoogieVisitor;
-import de.uni_freiburg.informatik.ultimate.boogie.ExpressionFactory;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.AssignmentStatement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.BinaryExpression.Operator;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Body;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.CallStatement;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Declaration;
@@ -58,7 +56,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.ModifiesSpecification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Procedure;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Specification;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Statement;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.UnaryExpression;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableDeclaration;
 import de.uni_freiburg.informatik.ultimate.boogie.ast.VariableLHS;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.CACSLLocation;
@@ -220,14 +217,13 @@ public class ProcedureManager {
 				// model is required. Maybe we can require the memory model if the list of functions for which we
 				// check memory neutrality is not empty.
 
-				final Expression vIe = memoryHandler.getValidArray(loc);
+				final Expression neutrality = memoryHandler.constructMemoryNeutralityCheckExpr(loc);
+
 				final int nrSpec = newSpec.length;
 				final Check check = new Check(Spec.MEMORY_NEUTRAL);
 				final ILocation ensLoc = LocationFactory.createLocation(loc);
 				newSpecWithExtraEnsuresClauses = Arrays.copyOf(newSpec, nrSpec + 1);
-				newSpecWithExtraEnsuresClauses[nrSpec] = new EnsuresSpecification(ensLoc, false,
-						ExpressionFactory.newBinaryExpression(loc, Operator.COMPEQ, vIe,
-								ExpressionFactory.constructUnaryExpression(loc, UnaryExpression.Operator.OLD, vIe)));
+				newSpecWithExtraEnsuresClauses[nrSpec] = new EnsuresSpecification(ensLoc, false, neutrality);
 				check.annotate(newSpecWithExtraEnsuresClauses[nrSpec]);
 				if (mSettings.isSvcompMemtrackCompatibilityMode()) {
 					new Overapprox(Collections.singletonMap("memtrack", ensLoc))

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/SimpleIncreasingStrategy.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/SimpleIncreasingStrategy.java
@@ -48,8 +48,6 @@ import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.e
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.util.SFO;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.interfaces.handler.ITypeHandler;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Pair;
-import de.uni_freiburg.informatik.ultimate.util.datastructures.relation.Triple;
 
 /**
  * This strategy is the default strategy for the 1D-memory addressing scheme. The generic parameter is used to ensure
@@ -69,12 +67,12 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 	}
 
 	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructMallocSpecificationExpressions(final ILocation tuLoc,
+	public AllocationProcedureSpec constructMallocSpecification(final ILocation tuLoc,
 			final MemoryArea memoryArea, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
 		final var cTypeOfPointerComponent = mExpressionTranslation.getCTypeOfPointerComponents();
 
-		final ArrayList<Pair<Expression, Set<VariableLHS>>> expressions = new ArrayList<>();
+		final ArrayList<Expression> expressions = new ArrayList<>();
 
 		final var memoryAreaName = memoryArea.getMemoryStructureDeclaration().getName();
 		final var zeroNumericValueExpr =
@@ -104,7 +102,7 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 		// #res!base == old(counterExpression);
 		final var baseEqualCounterExpr = ExpressionFactory.newBinaryExpression(tuLoc, Operator.COMPEQ, resBaseExpr,
 				ExpressionFactory.constructUnaryExpression(tuLoc, UnaryExpression.Operator.OLD, counterExpression));
-		expressions.add(new Pair<>(baseEqualCounterExpr, Collections.emptySet()));
+		expressions.add(baseEqualCounterExpr);
 
 		// #res!base > 0;
 		final var baseGreaterZeroExpr = mExpressionTranslation.constructBinaryComparisonIntegerExpression(tuLoc,
@@ -112,18 +110,18 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 				ExpressionFactory.constructStructAccessExpression(tuLoc, resultExpr, SFO.POINTER_BASE),
 				cTypeOfPointerComponent, zeroNumericValueExpr, cTypeOfPointerComponent);
 
-		expressions.add(new Pair<>(baseGreaterZeroExpr, Collections.emptySet()));
+		expressions.add(baseGreaterZeroExpr);
 
 		if (memoryArea == MemoryArea.STACK) {
 			// res!base > #StackHeapBarrier
 			final var baseGreaterThanBarrierExpr = baseGreaterThanBarrier(tuLoc, stackHeapBarrierExpr, resultExpr);
-			expressions.add(new Pair<>(baseGreaterThanBarrierExpr, Collections.emptySet()));
+			expressions.add(baseGreaterThanBarrierExpr);
 
 			// #StackAllocations > #StackHeapBarrier;
 			final var stackAllocationsGreaterThanBarrier = mExpressionTranslation
 					.constructBinaryComparisonIntegerExpression(tuLoc, IASTBinaryExpression.op_greaterThan,
 							counterExpression, cTypeOfPointerComponent, stackHeapBarrierExpr, cTypeOfPointerComponent);
-			expressions.add(new Pair<>(stackAllocationsGreaterThanBarrier, Collections.emptySet()));
+			expressions.add(stackAllocationsGreaterThanBarrier);
 
 			// #StackAllocations < #32-bit max / 64-bit max
 			if (mIsBitVectorTranslation) {
@@ -139,19 +137,19 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 						.constructBinaryComparisonIntegerExpression(tuLoc, IASTBinaryExpression.op_lessThan,
 								counterExpression, cTypeOfPointerComponent, maxExpr, cTypeOfPointerComponent);
 
-				expressions.add(new Pair<>(stackAllocationsSmallerThanMax, Collections.emptySet()));
+				expressions.add(stackAllocationsSmallerThanMax);
 			}
 
 		} else if (memoryArea == MemoryArea.HEAP) {
 			// res!base < #StackHeapBarrier
 			final var baseSmallerThanBarrierExpr = baseSmallerThanBarrier(tuLoc, stackHeapBarrierExpr, resultExpr);
-			expressions.add(new Pair<>(baseSmallerThanBarrierExpr, Collections.emptySet()));
+			expressions.add(baseSmallerThanBarrierExpr);
 
 			// #HeapAllocations < #StackHeapBarrier;
 			final var stackAllocationsGreaterThanBarrier = mExpressionTranslation
 					.constructBinaryComparisonIntegerExpression(tuLoc, IASTBinaryExpression.op_lessThan,
 							counterExpression, cTypeOfPointerComponent, stackHeapBarrierExpr, cTypeOfPointerComponent);
-			expressions.add(new Pair<>(stackAllocationsGreaterThanBarrier, Collections.emptySet()));
+			expressions.add(stackAllocationsGreaterThanBarrier);
 		}
 
 		// res!base > #InitialAllocation
@@ -159,7 +157,7 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 				tuLoc, IASTBinaryExpression.op_greaterThan,
 				ExpressionFactory.constructStructAccessExpression(tuLoc, resultExpr, SFO.POINTER_BASE),
 				cTypeOfPointerComponent, initialAllocCounterExpr, cTypeOfPointerComponent);
-		expressions.add(new Pair<>(baseGreaterThanInitialAllocsExpr, Collections.emptySet()));
+		expressions.add(baseGreaterThanInitialAllocsExpr);
 
 		// StackAllocations == old(StackAllocations) + ~size
 		// HeapAllocations == old(HeapAllocations) + ~size
@@ -169,18 +167,17 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 				oldExpr, cTypeOfPointerComponent, sizeExpr, mTypeSizeAndOffsetComputer.getSizeT());
 		final var counterUpdateValueExpr =
 				ExpressionFactory.newBinaryExpression(tuLoc, Operator.COMPEQ, counterExpression, sumExpr);
+		expressions.add(counterUpdateValueExpr);
 
-		expressions.add(new Pair<>(counterUpdateValueExpr,
-				Collections.singleton((VariableLHS) CTranslationUtil.convertExpressionToLHS(counterExpression))));
-
-		return expressions;
+		final var counterLHS = (VariableLHS) CTranslationUtil.convertExpressionToLHS(counterExpression);
+		return new AllocationProcedureSpec(expressions, Set.of(counterLHS));
 	}
 
 	@Override
-	public List<Triple<Expression, Set<VariableLHS>, Boolean>> constructDeallocSpecificationExpressions(
-			final ILocation tuLoc, final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
+	public AllocationProcedureSpec constructDeallocSpecification(final ILocation tuLoc,
+			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return Collections.emptyList();
+		return new AllocationProcedureSpec(Collections.emptyList(), Collections.emptySet());
 	}
 
 	@Override
@@ -218,10 +215,10 @@ public class SimpleIncreasingStrategy extends MemoryManagementStrategyBase {
 	}
 
 	@Override
-	public List<Pair<Expression, Set<VariableLHS>>> constructAllocInitSpecificationExpressions(final ILocation tuLoc,
+	public AllocationProcedureSpec constructAllocInitSpecification(final ILocation tuLoc,
 			final RequiredMemoryModelFeatures requiredMemoryModelFeatures,
 			final MemoryModelDeclarationsHandler memoryModelDeclarationsHandler) {
-		return Collections.emptyList();
+		return new AllocationProcedureSpec(Collections.emptyList(), Collections.emptySet());
 	}
 
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
@@ -217,11 +217,15 @@ public class StructHandler {
 
 		final ICType resultType = structType.getFieldTypes()[fieldIndex];
 
-		final ExpressionResult call = unchecked ? mMemoryHandler.getReadUnchecked(newPointer, resultType)
-				: mMemoryHandler.getReadCall(newPointer, resultType);
 		final ExpressionResultBuilder resultBuilder = new ExpressionResultBuilder();
-		resultBuilder.addAllExceptLrValue(call);
-		resultBuilder.setLrValue(new RValue(call.getLrValue().getValue(), resultType));
+		if (unchecked) {
+			final Expression read = mMemoryHandler.getReadUnchecked(newPointer, resultType);
+			resultBuilder.setLrValue(new RValue(read, resultType));
+		} else {
+			final ExpressionResult call = mMemoryHandler.getReadCall(newPointer, resultType);
+			resultBuilder.addAllExceptLrValue(call);
+			resultBuilder.setLrValue(new RValue(call.getLrValue().getValue(), resultType));
+		}
 		return resultBuilder.build();
 	}
 

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/StructHandler.java
@@ -130,8 +130,7 @@ public class StructHandler {
 			// TODO: different calculations for unions
 			final Expression startAddress = fieldOwnerHlv.getAddress();
 
-			final Expression newPointer = mMemoryHandler.constructAddressForStructField(loc, startAddress, fieldOffset,
-					mExpressionTranslation.getCTypeOfPointerComponents());
+			final Expression newPointer = mMemoryHandler.constructAddressForStructField(loc, startAddress, fieldOffset);
 
 			final BitfieldInformation bi = constructBitfieldInformation(bitfieldWidth);
 			newValue = LRValueFactory.constructHeapLValue(mTypeHandler, newPointer, cFieldType, bi);
@@ -197,8 +196,8 @@ public class StructHandler {
 				final Offset fieldOffset =
 						mTypeSizeAndOffsetComputer.constructOffsetForField(loc, foType, neighbourField);
 
-				final Expression neighbourFieldAddress = mMemoryHandler.constructAddressForStructField(loc,
-						unionAddress, fieldOffset, mExpressionTranslation.getCTypeOfPointerComponents());
+				final Expression neighbourFieldAddress =
+						mMemoryHandler.constructAddressForStructField(loc, unionAddress, fieldOffset);
 
 				builder.setLrValue(LRValueFactory.constructHeapLValue(mTypeHandler, neighbourFieldAddress,
 						foType.getFieldType(neighbourField), null));
@@ -237,8 +236,7 @@ public class StructHandler {
 		}
 		final Offset fieldOffset = mTypeSizeAndOffsetComputer.constructOffsetForField(loc, structType, fieldIndex);
 
-		return mMemoryHandler.constructAddressForStructField(loc, address, fieldOffset,
-				mTypeSizeAndOffsetComputer.getSizeT());
+		return mMemoryHandler.constructAddressForStructField(loc, address, fieldOffset);
 
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizeAndOffsetComputer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizeAndOffsetComputer.java
@@ -447,7 +447,7 @@ public class TypeSizeAndOffsetComputer {
 		Expression asExpression(ILocation loc);
 	}
 
-	class SizeTValueInteger implements SizeTValue {
+	private class SizeTValueInteger implements SizeTValue {
 		private final BigInteger mValue;
 
 		public SizeTValueInteger(final BigInteger value) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizes.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/TypeSizes.java
@@ -282,8 +282,8 @@ public class TypeSizes {
 	}
 
 	public BigInteger extractIntegerValue(final Expression expr, final ICType cType) {
-		if (expr instanceof IntegerLiteral) {
-			final BigInteger value = new BigInteger(((IntegerLiteral) expr).getValue());
+		if (expr instanceof final IntegerLiteral intLit) {
+			final BigInteger value = new BigInteger(intLit.getValue());
 			final CPrimitive cPrimitive = (CPrimitive) CEnum.replaceEnumWithInt(cType);
 			if (!isUnsigned(cPrimitive)) {
 				return value;
@@ -294,8 +294,8 @@ public class TypeSizes {
 			final BigInteger maxValuePlusOne = maxValue.add(BigInteger.ONE);
 			return value.mod(maxValuePlusOne);
 		}
-		if (expr instanceof BitvecLiteral) {
-			final BigInteger value = new BigInteger(((BitvecLiteral) expr).getValue());
+		if (expr instanceof final BitvecLiteral bvLit) {
+			final BigInteger value = new BigInteger(bvLit.getValue());
 			final CPrimitive cPrimitive = (CPrimitive) CEnum.replaceEnumWithInt(cType);
 			if (isUnsigned(cPrimitive)) {
 				if (getMinValueOfPrimitiveType(cPrimitive).compareTo(value) > 0) {

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/memoryhandler/ConstructMemcpyOrMemmove.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/chandler/memoryhandler/ConstructMemcpyOrMemmove.java
@@ -244,14 +244,7 @@ public final class ConstructMemcpyOrMemmove {
 			for (final CPrimitives cPrim : mMemoryHandler.getRequiredMemoryStructureFeatures()
 					.getDataOnHeapRequired()) {
 				final ICType cPrimType = new CPrimitive(cPrim);
-				final Expression srcAcc;
-				{
-					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadUnchecked(currentSrc, cPrimType);
-					srcAcc = srcAccExpRes.getLrValue().getValue();
-					loopBody.addStatements(srcAccExpRes.getStatements());
-					loopBody.addDeclarations(srcAccExpRes.getDeclarations());
-					assert srcAccExpRes.getOverapprs().isEmpty();
-				}
+				final Expression srcAcc = mMemoryHandler.getReadUnchecked(currentSrc, cPrimType);
 
 				{
 					final List<Statement> writeCall = mMemoryHandler.getWriteCall(ignoreLoc,
@@ -293,14 +286,7 @@ public final class ConstructMemcpyOrMemmove {
 
 			if (mMemoryHandler.getRequiredMemoryStructureFeatures().isPointerOnHeapRequired()) {
 				final ICType cPointer = CPointer.voidPointer();
-				final Expression srcAcc;
-				{
-					final ExpressionResult srcAccExpRes = mMemoryHandler.getReadUnchecked(currentSrc, cPointer);
-					srcAcc = srcAccExpRes.getLrValue().getValue();
-					loopBody.addStatements(srcAccExpRes.getStatements());
-					loopBody.addDeclarations(srcAccExpRes.getDeclarations());
-					assert srcAccExpRes.getOverapprs().isEmpty();
-				}
+				final Expression srcAcc = mMemoryHandler.getReadUnchecked(currentSrc, cPointer);
 
 				{
 					final List<Statement> writeCall = mMemoryHandler.getWriteCall(ignoreLoc,

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/library/FunctionModelHelper.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/base/library/FunctionModelHelper.java
@@ -342,10 +342,17 @@ public class FunctionModelHelper {
 		body.add(mMemoryHandler.getUltimateMemAllocCall(len.getExp(), retvar.getLhs(), loc, MemoryArea.HEAP));
 
 		final var nullChar = mTypeSizes.constructLiteralForIntegerType(loc, charType, BigInteger.ZERO);
-		final var lastChar = mMemoryHandler.lastCharOfString(loc, sizeT, len.getExp(), retvar.getExp());
 
-		body.addAll(mMemoryHandler.getWriteCall(loc,
-				LRValueFactory.constructHeapLValue(mTypeHandler, lastChar, charType, null), nullChar, charType, false));
+		// *(retvar + (len - 1)) = '\0';
+		{
+			final var lenMinusOne = mExpressionTranslation.constructArithmeticIntegerExpression(loc,
+					IASTBinaryExpression.op_minus, mExpressionTranslation.applyWraparound(loc, sizeT, len.getExp()),
+					sizeT, mTypeSizes.constructLiteralForIntegerType(loc, sizeT, BigInteger.ONE), sizeT);
+			final Expression lastChar = mMemoryHandler.addExpressionToPointer(loc, retvar.getExp(), lenMinusOne);
+			body.addAll(mMemoryHandler.getWriteCall(loc,
+					LRValueFactory.constructHeapLValue(mTypeHandler, lastChar, charType, null), nullChar, charType,
+					false));
+		}
 
 		final var stmt = StatementFactory.constructIfStatement(loc, new WildcardExpression(loc),
 				new Statement[] { setPtrToNull }, body.toArray(Statement[]::new));

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -264,9 +264,7 @@ public class ExpressionResultTransformer {
 			final ExpressionResultBuilder erb = new ExpressionResultBuilder().addAllExceptLrValue(expr);
 			final RValue newValue;
 			if (underlyingType instanceof CPrimitive || underlyingType instanceof CPointer) {
-				final ExpressionResult rex =
-						unchecked ? mMemoryHandler.getReadUnchecked(hlv.getAddress(), underlyingType)
-								: mMemoryHandler.getReadCall(hlv.getAddress(), underlyingType);
+				final ExpressionResult rex = readAsExpressionResult(hlv.getAddress(), unchecked, underlyingType);
 				newValue = (RValue) rex.getLrValue();
 				erb.addAllExceptLrValue(rex);
 			} else if (underlyingType instanceof final CArray cArray) {
@@ -466,10 +464,8 @@ public class ExpressionResultTransformer {
 			final ExpressionResult readRex;
 			if (arrayValueType instanceof final CStructOrUnion cStructOrUnion) {
 				readRex = readStructFromHeap(old, loc, addressExpr, cStructOrUnion, hook, unchecked);
-			} else if (unchecked) {
-				readRex = mMemoryHandler.getReadUnchecked(addressExpr, arrayType.getValueType());
 			} else {
-				readRex = mMemoryHandler.getReadCall(addressExpr, arrayType.getValueType());
+				readRex = readAsExpressionResult(addressExpr, unchecked, arrayType.getValueType());
 			}
 			builder.addAllExceptLrValue(readRex);
 			builder.setOrResetLrValue(readRex.getLrValue());
@@ -485,6 +481,15 @@ public class ExpressionResultTransformer {
 		}
 		builder.setOrResetLrValue(resultValue);
 		return builder.build();
+	}
+
+	private ExpressionResult readAsExpressionResult(final Expression addressExpr, final boolean unchecked,
+			final ICType resultType) {
+		if (unchecked) {
+			final Expression read = mMemoryHandler.getReadUnchecked(addressExpr, resultType);
+			return new ExpressionResult(new RValue(read, resultType));
+		}
+		return mMemoryHandler.getReadCall(addressExpr, resultType);
 	}
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/ExpressionResultTransformer.java
@@ -387,8 +387,8 @@ public class ExpressionResultTransformer {
 					throw new UnsupportedOperationException("Bitfield read struct from heap");
 				}
 
-				final var newAddress = mMemoryHandler.constructAddressForStructField(loc, structOnHeapAddress,
-						innerStructOffset, mExprTrans.getCTypeOfPointerComponents());
+				final var newAddress =
+						mMemoryHandler.constructAddressForStructField(loc, structOnHeapAddress, innerStructOffset);
 
 				final ExpressionResult fieldRead =
 						readStructFromHeap(old, loc, newAddress, cStructOrUnion, hook, unchecked);

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/LRValue.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/LRValue.java
@@ -30,7 +30,6 @@ package de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.resul
 import java.math.BigInteger;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Expression;
-import de.uni_freiburg.informatik.ultimate.boogie.ast.StructConstructor;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.CTranslationUtil;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
@@ -118,9 +117,6 @@ public abstract class LRValue {
 			return true;
 		}
 
-		if (value instanceof StructConstructor) {
-			return memoryPointer.isNullPointer(value);
-		}
-		return false;
+		return memoryPointer.isNullPointer(value);
 	}
 }

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/LRValue.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/result/LRValue.java
@@ -83,10 +83,10 @@ public abstract class LRValue {
 
 	@Override
 	public final String toString() {
-		if (this instanceof HeapLValue) {
-			return "address: " + ((HeapLValue) this).getAddress();
-		} else if (this instanceof LocalLValue) {
-			return "lhs: " + ((LocalLValue) this).getLhs();
+		if (this instanceof final HeapLValue hlv) {
+			return "address: " + hlv.getAddress();
+		} else if (this instanceof final LocalLValue llv) {
+			return "lhs: " + llv.getLhs();
 		} else {
 			return "value: " + getValue();
 		}
@@ -106,8 +106,8 @@ public abstract class LRValue {
 		}
 
 		final Expression value;
-		if (this instanceof HeapLValue) {
-			value = ((HeapLValue) this).getAddress();
+		if (this instanceof final HeapLValue hlv) {
+			value = hlv.getAddress();
 			throw new AssertionError("unexpected: double check this case");
 		}
 		value = getValue();

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
@@ -179,13 +179,11 @@ public final class SFO {
 	public static final String MEMCPY_DEST = "dest";
 	public static final String MEMCPY_SRC = "src";
 	public static final String MEMCPY_SIZE = "size";
-	public static final String MEMCPY = "#memcpy";
 
 	public static final String STRCPY_DEST = "dest";
 	public static final String STRCPY_SRC = "src";
 
 	public static final String TO_INT = "#to_int";
-	public static final String MEMSET = "ULTIMATE.memset";
 
 	/**
 	 * used for detecting data races

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/implementation/util/SFO.java
@@ -183,6 +183,8 @@ public final class SFO {
 	public static final String STRCPY_DEST = "dest";
 	public static final String STRCPY_SRC = "src";
 
+	public static final String ALLOCINIT_PTRBASE = "ptrBase";
+
 	public static final String TO_INT = "#to_int";
 
 	/**

--- a/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/ITypeHandler.java
+++ b/trunk/source/CACSL2BoogieTranslator/src/de/uni_freiburg/informatik/ultimate/cdt/translation/interfaces/handler/ITypeHandler.java
@@ -50,7 +50,6 @@ import de.uni_freiburg.informatik.ultimate.boogie.ast.StructLHS;
 import de.uni_freiburg.informatik.ultimate.boogie.type.BoogieType;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.FlatSymbolTable;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.IDispatcher;
-import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.base.chandler.IMemoryPointer;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.CPrimitive.CPrimitiveCategory;
 import de.uni_freiburg.informatik.ultimate.cdt.translation.implementation.container.c.ICType;
@@ -189,6 +188,4 @@ public interface ITypeHandler {
 	void registerNamedIncompleteType(String incompleteType, String named);
 
 	void addLibraryTypes(Map<String, ICType> libraryTypes);
-
-	IMemoryPointer getMemoryPointer();
 }


### PR DESCRIPTION
Since the dedicated work by @jankoerner in #756, our C translation uses general interfaces to encapsulate different memory model implementations, rather than hardcoding a single memory model all throughout the translation (thanks again for this work!).

This PR collects some simplifications and refactorings of the code for which there was not enough time in the project / before SV-COMP; with the goal to improve maintainability and make it easier to implement further memory models in the future.

_To review the changes in this PR, it might be a good idea to view them commit-by-commit._

In addition to the changes already here, the following items could also be improved (some of them may simply require more documentation):

- [ ] It would probably make sense to move a lot of this code into a dedicated sub-package, to bundle it in one place. Then, we should also see which parts need to be public and what can be package-private.
- [x] what is the meaning of the lists of tuples returned by
  - [x] `IMemoryAddressing::constructMallocSpecificationExpressions`
  - [x] `IMemoryAddressing::constructDeallocSpecificationExpressions`
  - [x] `IMemoryAddressing::constructAllocInitSpecificationExpressions`
- [ ] What is the meaning of these methods? (Improve documentation or reconsider if they should be implemented differently.)
  - [ ] `IMemoryAddressing::constructUltimateInitStatements` (what do these statements do?)
  - [ ] `IMemoryAddressing::getFixedAddressCounterCountingStep`
  - [ ] `IMemoryAddressing::constructRhsAssignmentStatementHda`
- [ ] what is the relation between the methods `::doPointerArithmetic`, `::addExpressionToPointer`, `addIntegerConstantToPointer` and `::doPointerSubtraction` on `IMemoryAdressing`? Can some of them be implemented in terms of the others?
- [ ] These methods seem overly specific. Can they be implemented by a caller, using the other existing methods?
  - [x] `IMemoryAddressing::constructAddressForStructField`  (perhaps implementable using `::addIntegerConstantToPointer`?)
  - [x] `IMemoryAddressing::getLastCharOfString`
  - [ ] `IMemoryAddressing::constructStrChrAssumeStatement` (if not, improve documentation and let it return an expression)
  - [ ] `IMemoryAddressing::checksForStringCopyOverlapping` (otherwise, document parameters and return an expression)
  - [ ] `IMemoryAddressing::constructReallocBodyStatements`
- [ ] Having two methods `IMemoryAddressing::constructPointerValidityCheckExpr` and `::constructPointerTargetFullyAllocatedCheckExpr` seems specific to the 2-dimensional model. Can they be merged into a single method? (that perhaps returns a list of expressions ~~; and callers would need to take care of the `size` parameter separately e.g. through a call to `::addExpressionToPointer`~~)
- [x] `IMemoryAddressing::getChecksForFreeCall` should return expressions (or `ExpressionResult`s) rather than assert statements
- [x] Can `IMemoryAddressing::constructMemSafeStatementsForPointerExpression` be implemented in terms of `::constructPointerValidityCheckExpr` and `::constructPointerTargetFullyAllocatedCheckExpr`?
- [ ] `IMemoryAddressing::constructInitialPointerFromPointer` only makes sense for the 2-dimensional model. It is used for variadic arguments; they must be implemented in another way.
- [x] `IMemoryAddressing::getValidArray` only makes sense for the 2-dimensional model. It is used only for memory neutrality checks; these should be implemented like `::constructPointerValidityCheckExpr` etc.
- [ ] An instance of `IMemoryPointer` is not actually a pointer. Can we rename the interface?
- [ ] (where) is `LocalLValueILocationPair` needed? (if we keep it, make it a record, possibly private, and improve field names)
- [ ] `MemoryAddressingFactory` violates the open-closed principle (for every new `IMemoryPointer` implementation, we would need to change this class). Can this functionality become a method on `IMemoryPointer`?
- [ ] The construction of a suitable pointer-integer conversion in `MemoryAddressingBase` violates the open-closed principle (for every new `IMemoryPointer` implementation, we would need to change this class). Can this functionality become a method on `IMemoryPointer`?
- [ ] update the documentation (in particular, of parameters) for `MemoryHandler::getWriteCall`
- [ ] update the documentation for `MemoryHandler::constructMemsafetyChecksForPointerExpression`
- [ ] document `MemoryStructureMultiBitprecise`
- [ ] documentation for `SimpleIncreasingStrategy` mentions a type parameter that does not exist
- [ ] The documentation for `NonBijectiveMapping1D` talks about base and offset (copy-pasted from 2D case). Is the mapping even non-bijective in the 1-dimensional case?
- [x] The fields `SFO.MEMCPY` and `SFO.MEMSET` are not used and can be deleted
- [ ] the documentation of `FakePointer1D` talks about base and offset