### PR TITLE
Add ARM64 build support for Linux and macOS

### DIFF
--- a/trunk/source/BA_FeatureDependenciesCommon/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesCommon/feature.xml
@@ -4,7 +4,7 @@
       label="BA_FeatureDependenciesCommon"
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <plugin
          id="com.google.gson"
@@ -72,6 +72,12 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.cdt.core.linux.aarch64"
+         os="linux"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.cdt.core.linux.x86_64"
          os="linux"
          arch="x86_64"
@@ -111,6 +117,12 @@
 
    <plugin
          id="org.eclipse.core.filesystem"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.core.filesystem.linux.aarch64"
+         os="linux"
+         arch="aarch64"
          version="0.0.0"/>
 
    <plugin

--- a/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
@@ -4,7 +4,7 @@
       label="BA_FeatureDependenciesDebugE4"
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <requires>
       <import feature="BA_FeatureDependenciesCommon"/>
@@ -229,6 +229,13 @@
          os="macosx"
          ws="cocoa"
          arch="x86_64"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.linux.aarch64"
+         os="linux"
+         ws="gtk"
+         arch="aarch64"
          version="0.0.0"/>
 
    <plugin

--- a/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
@@ -225,6 +225,13 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.swt.cocoa.macosx.aarch64"
+         os="macosx"
+         ws="cocoa"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.swt.cocoa.macosx.x86_64"
          os="macosx"
          ws="cocoa"

--- a/trunk/source/BA_FeatureUltimateCommandLine/feature.xml
+++ b/trunk/source/BA_FeatureUltimateCommandLine/feature.xml
@@ -4,7 +4,7 @@
       label="BA_FeatureUltimateCommandLine"
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <requires>
       <import feature="BA_FeatureDependenciesCommon"/>

--- a/trunk/source/BA_FeatureUltimateCommon/feature.xml
+++ b/trunk/source/BA_FeatureUltimateCommon/feature.xml
@@ -5,7 +5,7 @@
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
       os="linux,win32,macosx"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <requires>
       <import feature="BA_FeatureDependenciesCommon"/>
@@ -13,10 +13,7 @@
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.generator.icfgbuilder"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.analysis.lassoranker"
@@ -184,10 +181,7 @@
 
    <plugin
          id="edu.uci.ics.jung"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.blockencoding"

--- a/trunk/source/BA_FeatureUltimateDebug/feature.xml
+++ b/trunk/source/BA_FeatureUltimateDebug/feature.xml
@@ -5,7 +5,7 @@
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
       os="linux,win32,macosx"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <requires>
       <import feature="BA_FeatureDependenciesDebugE4"/>
@@ -31,9 +31,6 @@
 
    <plugin
          id="edu.uci.ics.jung"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/trunk/source/BA_FeatureWebBackend/feature.xml
+++ b/trunk/source/BA_FeatureWebBackend/feature.xml
@@ -4,7 +4,7 @@
       label="BA_FeatureWebBackend"
       version="0.3.1"
       provider-name="Ultimate Program Analysis Team"
-      arch="x86_64">
+      arch="aarch64,x86_64">
 
    <requires>
       <import feature="BA_FeatureDependenciesCommon" version="0.0.0"/>

--- a/trunk/source/BA_MavenParentUltimate/pom.xml
+++ b/trunk/source/BA_MavenParentUltimate/pom.xml
@@ -208,6 +208,11 @@
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
 					</environments>

--- a/trunk/source/BA_MavenParentUltimate/pom.xml
+++ b/trunk/source/BA_MavenParentUltimate/pom.xml
@@ -198,6 +198,11 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
+							<arch>aarch64</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
 						<environment>


### PR DESCRIPTION
The framework update introduces build support for the 64-bit ARM (aarch64) target architecture. The Ultimate framework and its components can now be built and executed on ARM64 platforms running Linux and macOS. This feature resolves #749.