### PR TITLE
Migrate framework to Eclipse E4.41 and update other dependencies

### DIFF
--- a/releaseScripts/default/adds/UltDelta.py
+++ b/releaseScripts/default/adds/UltDelta.py
@@ -52,6 +52,16 @@ def check_string_contains(strings, words):
     return False
 
 
+@lru_cache(maxsize=1)
+def get_launcher_jar():
+    candidates = glob.glob(os.path.join(ultimatedir, "plugins", "org.eclipse.equinox.launcher_*.jar"))
+    if not candidates:
+        raise RuntimeError("Could not find any launcher JAR.")
+    if len(candidates) > 1:
+        raise RuntimeError("Found multiple launcher JARs: " + ", ".join(candidates))
+    return candidates[0]
+
+
 def get_binary():
     ultimate_bin = [
         "java",
@@ -65,10 +75,7 @@ def get_binary():
 
     ultimate_bin = ultimate_bin + [
         "-jar",
-        os.path.join(
-            ultimatedir,
-            "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
-        ),
+        get_launcher_jar(),
         "-data",
         datadir,
     ]

--- a/releaseScripts/default/adds/UltDelta.py
+++ b/releaseScripts/default/adds/UltDelta.py
@@ -67,7 +67,7 @@ def get_binary():
         "-jar",
         os.path.join(
             ultimatedir,
-            "plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
+            "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
         ),
         "-data",
         datadir,

--- a/releaseScripts/default/adds/Ultimate.py
+++ b/releaseScripts/default/adds/Ultimate.py
@@ -292,7 +292,7 @@ def create_ultimate_base_call():
         "-jar",
         os.path.join(
             ultimatedir,
-            "plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
+            "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
         ),
         "-data",
         "@noDefault",

--- a/releaseScripts/default/adds/Ultimate.py
+++ b/releaseScripts/default/adds/Ultimate.py
@@ -277,6 +277,16 @@ def get_java():
     sys.exit(ExitCode.FAIL_NO_JAVA)
 
 
+@lru_cache(maxsize=1)
+def get_launcher_jar():
+    candidates = glob.glob(os.path.join(ultimatedir, "plugins", "org.eclipse.equinox.launcher_*.jar"))
+    if not candidates:
+        raise RuntimeError("Could not find any launcher JAR.")
+    if len(candidates) > 1:
+        raise RuntimeError("Found multiple launcher JARs: " + ", ".join(candidates))
+    return candidates[0]
+
+
 def create_ultimate_base_call():
     ultimate_bin = [
         get_java(),
@@ -290,10 +300,7 @@ def create_ultimate_base_call():
 
     ultimate_bin = ultimate_bin + [
         "-jar",
-        os.path.join(
-            ultimatedir,
-            "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
-        ),
+        get_launcher_jar(),
         "-data",
         "@noDefault",
         "-ultimatedata",

--- a/releaseScripts/default/adds/reqchecker/run_complete_analysis.py
+++ b/releaseScripts/default/adds/reqchecker/run_complete_analysis.py
@@ -719,7 +719,7 @@ def create_common_ultimate_cli_args(args, toolchain, settings, input_file):
         "-Xmx100G",
         "-Xss4m",
         "-jar",
-        "plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
+        "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
         "-tc",
         toolchain,
         "-s",

--- a/releaseScripts/default/adds/reqchecker/run_complete_analysis.py
+++ b/releaseScripts/default/adds/reqchecker/run_complete_analysis.py
@@ -712,6 +712,16 @@ def extract_vacuity_run_z3(args, tmp_smt_filename):
     return relevant_lines
 
 
+@lru_cache(maxsize=1)
+def get_launcher_jar():
+    candidates = glob.glob("plugins/org.eclipse.equinox.launcher_*.jar")
+    if not candidates:
+        raise RuntimeError("Could not find any launcher JAR.")
+    if len(candidates) > 1:
+        raise RuntimeError("Found multiple launcher JARs: " + ", ".join(candidates))
+    return candidates[0]
+
+
 def create_common_ultimate_cli_args(args, toolchain, settings, input_file):
     return [
         "java",
@@ -719,7 +729,7 @@ def create_common_ultimate_cli_args(args, toolchain, settings, input_file):
         "-Xmx100G",
         "-Xss4m",
         "-jar",
-        "plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar",
+        get_launcher_jar(),
         "-tc",
         toolchain,
         "-s",

--- a/releaseScripts/default/adds/run-ultimate.sh
+++ b/releaseScripts/default/adds/run-ultimate.sh
@@ -4,6 +4,6 @@ java \
 -Dosgi.configuration.area=config/ \
 -Xmx10G \
 -Xss4m \
--jar plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar \
+-jar plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar \
 -data config/data \
 "$@"

--- a/releaseScripts/website-config/backend/WebBackend.ini
+++ b/releaseScripts/website-config/backend/WebBackend.ini
@@ -1,5 +1,5 @@
 -startup
-plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar
+plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar
 --launcher.library
 plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64_1.2.1500.v20250801-0854
 -nosplash

--- a/trunk/source/BA_FeatureDependenciesCommon/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesCommon/feature.xml
@@ -11,14 +11,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="com.ibm.icu"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.sun.jna"
-         version="0.0.0"/>
-
-   <plugin
          id="com.sun.xml.bind.jaxb-impl"
          version="0.0.0"/>
 
@@ -35,27 +27,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.logging"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.log4j"
          version="0.0.0"/>
 
    <plugin
          id="org.apache.logging.log4j.api"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.xerces"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.xml.resolver"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.xml.serializer"
          version="0.0.0"/>
 
    <plugin

--- a/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
@@ -63,14 +63,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.xalan"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.xmlgraphics"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.databinding"
          version="0.0.0"/>
 

--- a/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
+++ b/trunk/source/BA_FeatureDependenciesDebugE4/feature.xml
@@ -7,7 +7,7 @@
       arch="x86_64">
 
    <requires>
-      <import feature="BA_FeatureDependenciesCommon"/>
+      <import feature="BA_FeatureUltimateCommon"/>
    </requires>
 
    <plugin

--- a/trunk/source/BA_FeatureUltimateCommandLine/feature.xml
+++ b/trunk/source/BA_FeatureUltimateCommandLine/feature.xml
@@ -7,7 +7,6 @@
       arch="x86_64">
 
    <requires>
-      <import feature="BA_FeatureDependenciesCommon"/>
       <import feature="BA_FeatureUltimateCommon"/>
    </requires>
 

--- a/trunk/source/BA_FeatureUltimateCommon/feature.xml
+++ b/trunk/source/BA_FeatureUltimateCommon/feature.xml
@@ -13,10 +13,7 @@
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.generator.icfgbuilder"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.analysis.lassoranker"
@@ -184,10 +181,7 @@
 
    <plugin
          id="edu.uci.ics.jung"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.plugins.blockencoding"

--- a/trunk/source/BA_FeatureUltimateDebug/feature.xml
+++ b/trunk/source/BA_FeatureUltimateDebug/feature.xml
@@ -31,9 +31,6 @@
 
    <plugin
          id="edu.uci.ics.jung"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/trunk/source/BA_FeatureUltimateDebug/feature.xml
+++ b/trunk/source/BA_FeatureUltimateDebug/feature.xml
@@ -9,8 +9,6 @@
 
    <requires>
       <import feature="BA_FeatureDependenciesDebugE4"/>
-      <import feature="BA_FeatureDependenciesCommon"/>
-      <import feature="BA_FeatureUltimateCommon"/>
    </requires>
 
    <plugin

--- a/trunk/source/BA_FeatureUltimateDeltaDebugger/feature.xml
+++ b/trunk/source/BA_FeatureUltimateDeltaDebugger/feature.xml
@@ -6,20 +6,11 @@
       provider-name="Ultimate Program Analysis Team">
 
    <requires>
-      <import feature="BA_FeatureDependenciesCommon"/>
-      <import feature="BA_FeatureUltimateCommon"/>
+      <import feature="BA_FeatureUltimateCommandLine"/>
    </requires>
 
    <plugin
          id="de.uni_freiburg.informatik.ultimate.deltadebugger"
-         version="0.0.0"/>
-
-   <plugin
-         id="de.uni_freiburg.informatik.ultimate.cli"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.cli"
          version="0.0.0"/>
 
 </feature>

--- a/trunk/source/BA_FeatureWebBackend/feature.xml
+++ b/trunk/source/BA_FeatureWebBackend/feature.xml
@@ -7,7 +7,7 @@
       arch="x86_64">
 
    <requires>
-      <import feature="BA_FeatureDependenciesCommon" version="0.0.0"/>
+      <import feature="BA_FeatureUltimateCommon"/>
    </requires>
 
    <plugin

--- a/trunk/source/BA_MavenParentUltimate/pom.xml
+++ b/trunk/source/BA_MavenParentUltimate/pom.xml
@@ -20,9 +20,9 @@
 
 		<!-- maven plugin versions -->
 		<!-- https://mvnrepository.com/artifact/org.eclipse.tycho/tycho-core -->
-		<tycho-version>5.0.0</tycho-version>
+		<tycho-version>5.0.2</tycho-version>
 		<!-- https://mvnrepository.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin -->
-		<sonar-version>5.2.0.4988</sonar-version>
+		<sonar-version>5.5.0.6356</sonar-version>
 		<!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
 		<jacoco-version>0.8.14</jacoco-version>
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-clean-plugin -->
@@ -30,13 +30,13 @@
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-antrun-plugin -->
 		<maven-antrun-version>3.2.0</maven-antrun-version>
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-war-plugin -->
-		<maven-war-version>3.5.0</maven-war-version>
+		<maven-war-version>3.5.1</maven-war-version>
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
-		<maven-assembly-version>3.7.1</maven-assembly-version>
+		<maven-assembly-version>3.8.0</maven-assembly-version>
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-resources-plugin -->
-		<maven-resources-version>3.3.1</maven-resources-version>
+		<maven-resources-version>3.5.0</maven-resources-version>
 		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
-		<maven-compiler-version>3.14.1</maven-compiler-version>
+		<maven-compiler-version>3.15.0</maven-compiler-version>
 
 		<!-- reference to workspace root -->
 		<workspaceDir>${basedir}/..</workspaceDir>
@@ -233,7 +233,7 @@
 					<dependency>
 						<groupId>org.eclipse.jdt</groupId>
 						<artifactId>ecj</artifactId>
-						<version>3.43.0</version>
+						<version>3.45.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/trunk/source/BA_SiteRepository/CLI-E4.product
+++ b/trunk/source/BA_SiteRepository/CLI-E4.product
@@ -48,8 +48,6 @@
 
    <features>
       <feature id="BA_FeatureUltimateCommandLine"/>
-      <feature id="BA_FeatureUltimateCommon"/>
-      <feature id="BA_FeatureDependenciesCommon"/>
    </features>
 
    <configurations>

--- a/trunk/source/BA_SiteRepository/Debug-E4.product
+++ b/trunk/source/BA_SiteRepository/Debug-E4.product
@@ -47,9 +47,6 @@
    </plugins>
 
    <features>
-      <feature id="BA_FeatureDependenciesCommon"/>
-      <feature id="BA_FeatureDependenciesDebugE4"/>
-      <feature id="BA_FeatureUltimateCommon"/>
       <feature id="BA_FeatureUltimateDebug"/>
    </features>
 

--- a/trunk/source/BA_SiteRepository/DeltaDebugger.product
+++ b/trunk/source/BA_SiteRepository/DeltaDebugger.product
@@ -48,8 +48,6 @@
 
    <features>
       <feature id="BA_FeatureUltimateDeltaDebugger"/>
-      <feature id="BA_FeatureUltimateCommon"/>
-      <feature id="BA_FeatureDependenciesCommon"/>
    </features>
 
    <configurations>

--- a/trunk/source/BA_SiteRepository/Ultimate.target
+++ b/trunk/source/BA_SiteRepository/Ultimate.target
@@ -25,13 +25,13 @@
                 <dependency>
                     <groupId>io.github.uuverifiers</groupId>
                     <artifactId>eldarica_2.12</artifactId>
-                    <version>2.1</version>
+                    <version>2.2.1</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>io.github.uuverifiers</groupId>
                     <artifactId>princess_2.12</artifactId>
-                    <version>2024-11-08</version>
+                    <version>2025-11-17</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
@@ -43,31 +43,31 @@
                 <dependency>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
-                    <version>3.17.0</version>
+                    <version>3.20.0</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
-                    <version>2.2.7</version>
+                    <version>2.3.2</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-log4j2</artifactId>
-                    <version>2.2.7</version>
+                    <version>2.3.2</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.12.20</version>
+                    <version>2.12.21</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
-                    <version>2.3</version>
+                    <version>2.5</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>

--- a/trunk/source/BA_SiteRepository/Ultimate.target
+++ b/trunk/source/BA_SiteRepository/Ultimate.target
@@ -65,12 +65,6 @@
                     <type>jar</type>
                 </dependency>
                 <dependency>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                    <version>2.5</version>
-                    <type>jar</type>
-                </dependency>
-                <dependency>
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
                     <version>2.12.2</version>

--- a/trunk/source/BA_SiteRepository/Ultimate.target
+++ b/trunk/source/BA_SiteRepository/Ultimate.target
@@ -1,55 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<target name="Ultimate E4.37">
+<target name="Ultimate E4.39">
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <launcherArgs>
         <vmArgs>-ea -Xms4M -Xmx4G</vmArgs>
     </launcherArgs>
     <locations>
         <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-            <repository id="eclipse-releases" location="https://download.eclipse.org/releases/2025-09"/>
+            <repository id="eclipse-releases" location="https://download.eclipse.org/releases/2026-03"/>
             <unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.server.jetty.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-            <repository id="orbit-aggregation" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09"/>
-            <unit id="org.eclipse.orbit.legacy.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.aopalliance.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.github.package-url.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.github.virtuald.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.google.javascript.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.jcraft.jsch.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.jcraft.jzlib.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.jgoodies.common.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.jgoodies.forms.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.konghq.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.com.zaxxer.feature.group" version="0.0.0"/>
+            <repository id="orbit-aggregation" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03"/>
             <unit id="org.eclipse.orbit.maven.hamcrest.core.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.hamcrest.deprecated.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.hamcrest.library.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.javax.wsdl.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.jdom2.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.jnr.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.apache.axis.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.orbit.maven.org.apache.batik.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.apache.poi.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.apache.ws.commons.util.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.apache.xmlbeans.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.apache.xmlgraphics.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.codelibs.nekohtml.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.cyclonedx.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.dom4j.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.orbit.maven.org.jdom.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.org.pushingpixels.trident.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.orbit.maven.osgi.all.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.xalan.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.xerces.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.xml-resolver.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.orbit.maven.junit.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.orbit.maven.lucene.feature.group" version="0.0.0"/>
         </location>
         <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
             <dependencies>

--- a/trunk/source/BA_SiteRepository/UltimateEliminator.product
+++ b/trunk/source/BA_SiteRepository/UltimateEliminator.product
@@ -44,42 +44,9 @@
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</windows>
    </vm>
 
-   <plugins>
-      <plugin id="com.github.jhoenicke.javacup"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.astbuilder"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.boogie.parser"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.boogie.preprocessor"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.controller.eliminator"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.core"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.boogieast"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.core"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.modelcheckerutils"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.smtlib"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.smtlibutils"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.ultimatemodel"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.lib.util"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.smtinterpol"/>
-      <plugin id="de.uni_freiburg.informatik.ultimate.smtsolver.external"/>
-      <plugin id="jakarta.activation-api"/>
-      <plugin id="jakarta.xml.bind-api"/>
-      <plugin id="org.apache.commons.commons-io"/>
-      <plugin id="org.apache.commons.lang3"/>
-      <plugin id="org.apache.log4j"/>
-      <plugin id="org.apache.logging.log4j.api"/>
-      <plugin id="org.eclipse.core.contenttype"/>
-      <plugin id="org.eclipse.core.expressions"/>
-      <plugin id="org.eclipse.core.filesystem"/>
-      <plugin id="org.eclipse.core.jobs"/>
-      <plugin id="org.eclipse.core.resources"/>
-      <plugin id="org.eclipse.core.runtime"/>
-      <plugin id="org.eclipse.equinox.app"/>
-      <plugin id="org.eclipse.equinox.common"/>
-      <plugin id="org.eclipse.equinox.preferences"/>
-      <plugin id="org.eclipse.equinox.registry"/>
-      <plugin id="org.eclipse.osgi"/>
-      <plugin id="org.eclipse.osgi.services"/>
-      <plugin id="org.eclipse.osgi.util"/>
-   </plugins>
+   <features>
+      <feature id="BA_FeatureUltimateCommandLine"/>
+   </features>
 
    <configurations>
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />

--- a/trunk/source/BA_SiteRepository/WebBackend.product
+++ b/trunk/source/BA_SiteRepository/WebBackend.product
@@ -36,8 +36,6 @@
    </plugins>
 
    <features>
-      <feature id="BA_FeatureDependenciesCommon"/>
-      <feature id="BA_FeatureUltimateCommon"/>
       <feature id="BA_FeatureWebBackend"/>
    </features>
 

--- a/trunk/source/WebsiteStatic/scripts/webinterface/externals.py
+++ b/trunk/source/WebsiteStatic/scripts/webinterface/externals.py
@@ -16,7 +16,7 @@ def get_ultimate_cli() -> list[str]:
     jar = (
         ult_bin.parent
         / "plugins"
-        / "org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar"
+        / "org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar"
     )
     datadir = ult_bin.parent / "data"
     return [


### PR DESCRIPTION
#757 previously updated the Eclipse dependencies to E4.37 and consolidated the target files. Building on that work, this update updates the Eclipse dependencies further to E4.41.

To achieve this, several unused feature groups (including some that no longer exist) have been removed from the target file, and the `feature.xml` files were cleaned up as well. Both changes should simplify future dependency updates.

Additionally, the Maven plugins, covering both the build process and regular dependencies, have been updated.

~~**Note:** This PR updates the version number of `org.eclipse.equinox.launcher` in several files within the Ultimate repo (e.g., `Ultimate.py`). However, the tool info module in benchexec still needs to be updated, as it also depends on the exact version number (see [here](https://github.com/sosy-lab/benchexec/blob/main/benchexec/tools/ultimate.py#L38)), which was also forgotten for the changes in #757. To avoid having to make such changes for every future dependency update, I already implemented a wildcard-based solution: https://github.com/ultimate-pa/benchexec/commit/88b9aa5b03b5cbcfd6c1aa5ef812811e493a618f. If you agree with that approach, I can also open a PR for benchexec.~~