### PR TITLE
Common settings handling for printer plugins

### DIFF
--- a/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_DerefFreeMemtrack.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_DerefFreeMemtrack.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Overflow.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Overflow.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach_1D.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach_1D.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach_Const.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/all/cToBoogie_Default_Reach_Const.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_4ByteHLMM_Reach.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_4ByteHLMM_Reach.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_4ByteHLMM_Reach_1D.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_4ByteHLMM_Reach_1D.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_DerefFreeMemtrack.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_DerefFreeMemtrack.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach_1D.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach_1D.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach_Const.epf
+++ b/trunk/examples/CToBoogieTranslation/regression/cToBoogie_Bitvector_Reach_Const.epf
@@ -2,8 +2,8 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 
 
 #Tue Feb 18 11:27:46 CET 2014

--- a/trunk/examples/Interactive/settings/GuiResetSettingsExported.epf
+++ b/trunk/examples/Interactive/settings/GuiResetSettingsExported.epf
@@ -335,10 +335,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Thu Feb 16 15:44:43 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Thu Feb 16 15:44:43 CET 2017

--- a/trunk/examples/Interactive/settings/ResetSettingsCamel.epf
+++ b/trunk/examples/Interactive/settings/ResetSettingsCamel.epf
@@ -313,10 +313,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017

--- a/trunk/examples/Interactive/settings/ResetSettingsCamelCannibalize.epf
+++ b/trunk/examples/Interactive/settings/ResetSettingsCamelCannibalize.epf
@@ -321,10 +321,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed May 10 01:11:15 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.12
 file_export_version=3.0
 #Wed May 10 01:11:15 CEST 2017

--- a/trunk/examples/Interactive/settings/ResetSettingsCamelNoEnhancment.epf
+++ b/trunk/examples/Interactive/settings/ResetSettingsCamelNoEnhancment.epf
@@ -321,10 +321,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed May 10 01:08:21 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.12
 file_export_version=3.0
 #Wed May 10 01:08:21 CEST 2017

--- a/trunk/examples/Interactive/settings/ResetSettingsFixed.epf
+++ b/trunk/examples/Interactive/settings/ResetSettingsFixed.epf
@@ -314,10 +314,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017

--- a/trunk/examples/Interactive/settings/ResetSettingsWolf.epf
+++ b/trunk/examples/Interactive/settings/ResetSettingsWolf.epf
@@ -314,10 +314,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Thu Feb 16 15:47:28 CET 2017

--- a/trunk/examples/LTL/regression/c/LTLAutomizerC.epf
+++ b/trunk/examples/LTL/regression/c/LTLAutomizerC.epf
@@ -266,10 +266,10 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\greif\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\greif\\AppData\\Local\\Temp\\
 #Fri Dec 09 13:35:39 CET 2016
 /instance/de.uni_freiburg.informatik.ultimate.witnessprinter/Command\ to\ execute\ witness\ verifier=
 @de.uni_freiburg.informatik.ultimate.witnessprinter=0.0.1

--- a/trunk/examples/programs/FloatingPoint/heapregression/floats-svcomp-Reach-64bit-Automizer_Bitvector.epf
+++ b/trunk/examples/programs/FloatingPoint/heapregression/floats-svcomp-Reach-64bit-Automizer_Bitvector.epf
@@ -193,8 +193,8 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.9
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
 #Fri Mar 31 14:38:20 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/programs/abstractInterpretation/regression/all/AIv2_EQ.epf
+++ b/trunk/examples/programs/abstractInterpretation/regression/all/AIv2_EQ.epf
@@ -205,10 +205,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.20
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017

--- a/trunk/examples/programs/abstractInterpretation/regression/eq/AIv2_EQ.epf
+++ b/trunk/examples/programs/abstractInterpretation/regression/eq/AIv2_EQ.epf
@@ -187,10 +187,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Fri Oct 06 15:09:12 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.21
 file_export_version=3.0
 #Fri Oct 06 15:09:12 CEST 2017

--- a/trunk/examples/programs/abstractInterpretation/regression/non_taipan/AIv2_EQ.epf
+++ b/trunk/examples/programs/abstractInterpretation/regression/non_taipan/AIv2_EQ.epf
@@ -205,10 +205,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.20
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017

--- a/trunk/examples/programs/abstractInterpretation/regression/recursive_all/AIv2_EQ.epf
+++ b/trunk/examples/programs/abstractInterpretation/regression/recursive_all/AIv2_EQ.epf
@@ -205,10 +205,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.20
 file_export_version=3.0
 #Fri Sep 08 22:39:43 CEST 2017

--- a/trunk/examples/programs/real-life/PricedTimedAutomata/settings-dumpsmt.epf
+++ b/trunk/examples/programs/real-life/PricedTimedAutomata/settings-dumpsmt.epf
@@ -251,10 +251,10 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\Sergio\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\Sergio\\AppData\\Local\\Temp\\
 #Wed Apr 06 15:29:51 CEST 2016
 @de.uni_freiburg.informatik.ultimate.core=0.0.1
 /instance/de.uni_freiburg.informatik.ultimate.core/Drop\ models\ when\ Ultimate\ exits=true

--- a/trunk/examples/programs/real-life/PricedTimedAutomata/settings_z3.epf
+++ b/trunk/examples/programs/real-life/PricedTimedAutomata/settings_z3.epf
@@ -211,10 +211,10 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\WINDOWS\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\WINDOWS\\
 #Tue Mar 22 18:13:24 CET 2016
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Automizer-FP-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Automizer-FP-mem.epf
@@ -36,7 +36,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Oct 18 16:33:01 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Impulse-FP-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Impulse-FP-mem.epf
@@ -37,7 +37,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Oct 18 19:01:47 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Impulse-FP-nBE.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Impulse-FP-nBE.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 13:45:45 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Impulse-FP.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Impulse-FP.epf
@@ -46,7 +46,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 20:28:09 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Impulse-TreeInterpolation-nBE.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Impulse-TreeInterpolation-nBE.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 13:47:27 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Impulse-TreeInterpolation.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Impulse-TreeInterpolation.epf
@@ -46,7 +46,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 20:28:24 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-FP-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-FP-mem.epf
@@ -36,7 +36,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Oct 18 19:02:15 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-FP-nBE.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-FP-nBE.epf
@@ -43,7 +43,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 13:48:06 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-FP.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-FP.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 20:28:38 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-Princess-TreeInterpolation.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-Princess-TreeInterpolation.epf
@@ -53,7 +53,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 23:18:29 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-Princess.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-Princess.epf
@@ -54,7 +54,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Feb 05 10:32:53 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SMTInterpol.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SMTInterpol.epf
@@ -53,7 +53,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Feb 05 10:31:19 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-LV-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-LV-mem.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Tue Feb 03 14:13:24 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-LV.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-LV.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 16:40:07 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC-mem.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Tue Feb 03 14:12:38 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-IC.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 16:39:33 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-LV-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-LV-mem.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Tue Feb 03 14:12:56 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-LV.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-LV.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 16:41:04 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-mem.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP-mem.epf
@@ -46,7 +46,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Tue Feb 03 14:13:09 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-SP.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-SP.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 16:39:18 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-TreeInterpolation-nBE.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-TreeInterpolation-nBE.epf
@@ -43,7 +43,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Oct 16 13:48:28 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/TACASInterpolation2015/Kojak-TreeInterpolation.epf
+++ b/trunk/examples/settings/TACASInterpolation2015/Kojak-TreeInterpolation.epf
@@ -53,7 +53,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Wed Feb 04 23:18:53 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/TraceAbstractionWithAFA.epf
+++ b/trunk/examples/settings/TraceAbstractionWithAFA.epf
@@ -63,7 +63,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Tue Jan 27 16:36:29 CET 2015
 \!/instance/de.uni_freiburg.informatik.ultimate.plugins.output.jungvisualization=
 file_export_version=3.0

--- a/trunk/examples/settings/ai/eq-bench/mempurity-32bit-Automizer_FixedPref_impreciseBitfields+AI_EQ_SS.epf
+++ b/trunk/examples/settings/ai/eq-bench/mempurity-32bit-Automizer_FixedPref_impreciseBitfields+AI_EQ_SS.epf
@@ -225,10 +225,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Tue Mar 27 18:44:09 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Tue Mar 27 18:44:09 CEST 2018

--- a/trunk/examples/settings/ai/eq-bench/svcomp-DerefFreeMemtrack-32bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
+++ b/trunk/examples/settings/ai/eq-bench/svcomp-DerefFreeMemtrack-32bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
@@ -225,10 +225,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Mar 28 11:51:59 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Wed Mar 28 11:51:59 CEST 2018

--- a/trunk/examples/settings/ai/eq-bench/svcomp-DerefFreeMemtrack-64bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
+++ b/trunk/examples/settings/ai/eq-bench/svcomp-DerefFreeMemtrack-64bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
@@ -218,10 +218,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Mar 28 11:00:48 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Wed Mar 28 11:00:48 CEST 2018

--- a/trunk/examples/settings/ai/eq-bench/svcomp-Reach-32bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
+++ b/trunk/examples/settings/ai/eq-bench/svcomp-Reach-32bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
@@ -224,10 +224,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Apr 11 17:54:41 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Wed Apr 11 17:54:41 CEST 2018

--- a/trunk/examples/settings/ai/eq-bench/svcomp-Reach-64bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
+++ b/trunk/examples/settings/ai/eq-bench/svcomp-Reach-64bit-Automizer_Fixed_noBitfields+AI_EQ_SS.epf
@@ -217,10 +217,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Apr 11 17:54:20 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\Users\\alex\\AppData\\Local\\Temp\\
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\Users\\alex\\AppData\\Local\\Temp\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Wed Apr 11 17:54:20 CEST 2018

--- a/trunk/examples/settings/automizer/ErrorLocalization/Do-Multi-Trace-Analysis.epf
+++ b/trunk/examples/settings/automizer/ErrorLocalization/Do-Multi-Trace-Analysis.epf
@@ -316,10 +316,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Sat Mar 31 21:30:41 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Sat Mar 31 21:30:41 CEST 2018

--- a/trunk/examples/settings/automizer/ErrorLocalization/Do-Single-Trace-Analysis.epf
+++ b/trunk/examples/settings/automizer/ErrorLocalization/Do-Single-Trace-Analysis.epf
@@ -316,10 +316,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Sat Mar 31 21:31:32 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Sat Mar 31 21:31:32 CEST 2018

--- a/trunk/examples/settings/automizer/ErrorLocalization/Get-Angelic-Score.epf
+++ b/trunk/examples/settings/automizer/ErrorLocalization/Get-Angelic-Score.epf
@@ -317,10 +317,10 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Apr 11 15:00:49 CEST 2018
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=/tmp
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=/tmp
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.23
 file_export_version=3.0
 #Wed Apr 11 15:00:49 CEST 2018

--- a/trunk/examples/settings/automizer/PricedTimedAutomata/PricedTimedAutomata_z3.epf
+++ b/trunk/examples/settings/automizer/PricedTimedAutomata/PricedTimedAutomata_z3.epf
@@ -211,10 +211,10 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\WINDOWS\\
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\WINDOWS\\
 #Tue Mar 22 18:13:24 CET 2016
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/automizer/svComp-64bit-memsafety-AutomizerTwotrack.epf
+++ b/trunk/examples/settings/automizer/svComp-64bit-memsafety-AutomizerTwotrack.epf
@@ -40,7 +40,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Oct 13 17:18:26 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/default/reqcheck/ReqCheck-ReqToTest.epf
+++ b/trunk/examples/settings/default/reqcheck/ReqCheck-ReqToTest.epf
@@ -77,9 +77,9 @@ file_export_version=3.0
 
 #Tue Jan 14 10:14:05 CET 2020
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.25
 file_export_version=3.0
 

--- a/trunk/examples/settings/kojak/kojak-standard.epf
+++ b/trunk/examples/settings/kojak/kojak-standard.epf
@@ -54,7 +54,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Jan 11 11:54:01 CET 2016
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/searchAndReplaceInSettings.sh
+++ b/trunk/examples/settings/searchAndReplaceInSettings.sh
@@ -11,9 +11,8 @@
 # ./searchAndReplaceInSettings.sh [OLDSTRING] [NEWSTRING]
 #
 # The replacement will be done in all subfolders of trunk/examples/settings
-# and in /trunk/examples/source/WebUltimateBridge/src/de/uni_freiburg/informatik/ultimate/webbridge/resources/settings/
 #
-# Check if your replacement was succesfull using
+# Check if your replacement was successful using
 # grep -ir SOME_KEYWORD .
 #
 # Author: Matthias Heizmann, Claus Schaetzle
@@ -22,7 +21,7 @@
 
 # Convert a raw string into a basic regular expression for a sed s/.../.../ command
 sedQuote() {
-    sed 's/[][/\.*$^]/\\&/g' <<< "$*"
+    echo "$*" | sed 's/[][/\.*$^]/\\&/g'
 }
 
 echo "Replacing the OLDSTRING with NEWSTRING in each .epf file"
@@ -30,6 +29,5 @@ echo "OLDSTRING: $1"
 echo "NEWSTRING: $2"
 old="$(sedQuote "$1")"
 new="$(sedQuote "$2")"
-find .. ../../source/WebUltimateBridge/src/de/uni_freiburg/informatik/ultimate/webbridge/resources/settings/ \
-	-name \*.epf -exec sed -i -e "s/$old/$new/g" {} +
+find .. -name \*.epf -exec sed -i -e "s/$old/$new/g" {} +
 

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing2.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing2.epf
@@ -254,9 +254,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Sun Feb 12 16:17:32 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Sun Feb 12 16:17:32 CET 2017

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing2_DEBUG.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing2_DEBUG.epf
@@ -260,9 +260,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Sun Feb 12 16:17:32 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Sun Feb 12 16:17:32 CET 2017

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing_ExternalZ3.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing_ExternalZ3.epf
@@ -257,9 +257,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Fri Mar 10 13:30:17 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Fri Mar 10 13:30:17 CET 2017

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing_ExternalZ3_DEBUG.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing_ExternalZ3_DEBUG.epf
@@ -257,9 +257,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Wed Mar 01 22:53:40 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Wed Mar 01 22:53:40 CET 2017

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing_InternalSmtInterpol_DEBUG.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing_InternalSmtInterpol_DEBUG.epf
@@ -252,9 +252,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Tue Feb 28 20:49:32 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Tue Feb 28 20:49:32 CET 2017

--- a/trunk/examples/settings/spaceex/spaceex_parser_testing_ModelsAndUnsatCore_DEBUG.epf
+++ b/trunk/examples/settings/spaceex/spaceex_parser_testing_ModelsAndUnsatCore_DEBUG.epf
@@ -256,9 +256,9 @@ file_export_version=3.0
 file_export_version=3.0
 #Tue Feb 28 21:35:45 CET 2017
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/File\ name\:=boogiePrinter.bpl
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=false
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ file\ name=boogiePrinter.bpl
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=false
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=false
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.1.8
 file_export_version=3.0
 #Tue Feb 28 21:35:45 CET 2017

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-memsafety-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-memsafety-BE-Impulse.epf
@@ -43,7 +43,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Oct 20 14:22:00 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-memsafety-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-memsafety-BE-Kojak.epf
@@ -42,7 +42,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Oct 20 14:22:13 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-precise-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-precise-BE-Impulse.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:32:26 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-precise-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-precise-BE-Kojak.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:32:42 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-simple-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-simple-BE-Impulse.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:33:16 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-32bit-simple-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-32bit-simple-BE-Kojak.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:33:32 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-memsafety-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-memsafety-BE-Impulse.epf
@@ -41,7 +41,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Oct 20 14:24:00 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-memsafety-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-memsafety-BE-Kojak.epf
@@ -40,7 +40,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Oct 20 14:24:13 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-precise-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-precise-BE-Impulse.epf
@@ -43,7 +43,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:34:06 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-precise-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-precise-BE-Kojak.epf
@@ -42,7 +42,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:34:22 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-simple-BE-Impulse.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-simple-BE-Impulse.epf
@@ -43,7 +43,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:34:51 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2015/svComp-64bit-simple-BE-Kojak.epf
+++ b/trunk/examples/settings/svcomp2015/svComp-64bit-simple-BE-Kojak.epf
@@ -42,7 +42,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 24 16:35:05 CEST 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-10.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-10.epf
@@ -55,7 +55,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:06:59 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-2.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-2.epf
@@ -55,7 +55,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Nov 07 02:25:47 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-4.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-db-4.epf
@@ -55,7 +55,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Nov 07 02:26:14 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-default.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-no_be-default.epf
@@ -54,7 +54,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:04:33 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-yes_be-db-10.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-yes_be-db-10.epf
@@ -54,7 +54,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:07:20 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-yes_be-default.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_32_sepsolver-yes_be-default.epf
@@ -52,7 +52,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:01:33 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-10.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-10.epf
@@ -52,7 +52,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:08:31 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-2.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-2.epf
@@ -52,7 +52,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Nov 07 02:26:36 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-4.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-db-4.epf
@@ -52,7 +52,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sat Nov 07 02:26:54 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-default.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-no_be-default.epf
@@ -51,7 +51,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:03:54 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-yes_be-db-10.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-yes_be-db-10.epf
@@ -51,7 +51,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:08:09 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-yes_be-default.epf
+++ b/trunk/examples/settings/svcomp2016/experimental/kojak_64_sepsolver-yes_be-default.epf
@@ -49,7 +49,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Nov 05 00:02:20 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=info

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-DerefFreeMemtrack-32bit-Kojak_Bitvector.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-DerefFreeMemtrack-32bit-Kojak_Bitvector.epf
@@ -63,7 +63,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:52:02 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-DerefFreeMemtrack-32bit-Kojak_Default.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-DerefFreeMemtrack-32bit-Kojak_Default.epf
@@ -59,7 +59,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:40:16 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-Overflow-64bit-Kojak_Default.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-Overflow-64bit-Kojak_Default.epf
@@ -59,7 +59,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:42:03 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-32bit-Kojak_Bitvector.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-32bit-Kojak_Bitvector.epf
@@ -64,7 +64,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:49:53 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-32bit-Kojak_Default.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-32bit-Kojak_Default.epf
@@ -60,7 +60,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:43:17 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-64bit-Kojak_Bitvector.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-64bit-Kojak_Bitvector.epf
@@ -62,7 +62,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:51:12 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-64bit-Kojak_Default.epf
+++ b/trunk/examples/settings/svcomp2016/kojak/svcomp-Reach-64bit-Kojak_Default.epf
@@ -58,7 +58,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Sun Nov 08 00:44:45 CET 2015
 file_export_version=3.0
 /instance/de.uni_freiburg.informatik.ultimate.core/Log\ level\ for\ plugins=INFO

--- a/trunk/examples/settings/translation/BoogiePrinter.epf
+++ b/trunk/examples/settings/translation/BoogiePrinter.epf
@@ -2,6 +2,6 @@
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming?=true
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory?=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Use\ automatic\ naming=true
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Save\ file\ in\ source\ directory=true
 

--- a/trunk/examples/settings/witness/svComp-32bit-precise-Automizer-ValidateCPA.epf
+++ b/trunk/examples/settings/witness/svComp-32bit-precise-Automizer-ValidateCPA.epf
@@ -99,7 +99,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Thu Jun 04 14:46:55 CEST 2015
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/witness/svComp-32bit-precise-Automizer-Witness.epf
+++ b/trunk/examples/settings/witness/svComp-32bit-precise-Automizer-Witness.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Fri Oct 31 20:51:59 CET 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/witness/svComp-32bit-precise-BE-Impulse-Witness.epf
+++ b/trunk/examples/settings/witness/svComp-32bit-precise-BE-Impulse-Witness.epf
@@ -45,7 +45,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Nov 03 14:41:51 CET 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/examples/settings/witness/svComp-32bit-precise-BE-Kojak-Witness.epf
+++ b/trunk/examples/settings/witness/svComp-32bit-precise-BE-Kojak-Witness.epf
@@ -44,7 +44,7 @@ file_export_version=3.0
 \!/instance/de.uni_freiburg.informatik.ultimate.boogie.printer=
 file_export_version=3.0
 @de.uni_freiburg.informatik.ultimate.boogie.printer=0.0.1
-/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Dump\ path\:=C\:\\data\\bin\\svcompC
+/instance/de.uni_freiburg.informatik.ultimate.boogie.printer/Output\ directory=C\:\\data\\bin\\svcompC
 #Mon Nov 03 12:22:26 CET 2014
 file_export_version=3.0
 \!/instance/CDTParser=

--- a/trunk/source/BoogiePrinter/src/de/uni_freiburg/informatik/ultimate/boogie/printer/BoogiePrinterObserver.java
+++ b/trunk/source/BoogiePrinter/src/de/uni_freiburg/informatik/ultimate/boogie/printer/BoogiePrinterObserver.java
@@ -37,9 +37,8 @@ import java.io.PrintWriter;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Unit;
 import de.uni_freiburg.informatik.ultimate.boogie.output.BoogieOutput;
-import de.uni_freiburg.informatik.ultimate.boogie.printer.preferences.PreferenceInitializer;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
-import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelType;
 import de.uni_freiburg.informatik.ultimate.core.model.observers.IUnmanagedObserver;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
@@ -61,11 +60,8 @@ public class BoogiePrinterObserver implements IUnmanagedObserver {
 	@Override
 	public boolean process(final IElement root) {
 		if (root instanceof final Unit unit) {
-			final PrintWriter writer = openTempFile(root);
-			if (writer != null) {
-				try (final BoogieOutput output = new BoogieOutput(writer)) {
-					output.printBoogieProgram(unit);
-				}
+			try (final BoogieOutput output = new BoogieOutput(openTempFile(root))) {
+				output.printBoogieProgram(unit);
 			}
 			return false;
 		}
@@ -73,60 +69,15 @@ public class BoogiePrinterObserver implements IUnmanagedObserver {
 	}
 
 	private PrintWriter openTempFile(final IElement root) {
-		String path;
-		String filename;
-		File file = null;
-
-		if (mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-				.getBoolean(PreferenceInitializer.SAVE_IN_SOURCE_DIRECTORY_LABEL)) {
-			final ILocation loc = ILocation.getAnnotation(root);
-			final File inputFile = new File(loc.getFileName());
-			if (inputFile.isDirectory()) {
-				path = inputFile.getPath();
-			} else {
-				path = inputFile.getParent();
-			}
-			if (path == null) {
-				mLogger.warn("Model does not provide a valid source location, falling back to default dump path...");
-				path = mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-						.getString(PreferenceInitializer.DUMP_PATH_LABEL);
-			}
-		} else {
-			path = mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-					.getString(PreferenceInitializer.DUMP_PATH_LABEL);
-		}
-
+		final var prefs = mServices.getPreferenceProvider(Activator.PLUGIN_ID);
+		final var outputFileSettings =
+				FilePrinterUtils.OutputFileSettings.fromPrinterPreferences(prefs, "BoogiePrinter_", "_UID", ".bpl");
+		final File file = FilePrinterUtils.openOutputFile(outputFileSettings, root, mLogger);
 		try {
-			if (mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-					.getBoolean(PreferenceInitializer.UNIQUE_NAME_LABEL)) {
-				file = File.createTempFile(
-						"BoogiePrinter_" + new File(ILocation.getAnnotation(root).getFileName()).getName() + "_UID",
-						".bpl", new File(path));
-			} else {
-				filename = mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-						.getString(PreferenceInitializer.FILE_NAME_LABEL);
-				file = new File(path + File.separatorChar + filename);
-				if ((!file.isFile() || !file.canWrite()) && file.exists()) {
-					mLogger.warn("Cannot write to: " + file.getAbsolutePath());
-					return null;
-				}
-
-				if (file.exists()) {
-					mLogger.info("File already exists and will be overwritten: " + file.getAbsolutePath());
-				}
-				file.createNewFile();
-			}
-			mLogger.info("Writing to file " + file.getAbsolutePath());
 			return new PrintWriter(new FileWriter(file));
-
 		} catch (final IOException e) {
-			if (file != null) {
-				mLogger.fatal("Cannot open file: " + file.getAbsolutePath(), e);
-			} else {
-				mLogger.fatal("Cannot open file", e);
-			}
-
-			return null;
+			mLogger.fatal("Cannot open file: " + file.getAbsolutePath(), e);
+			throw new IllegalStateException("Could not open file: " + file.toString(), e);
 		}
 	}
 

--- a/trunk/source/BoogiePrinter/src/de/uni_freiburg/informatik/ultimate/boogie/printer/preferences/PreferenceInitializer.java
+++ b/trunk/source/BoogiePrinter/src/de/uni_freiburg/informatik/ultimate/boogie/printer/preferences/PreferenceInitializer.java
@@ -28,37 +28,16 @@ package de.uni_freiburg.informatik.ultimate.boogie.printer.preferences;
 
 import de.uni_freiburg.informatik.ultimate.boogie.printer.Activator;
 import de.uni_freiburg.informatik.ultimate.core.lib.preferences.UltimatePreferenceInitializer;
-import de.uni_freiburg.informatik.ultimate.core.model.preferences.PreferenceType;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.preferences.UltimatePreferenceItem;
 
 public class PreferenceInitializer extends UltimatePreferenceInitializer {
-
-	public static final String SAVE_IN_SOURCE_DIRECTORY_LABEL = "Save file in source directory?";
-	private static final boolean SAVE_IN_SOURCE_DIRECTORY_DEFAULT = false;
-
-	public static final String UNIQUE_NAME_LABEL = "Use automatic naming?";
-	private static final boolean UNIQUE_NAME_DEFAULT = false;
-
-	public static final String DUMP_PATH_LABEL = "Dump path:";
-	private static final String DUMP_PATH_DEFAULT = System.getProperty("java.io.tmpdir");
-
-	public static final String FILE_NAME_LABEL = "File name:";
-	private static final String FILE_NAME_DEFAULT = "boogiePrinter.bpl";
-
 	public PreferenceInitializer() {
 		super(Activator.PLUGIN_ID, Activator.PLUGIN_NAME);
 	}
 
 	@Override
 	protected UltimatePreferenceItem<?>[] initDefaultPreferences() {
-		// TODO Auto-generated method stub
-		return new UltimatePreferenceItem<?>[] {
-				new UltimatePreferenceItem<>(DUMP_PATH_LABEL, DUMP_PATH_DEFAULT, PreferenceType.Directory),
-				new UltimatePreferenceItem<>(FILE_NAME_LABEL, FILE_NAME_DEFAULT, PreferenceType.String),
-				new UltimatePreferenceItem<>(SAVE_IN_SOURCE_DIRECTORY_LABEL, SAVE_IN_SOURCE_DIRECTORY_DEFAULT,
-						PreferenceType.Boolean),
-				new UltimatePreferenceItem<>(UNIQUE_NAME_LABEL, UNIQUE_NAME_DEFAULT, PreferenceType.Boolean),
-
-		};
+		return FilePrinterUtils.getPrinterPreferences("boogiePrinter.bpl");
 	}
 }

--- a/trunk/source/ChcSmtPrinter/src/de/uni_freiburg/informatik/ultimate/chcprinter/ChcSmtPrinterObserver.java
+++ b/trunk/source/ChcSmtPrinter/src/de/uni_freiburg/informatik/ultimate/chcprinter/ChcSmtPrinterObserver.java
@@ -30,10 +30,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import de.uni_freiburg.informatik.ultimate.chcprinter.preferences.ChcSmtPrinterPreferenceInitializer;
 import de.uni_freiburg.informatik.ultimate.core.lib.observers.BaseObserver;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
-import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceProvider;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
 import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
@@ -96,7 +95,9 @@ public class ChcSmtPrinterObserver extends BaseObserver {
 		final HcSymbolTable symbolTable = annot.getSymbolTable();
 		final ManagedScript mgdScript = annot.getScript();
 
-		final File file = openTempFile(root);
+		final var outputFileSettings =
+				FilePrinterUtils.OutputFileSettings.fromPrinterPreferences(mPref, "ChcSmtPrinter_", "_UID", ".smt2");
+		final File file = FilePrinterUtils.openOutputFile(outputFileSettings, root, mLogger);
 		mLogger.info("Writing to file " + file.getAbsolutePath());
 		final LoggingScript loggingScript = new LoggingScript(new NoopScript(), file.getAbsolutePath(), true, USE_CSE);
 
@@ -133,51 +134,5 @@ public class ChcSmtPrinterObserver extends BaseObserver {
 		}
 
 		return true;
-	}
-
-	private File openTempFile(final IElement root) {
-		String path;
-		if (mPref.getBoolean(ChcSmtPrinterPreferenceInitializer.SAVE_IN_SOURCE_DIRECTORY_LABEL)) {
-			final ILocation loc = ILocation.getAnnotation(root);
-			final File inputFile = new File(loc.getFileName());
-			if (inputFile.isDirectory()) {
-				path = inputFile.getPath();
-			} else {
-				path = inputFile.getParent();
-			}
-			if (path == null) {
-				mLogger.warn("Model does not provide a valid source location, falling back to default dump path...");
-				path = mPref.getString(ChcSmtPrinterPreferenceInitializer.DUMP_PATH_LABEL);
-			}
-		} else {
-			path = mPref.getString(ChcSmtPrinterPreferenceInitializer.DUMP_PATH_LABEL);
-		}
-
-		if (mPref.getBoolean(ChcSmtPrinterPreferenceInitializer.UNIQUE_NAME_LABEL)) {
-			try {
-				return File.createTempFile(
-						"ChcSmtPrinter_" + new File(ILocation.getAnnotation(root).getFileName()).getName() + "_UID",
-						".smt2", new File(path));
-			} catch (final IOException e) {
-				throw new IllegalStateException("Could not create temporary file", e);
-			}
-		}
-
-		final String filename = mPref.getString(ChcSmtPrinterPreferenceInitializer.FILE_NAME_LABEL);
-		final File file = new File(path + File.separatorChar + filename);
-
-		if (file.exists()) {
-			if (!file.isFile() || !file.canWrite()) {
-				throw new IllegalStateException("Cannot write to " + file.getAbsolutePath());
-			}
-			mLogger.info("File already exists and will be overwritten: " + file.getAbsolutePath());
-		} else {
-			try {
-				file.createNewFile();
-			} catch (final IOException e) {
-				throw new IllegalStateException("Could not create file: " + file.toString(), e);
-			}
-		}
-		return file;
 	}
 }

--- a/trunk/source/ChcSmtPrinter/src/de/uni_freiburg/informatik/ultimate/chcprinter/preferences/ChcSmtPrinterPreferenceInitializer.java
+++ b/trunk/source/ChcSmtPrinter/src/de/uni_freiburg/informatik/ultimate/chcprinter/preferences/ChcSmtPrinterPreferenceInitializer.java
@@ -28,36 +28,16 @@ package de.uni_freiburg.informatik.ultimate.chcprinter.preferences;
 
 import de.uni_freiburg.informatik.ultimate.chcprinter.Activator;
 import de.uni_freiburg.informatik.ultimate.core.lib.preferences.UltimatePreferenceInitializer;
-import de.uni_freiburg.informatik.ultimate.core.model.preferences.PreferenceType;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.preferences.UltimatePreferenceItem;
 
 public class ChcSmtPrinterPreferenceInitializer extends UltimatePreferenceInitializer {
-
-	public static final String SAVE_IN_SOURCE_DIRECTORY_LABEL = "Save file in source directory";
-	private static final boolean SAVE_IN_SOURCE_DIRECTORY_DEFAULT = false;
-
-	public static final String UNIQUE_NAME_LABEL = "Use automatic naming";
-	private static final boolean UNIQUE_NAME_DEFAULT = false;
-
-	public static final String DUMP_PATH_LABEL = "Dump path";
-	private static final String DUMP_PATH_DEFAULT = System.getProperty("java.io.tmpdir");
-
-	public static final String FILE_NAME_LABEL = "File name";
-	private static final String FILE_NAME_DEFAULT = "chcSmtPrinter.smt2";
-
 	public ChcSmtPrinterPreferenceInitializer() {
 		super(Activator.PLUGIN_ID, Activator.PLUGIN_NAME);
 	}
 
 	@Override
 	protected UltimatePreferenceItem<?>[] initDefaultPreferences() {
-		return new UltimatePreferenceItem<?>[] {
-				new UltimatePreferenceItem<>(DUMP_PATH_LABEL, DUMP_PATH_DEFAULT, PreferenceType.Directory),
-				new UltimatePreferenceItem<>(FILE_NAME_LABEL, FILE_NAME_DEFAULT, PreferenceType.String),
-				new UltimatePreferenceItem<>(SAVE_IN_SOURCE_DIRECTORY_LABEL, SAVE_IN_SOURCE_DIRECTORY_DEFAULT,
-						PreferenceType.Boolean),
-				new UltimatePreferenceItem<>(UNIQUE_NAME_LABEL, UNIQUE_NAME_DEFAULT, PreferenceType.Boolean),
-
-		};
+		return FilePrinterUtils.getPrinterPreferences("chcSmtPrinter.smt2");
 	}
 }

--- a/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/util/FilePrinterUtils.java
+++ b/trunk/source/Library-UltimateCore/src/de/uni_freiburg/informatik/ultimate/core/lib/util/FilePrinterUtils.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 Dominik Klumpp (klumpp@informatik.uni-freiburg.de)
+ * Copyright (C) 2026 École Polytechnique
+ *
+ * This file is part of the ULTIMATE Core.
+ *
+ * The ULTIMATE Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ULTIMATE Core. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7:
+ * If you modify the ULTIMATE Core, or any covered work, by linking
+ * or combining it with Eclipse RCP (or a modified version of Eclipse RCP),
+ * containing parts covered by the terms of the Eclipse Public License, the
+ * licensors of the ULTIMATE Core grant you additional permission
+ * to convey the resulting work.
+ */
+package de.uni_freiburg.informatik.ultimate.core.lib.util;
+
+import java.io.File;
+import java.io.IOException;
+
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceProvider;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.PreferenceType;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.UltimatePreferenceItem;
+import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
+
+public class FilePrinterUtils {
+	private FilePrinterUtils() {
+		// static utility class cannot be instantiated
+	}
+
+	private static final String SAVE_IN_SOURCE_DIRECTORY_LABEL = "Save file in source directory";
+	private static final String AUTOMATIC_NAMING_LABEL = "Use automatic naming";
+	private static final String OUTPUT_DIRECTORY_LABEL = "Output directory";
+	private static final String OUTPUTFILE_NAME_LABEL = "Output file name";
+
+	public static UltimatePreferenceItem<?>[] getPrinterPreferences(final String defaultFileName) {
+		return new UltimatePreferenceItem<?>[] {
+				new UltimatePreferenceItem<>(OUTPUT_DIRECTORY_LABEL, System.getProperty("java.io.tmpdir"),
+						PreferenceType.Directory),
+				new UltimatePreferenceItem<>(OUTPUTFILE_NAME_LABEL, defaultFileName, PreferenceType.String),
+				new UltimatePreferenceItem<>(SAVE_IN_SOURCE_DIRECTORY_LABEL, false, PreferenceType.Boolean),
+				new UltimatePreferenceItem<>(AUTOMATIC_NAMING_LABEL, false, PreferenceType.Boolean),
+
+		};
+	}
+
+	public record OutputFileSettings(boolean saveInSourceDirectory, boolean automaticNaming, String outputDirectory,
+			String outputFileName, String automaticPrefix, String automaticSuffix, String automaticExtension) {
+		// simple record, typically populated from preferences (and fixed prefix, suffix and extension)
+
+		public static OutputFileSettings fromPrinterPreferences(final IPreferenceProvider prefs,
+				final String automaticPrefix, final String automaticSuffix, final String automaticExtension) {
+			return new OutputFileSettings(
+					// preference-based settings
+					prefs.getBoolean(SAVE_IN_SOURCE_DIRECTORY_LABEL), prefs.getBoolean(AUTOMATIC_NAMING_LABEL),
+					prefs.getString(OUTPUT_DIRECTORY_LABEL), prefs.getString(OUTPUTFILE_NAME_LABEL),
+
+					// fixed prefix, suffix and extension
+					automaticPrefix, automaticSuffix, automaticExtension);
+		}
+	}
+
+	public static File openOutputFile(final OutputFileSettings settings, final IElement root, final ILogger logger) {
+		return openOutputFile(settings, ILocation.getAnnotation(root).getFileName(), logger);
+	}
+
+	public static File openOutputFile(final OutputFileSettings settings, final String inputFileName,
+			final ILogger logger) {
+		final String path = getDumpPath(settings, inputFileName, logger);
+		if (settings.automaticNaming()) {
+			try {
+				return File.createTempFile(
+						settings.automaticPrefix() + new File(inputFileName).getName() + settings.automaticSuffix(),
+						settings.automaticExtension(), new File(path));
+			} catch (final IOException e) {
+				logger.fatal("Could not create temporary file");
+				throw new IllegalStateException("Could not create temporary file", e);
+			}
+		}
+
+		final File file = new File(path + File.separatorChar + settings.outputFileName());
+
+		if (file.exists()) {
+			if (!file.isFile() || !file.canWrite()) {
+				logger.fatal("Cannot write to " + file.getAbsolutePath());
+				throw new IllegalStateException("Cannot write to " + file.getAbsolutePath());
+			}
+			logger.warn("File already exists and will be overwritten: " + file.getAbsolutePath());
+			return file;
+		}
+
+		// As the file does not yet exist, try to create it.
+		try {
+			file.createNewFile();
+		} catch (final IOException e) {
+			logger.fatal("Could not create file: " + file.getAbsolutePath(), e);
+			throw new IllegalStateException("Could not create file: " + file.toString(), e);
+		}
+		return file;
+	}
+
+	private static String getDumpPath(final OutputFileSettings settings, final String inputFileName,
+			final ILogger logger) {
+		if (settings.saveInSourceDirectory()) {
+			final File inputFile = new File(inputFileName);
+			final String path = inputFile.isDirectory() ? inputFile.getPath() : inputFile.getParent();
+			if (path != null) {
+				return path;
+			}
+			logger.warn("Model does not provide a valid source location, falling back to output directory %s",
+					settings.outputDirectory());
+		}
+		return settings.outputDirectory();
+	}
+}

--- a/trunk/source/ReqPrinter/src/de/uni_freiburg/informatik/ultimate/req/printer/ReqPrinterObserver.java
+++ b/trunk/source/ReqPrinter/src/de/uni_freiburg/informatik/ultimate/req/printer/ReqPrinterObserver.java
@@ -31,9 +31,8 @@
 package de.uni_freiburg.informatik.ultimate.req.printer;
 
 import java.io.BufferedWriter;
-import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -41,8 +40,8 @@ import java.util.List;
 
 import de.uni_freiburg.informatik.ultimate.boogie.ast.Unit;
 import de.uni_freiburg.informatik.ultimate.core.lib.models.ObjectContainer;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
-import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
 import de.uni_freiburg.informatik.ultimate.core.model.models.ModelType;
 import de.uni_freiburg.informatik.ultimate.core.model.observers.IUnmanagedObserver;
 import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
@@ -51,7 +50,6 @@ import de.uni_freiburg.informatik.ultimate.lib.srparse.pattern.DeclarationPatter
 import de.uni_freiburg.informatik.ultimate.lib.srparse.pattern.DeclarationPattern.VariableCategory;
 import de.uni_freiburg.informatik.ultimate.lib.srparse.pattern.PatternType;
 import de.uni_freiburg.informatik.ultimate.pea2boogie.PatternContainer;
-import de.uni_freiburg.informatik.ultimate.req.printer.preferences.PreferenceInitializer;
 
 /**
  * @author hoenicke
@@ -115,55 +113,18 @@ public class ReqPrinterObserver implements IUnmanagedObserver {
 	}
 
 	private PrintWriter openTempFile(final IElement root) {
-		final String path = getPath(root);
+		final var prefs = mServices.getPreferenceProvider(Activator.PLUGIN_ID);
+		final var outputFileSettings = FilePrinterUtils.OutputFileSettings.fromPrinterPreferences(prefs,
+				ReqPrinter.class.getSimpleName() + "_", "_UID", ".req");
+		final var file = FilePrinterUtils.openOutputFile(outputFileSettings, root, mLogger);
+
+		mLogger.info("Writing to file " + file.getAbsolutePath());
 		try {
-			final File file;
-			if (mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-					.getBoolean(PreferenceInitializer.UNIQUE_NAME_LABEL)) {
-				file = File.createTempFile(
-						ReqPrinter.class.getSimpleName() + "_"
-								+ new File(ILocation.getAnnotation(root).getFileName()).getName() + "_UID",
-						".req", new File(path));
-			} else {
-				final String filename = mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-						.getString(PreferenceInitializer.FILE_NAME_LABEL);
-				file = new File(path + File.separatorChar + filename);
-				if ((!file.isFile() || !file.canWrite()) && file.exists()) {
-					mLogger.warn("Cannot write to: " + file.getAbsolutePath());
-					return null;
-				}
-
-				if (file.exists()) {
-					mLogger.info("File already exists and will be overwritten: " + file.getAbsolutePath());
-				}
-				file.createNewFile();
-			}
-			mLogger.info("Writing to file " + file.getAbsolutePath());
 			return new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file))), false);
-
-		} catch (final IOException e) {
-			mLogger.fatal("Cannot open file", e);
-			return null;
+		} catch (final FileNotFoundException e) {
+			mLogger.fatal("Cannot find file: " + file.getAbsolutePath(), e);
+			throw new IllegalStateException("Cannot find file: " + file.toString(), e);
 		}
-	}
-
-	private String getPath(final IElement root) {
-		if (mServices.getPreferenceProvider(Activator.PLUGIN_ID)
-				.getBoolean(PreferenceInitializer.SAVE_IN_SOURCE_DIRECTORY_LABEL)) {
-			final ILocation loc = ILocation.getAnnotation(root);
-			final File inputFile = new File(loc.getFileName());
-			final String path;
-			if (inputFile.isDirectory()) {
-				path = inputFile.getPath();
-			} else {
-				path = inputFile.getParent();
-			}
-			if (path != null) {
-				return path;
-			}
-			mLogger.warn("Model does not provide a valid source location, falling back to default dump path...");
-		}
-		return mServices.getPreferenceProvider(Activator.PLUGIN_ID).getString(PreferenceInitializer.DUMP_PATH_LABEL);
 	}
 
 	@Override

--- a/trunk/source/ReqPrinter/src/de/uni_freiburg/informatik/ultimate/req/printer/preferences/PreferenceInitializer.java
+++ b/trunk/source/ReqPrinter/src/de/uni_freiburg/informatik/ultimate/req/printer/preferences/PreferenceInitializer.java
@@ -27,41 +27,17 @@
 package de.uni_freiburg.informatik.ultimate.req.printer.preferences;
 
 import de.uni_freiburg.informatik.ultimate.core.lib.preferences.UltimatePreferenceInitializer;
-import de.uni_freiburg.informatik.ultimate.core.model.preferences.PreferenceType;
+import de.uni_freiburg.informatik.ultimate.core.lib.util.FilePrinterUtils;
 import de.uni_freiburg.informatik.ultimate.core.model.preferences.UltimatePreferenceItem;
 import de.uni_freiburg.informatik.ultimate.req.printer.Activator;
 
 public class PreferenceInitializer extends UltimatePreferenceInitializer {
-
-	public static final String SAVE_IN_SOURCE_DIRECTORY_LABEL = "Save file in source directory";
-	private static final boolean SAVE_IN_SOURCE_DIRECTORY_DEFAULT = false;
-	private static final String SAVE_IN_SOURCE_DIRECTORY_DESC = null;
-
-	public static final String UNIQUE_NAME_LABEL = "Use automatic naming";
-	private static final boolean UNIQUE_NAME_DEFAULT = false;
-	private static final String UNIQUE_NAME_DESC = null;
-
-	public static final String DUMP_PATH_LABEL = "Output directory";
-	private static final String DUMP_PATH_DEFAULT = System.getProperty("java.io.tmpdir");
-	private static final String DUMP_PATH_DESC = null;
-
-	public static final String FILE_NAME_LABEL = "Output file name";
-	private static final String FILE_NAME_DEFAULT = "requirements.req";
-	private static final String FILE_NAME_DESC = null;
-
 	public PreferenceInitializer() {
 		super(Activator.PLUGIN_ID, Activator.PLUGIN_NAME);
 	}
 
 	@Override
 	protected UltimatePreferenceItem<?>[] initDefaultPreferences() {
-		return new UltimatePreferenceItem<?>[] {
-				new UltimatePreferenceItem<>(DUMP_PATH_LABEL, DUMP_PATH_DEFAULT, DUMP_PATH_DESC,
-						PreferenceType.Directory),
-				new UltimatePreferenceItem<>(FILE_NAME_LABEL, FILE_NAME_DEFAULT, FILE_NAME_DESC, PreferenceType.String),
-				new UltimatePreferenceItem<>(SAVE_IN_SOURCE_DIRECTORY_LABEL, SAVE_IN_SOURCE_DIRECTORY_DEFAULT,
-						SAVE_IN_SOURCE_DIRECTORY_DESC, PreferenceType.Boolean),
-				new UltimatePreferenceItem<>(UNIQUE_NAME_LABEL, UNIQUE_NAME_DEFAULT, UNIQUE_NAME_DESC,
-						PreferenceType.Boolean), };
+		return FilePrinterUtils.getPrinterPreferences("requirements.req");
 	}
 }


### PR DESCRIPTION
Our various printer plugins (`BoogiePrinter`, `ChcSmtPrinter`, `ReqPrinter`) have very similar settings, and the code using these settings has been copy-pasted from one plugin to the other.

This PR removes these duplications and unifies the setting names (which differed slightly). I chose the setting names as used by `ReqPrinter`, as they seemed the sanest choice (no unnecessary special characters like `?` and `:`, cleaner naming i.e. "output" instead of "dump").

---

(The context: In the branch `wip/dk/civlized-OG` we are working on another plugin which will get the same settings and logic; and I didn't want to copy-paste the code yet another time.)