### PR TITLE
Add setting to remove unnecessary labels

### DIFF
--- a/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/cfg/CfgBuilder.java
+++ b/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/cfg/CfgBuilder.java
@@ -760,7 +760,7 @@ public class CfgBuilder {
 					mRemovedAssumeTrueStatements++;
 					continue;
 				}
-				if (st instanceof final Label laSt && BoogieUtils.isAuxiliaryLabel(laSt)) {
+				if (st instanceof final Label laSt && canLabelBeRemoved(laSt)) {
 					final int gotoTarget = mGotoTargetCounter.getOrDefault(laSt.getName(), 0);
 					if (gotoTarget == 0) {
 						// not target of a goto
@@ -810,6 +810,11 @@ public class CfgBuilder {
 				currentLocation = endStatementSequence((StatementSequence) currentLocation);
 			}
 			return currentLocation;
+		}
+
+		private boolean canLabelBeRemoved(final Label label) {
+			return mServices.getPreferenceProvider(Activator.PLUGIN_ID).getBoolean(
+					IcfgPreferenceInitializer.LABEL_REMOVE_UNNECESSARY_LABELS) || BoogieUtils.isAuxiliaryLabel(label);
 		}
 
 		private BoogieIcfgLocation buildIf(final BoogieIcfgLocation currentLocation, final IfStatement st) {

--- a/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/preferences/IcfgPreferenceInitializer.java
+++ b/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/preferences/IcfgPreferenceInitializer.java
@@ -102,6 +102,9 @@ public class IcfgPreferenceInitializer extends UltimatePreferenceInitializer {
 	public static final String LABEL_CNF = "Convert code blocks to CNF";
 	public static final String LABEL_REMOVE_GOTO_EDGES = "Remove goto edges from ICFG";
 	public static final String LABEL_REMOVE_UNNECESSARY_LABELS = "Remove unnecessary labels from ICFG";
+	private static final String DESC_REMOVE_UNNECESSARY_LABELS =
+			"If this option is enabled, any label that has no corresponding goto, or whose goto appears only on the line preceding the label, is removed and not preserved in the ICFG. "
+					+ "Otherwise, this optimization is only applied for auxiliary labels.";
 	public static final String LABEL_DUMP_TO_FILE = "Dump SMT script to file";
 	public static final String LABEL_COMPRESS_SMT_DUMP_FILE = "Compress dumped SMT script";
 	public static final String DESC_COMPRESS_SMT_DUMP_FILE = "Compress the written .smt2 script with GZip";
@@ -145,7 +148,8 @@ public class IcfgPreferenceInitializer extends UltimatePreferenceInitializer {
 				new UltimatePreferenceItem<>(LABEL_CONTEXT_SWITCH_ONLY_AT_ATOMIC_BOUNDARIES,
 						DEF_CONTEXT_SWITCH_ONLY_AT_ATOMIC_BOUNDARIES, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_REMOVE_GOTO_EDGES, false, PreferenceType.Boolean),
-				new UltimatePreferenceItem<>(LABEL_REMOVE_UNNECESSARY_LABELS, true, PreferenceType.Boolean),
+				new UltimatePreferenceItem<>(LABEL_REMOVE_UNNECESSARY_LABELS, true, DESC_REMOVE_UNNECESSARY_LABELS,
+						PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_SIMPLIFY, false, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_CNF, false, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_SIMPLE_PARTIAL_SKOLEMIZATION, DEF_SIMPLE_PARTIAL_SKOLEMIZATION,

--- a/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/preferences/IcfgPreferenceInitializer.java
+++ b/trunk/source/IcfgBuilder/src/de/uni_freiburg/informatik/ultimate/plugins/generator/icfgbuilder/preferences/IcfgPreferenceInitializer.java
@@ -101,6 +101,7 @@ public class IcfgPreferenceInitializer extends UltimatePreferenceInitializer {
 	public static final String LABEL_SIMPLIFY = "Simplify code blocks";
 	public static final String LABEL_CNF = "Convert code blocks to CNF";
 	public static final String LABEL_REMOVE_GOTO_EDGES = "Remove goto edges from ICFG";
+	public static final String LABEL_REMOVE_UNNECESSARY_LABELS = "Remove unnecessary labels from ICFG";
 	public static final String LABEL_DUMP_TO_FILE = "Dump SMT script to file";
 	public static final String LABEL_COMPRESS_SMT_DUMP_FILE = "Compress dumped SMT script";
 	public static final String DESC_COMPRESS_SMT_DUMP_FILE = "Compress the written .smt2 script with GZip";
@@ -144,6 +145,7 @@ public class IcfgPreferenceInitializer extends UltimatePreferenceInitializer {
 				new UltimatePreferenceItem<>(LABEL_CONTEXT_SWITCH_ONLY_AT_ATOMIC_BOUNDARIES,
 						DEF_CONTEXT_SWITCH_ONLY_AT_ATOMIC_BOUNDARIES, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_REMOVE_GOTO_EDGES, false, PreferenceType.Boolean),
+				new UltimatePreferenceItem<>(LABEL_REMOVE_UNNECESSARY_LABELS, true, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_SIMPLIFY, false, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_CNF, false, PreferenceType.Boolean),
 				new UltimatePreferenceItem<>(LABEL_SIMPLE_PARTIAL_SKOLEMIZATION, DEF_SIMPLE_PARTIAL_SKOLEMIZATION,


### PR DESCRIPTION
26cbad3 introduced an optimization in `IcfgBuilder` to remove unnecessary labels (i.e., labels without a goto, or where the only goto is immediately preceding the label) from the CFG. However, this optimization was too aggressive: #713 introduced the concept of locations of interest (LOIs), and non-auxiliary labels are meant to be treated as LOIs and should therefore always be preserved in the CFG. This was fixed in e158e9d by restricting the optimization to auxiliary labels only, so non-auxiliary labels are now always kept as LOIs. However, in cases where we are not interested in invariants at labels (e.g. SV-COMP), we'd still like the more aggressive optimization to reduce CFG size.

This PR adds a setting controlling whether the label-removal optimization applies to all labels (not just auxiliary ones), for cases where preserving LOIs at labels isn't required. By default, the setting is enabled, i.e., it behaves the same as before e158e9d. For stricter handling of labels (e.g., if you expect invariants at every label in Referee), you can disable the setting.