### PR TITLE
Add GraphPrinter plugin for DOT format graph output

### DIFF
--- a/trunk/source/BA_FeatureUltimateCommon/feature.xml
+++ b/trunk/source/BA_FeatureUltimateCommon/feature.xml
@@ -83,6 +83,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter"
+         version="0.0.0"/>
+
+   <plugin
          id="de.uni_freiburg.informatik.ultimate.boogie.procedureinliner"
          version="0.0.0"/>
 

--- a/trunk/source/BA_MavenParentUltimate/pom.xml
+++ b/trunk/source/BA_MavenParentUltimate/pom.xml
@@ -288,6 +288,7 @@
 		<module>../IRSDependencies</module>
 		<module>../JavaCup</module>
 		<module>../JungVisualization</module>
+		<module>../GraphPrinter</module>
 		<module>../LassoRanker</module>
 		<module>../Library-AcceleratedInterpolation</module>
 		<module>../Library-ApacheCommonsCLI</module>

--- a/trunk/source/GraphPrinter/.classpath
+++ b/trunk/source/GraphPrinter/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/trunk/source/GraphPrinter/.project
+++ b/trunk/source/GraphPrinter/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>GraphPrinter</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/trunk/source/GraphPrinter/META-INF/MANIFEST.MF
+++ b/trunk/source/GraphPrinter/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: GraphPrinter
+Bundle-SymbolicName: de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter;singleton:=true
+Bundle-Vendor: Ultimate Program Analysis Team
+Bundle-Version: 0.3.1
+Require-Bundle: de.uni_freiburg.informatik.ultimate.lib.core,
+ de.uni_freiburg.informatik.ultimate.core,
+ de.uni_freiburg.informatik.ultimate.lib.icfg
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-Activator: de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.Activator
+Automatic-Module-Name: de.uni.freiburg.informatik.ultimate.plugins.output.graphprinter

--- a/trunk/source/GraphPrinter/build.properties
+++ b/trunk/source/GraphPrinter/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = plugin.xml,\
+               META-INF/,\
+               .

--- a/trunk/source/GraphPrinter/plugin.xml
+++ b/trunk/source/GraphPrinter/plugin.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.2"?>
+<plugin>
+	<extension point="de.uni_freiburg.informatik.ultimate.ep.output">
+		<impl class="de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.GraphPrinter" />
+	</extension>
+</plugin>

--- a/trunk/source/GraphPrinter/pom.xml
+++ b/trunk/source/GraphPrinter/pom.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (C) 2026 Manuel Bentele
+
+    This file is part of the ULTIMATE GraphPrinter plug-in.
+
+    The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+    GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+    General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+    plug-in. If not, see <http://www.gnu.org/licenses/>.
+
+    Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+    covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+    covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+    additional permission to convey the resulting work.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter</artifactId>
+  <packaging>eclipse-plugin</packaging>
+
+  <parent>
+  	<groupId>de.uni_freiburg.informatik.ultimate</groupId>
+  	<artifactId>mavenparent</artifactId>
+  	<version>0.3.1</version>
+  	<relativePath>../BA_MavenParentUltimate</relativePath>
+  </parent>
+
+</project>

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/Activator.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/Activator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter;
+
+import org.eclipse.core.runtime.Plugin;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ *
+ * @author Manuel Bentele
+ */
+public class Activator extends Plugin {
+
+	public static final String PLUGIN_ID = GraphPrinter.class.getPackage().getName();
+	public static final String PLUGIN_NAME = "Graph Printer";
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/GraphPrinter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/GraphPrinter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter;
+
+import java.util.Collections;
+import java.util.List;
+
+import de.uni_freiburg.informatik.ultimate.core.model.IOutput;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ModelType;
+import de.uni_freiburg.informatik.ultimate.core.model.observers.IObserver;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceInitializer;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceProvider;
+import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
+import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceInitializer;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues;
+
+/**
+ * GraphPrinter is an {@link IOutput} plugin that prints graph structures (AST, CFG, interpolant automata, etc.) in DOT
+ * (Graphviz) format to files. It works like JungVisualization but does not require a GUI.
+ *
+ * @author Manuel Bentele
+ */
+public class GraphPrinter implements IOutput {
+
+	public static final String PLUGIN_ID = Activator.PLUGIN_ID;
+
+	private ILogger mLogger;
+	private ModelType mGraphType;
+	private IUltimateServiceProvider mServices;
+
+	@Override
+	public List<String> getDesiredToolIds() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<IObserver> getObservers() {
+		return Collections.singletonList(new GraphPrinterObserver(mLogger, mGraphType, mServices));
+	}
+
+	@Override
+	public ModelQuery getModelQuery() {
+		final IPreferenceProvider ups = mServices.getPreferenceProvider(getPluginID());
+		return ups.getEnum(GraphPrinterPreferenceValues.LABEL_GRAPH_MODEL, ModelQuery.class);
+	}
+
+	@Override
+	public void setInputDefinition(final ModelType graphType) {
+		mGraphType = graphType;
+	}
+
+	@Override
+	public String getPluginName() {
+		return Activator.PLUGIN_NAME;
+	}
+
+	@Override
+	public String getPluginID() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public void init() {
+		// not needed
+	}
+
+	@Override
+	public boolean isGuiRequired() {
+		return false;
+	}
+
+	@Override
+	public IPreferenceInitializer getPreferences() {
+		return new GraphPrinterPreferenceInitializer();
+	}
+
+	@Override
+	public void setServices(final IUltimateServiceProvider services) {
+		mLogger = services.getLoggingService().getLogger(Activator.PLUGIN_ID);
+		mServices = services;
+	}
+
+	@Override
+	public void finish() {
+		// not needed
+	}
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/GraphPrinterObserver.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/GraphPrinterObserver.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import de.uni_freiburg.informatik.ultimate.core.lib.models.VisualizationEdge;
+import de.uni_freiburg.informatik.ultimate.core.lib.models.VisualizationNode;
+import de.uni_freiburg.informatik.ultimate.core.model.models.IElement;
+import de.uni_freiburg.informatik.ultimate.core.model.models.IVisualizable;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ModelType;
+import de.uni_freiburg.informatik.ultimate.core.model.observers.IUnmanagedObserver;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.IPreferenceProvider;
+import de.uni_freiburg.informatik.ultimate.core.model.services.ILogger;
+import de.uni_freiburg.informatik.ultimate.core.model.services.IUltimateServiceProvider;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.IGraphFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot.DotFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * Observer that traverses {@link VisualizationNode} graphs and writes them to files using an {@link IGraphFormatter}.
+ *
+ * The observer checks if the root {@link IElement} is {@link IVisualizable}, obtains the {@link VisualizationNode} via
+ * {@link IVisualizable#getVisualizationGraph()}, and performs a traversal to collect all nodes and edges. The resulting
+ * graph is written to a file using an {@link IGraphFormatter} formatter.
+ *
+ * @author Manuel Bentele
+ */
+public class GraphPrinterObserver implements IUnmanagedObserver {
+
+	private final ILogger mLogger;
+	private final ModelType mInputGraphType;
+	private final IUltimateServiceProvider mServices;
+
+	private IGraphFormatter mFormatter;
+	private final Map<VisualizationNode, String> mNodeIds;
+	private final Set<VisualizationNode> mVisitedNodes;
+	private final Map<VisualizationEdge, Boolean> mSeenEdges;
+	private int mNodeCounter;
+
+	public GraphPrinterObserver(final ILogger logger, final ModelType graphType,
+			final IUltimateServiceProvider services) {
+		mLogger = logger;
+		mInputGraphType = graphType;
+		mServices = services;
+
+		mNodeIds = new HashMap<>();
+		mVisitedNodes = new LinkedHashSet<>();
+		mSeenEdges = new HashMap<>();
+		mNodeCounter = 0;
+	}
+
+	@Override
+	public void init(final ModelType modelType, final int currentModelIndex, final int numberOfModels) {
+		final IPreferenceProvider prefs = mServices.getPreferenceProvider(GraphPrinter.PLUGIN_ID);
+		final AnnotationMode annotationMode =
+				prefs.getEnum(GraphPrinterPreferenceValues.LABEL_GRAPH_ANNOTATION_MODE, AnnotationMode.class);
+
+		mFormatter = new DotFormatter(annotationMode);
+		mFormatter.setGraphName(getGraphName(modelType));
+
+		mNodeIds.clear();
+		mVisitedNodes.clear();
+		mSeenEdges.clear();
+		mNodeCounter = 0;
+	}
+
+	@Override
+	public boolean process(final IElement root) {
+		if (root instanceof final IVisualizable visu) {
+			final IVisualizable<?> visualizationGraph = visu.getVisualizationGraph();
+			if (visualizationGraph instanceof final VisualizationNode rootNode) {
+				dfstraverse(rootNode);
+				return false;
+			}
+		}
+
+		mLogger.error("Model is not visualizable: " + root);
+		return false;
+	}
+
+	@Override
+	public void finish() {
+		if (mFormatter == null || mVisitedNodes.isEmpty()) {
+			return;
+		}
+
+		writeFile();
+	}
+
+	private void writeFile() {
+		final Path outputPath = constructOutputPath();
+		try {
+			mLogger.info("Write graph to " + outputPath);
+			mFormatter.writeFile(outputPath);
+		} catch (final IOException e) {
+			mLogger.error("Could not write graph file: " + outputPath, e);
+		}
+	}
+
+	private Path constructOutputPath() {
+		final IPreferenceProvider prefs = mServices.getPreferenceProvider(GraphPrinter.PLUGIN_ID);
+		final String directory = prefs.getString(GraphPrinterPreferenceValues.LABEL_GRAPH_DIRECTORY);
+		final String filename = prefs.getString(GraphPrinterPreferenceValues.LABEL_GRAPH_FILENAME);
+		final boolean besidesInputFile = prefs.getBoolean(GraphPrinterPreferenceValues.LABEL_GRAPH_BESIDES_INPUT_FILE);
+
+		String basePath;
+		if (besidesInputFile && mInputGraphType != null && mInputGraphType.getNumberOfFiles() > 0) {
+			basePath = mInputGraphType.getAbsolutePath(0);
+		} else {
+			basePath = directory + File.separator + filename;
+		}
+
+		final String suffix = getModelTypeSuffix(mInputGraphType);
+		return Path.of(basePath + "_" + suffix + mFormatter.getFileEnding());
+	}
+
+	private void dfstraverse(final VisualizationNode node) {
+		final String nodeId = getOrCreateNodeId(node);
+		mFormatter.addNode(nodeId, getNodeLabel(node), NodeInfoExtractor.extractNodeInfo(node));
+		mVisitedNodes.add(node);
+
+		final List<VisualizationNode> children = node.getOutgoingNodes();
+		if (children != null) {
+			for (final VisualizationNode child : children) {
+				final String childId = getOrCreateNodeId(child);
+				for (final VisualizationEdge edge : node.getOutgoingEdges()) {
+					if (edge.getTarget().equals(child) && !mSeenEdges.containsKey(edge)) {
+						mFormatter.addEdge(nodeId, childId, getEdgeLabel(edge), NodeInfoExtractor.extractEdgeInfo(edge));
+						mSeenEdges.put(edge, true);
+					}
+				}
+			}
+
+			for (final VisualizationNode child : children) {
+				if (!mVisitedNodes.contains(child)) {
+					dfstraverse(child);
+				}
+			}
+		}
+	}
+
+	private String getOrCreateNodeId(final VisualizationNode node) {
+		return mNodeIds.computeIfAbsent(node, k -> "node" + Integer.toString(mNodeCounter++));
+	}
+
+	private static String getNodeLabel(final VisualizationNode node) {
+		final Object backing = node.getBacking();
+		if (backing != null) {
+			return improveLabel(backing.toString(), backing);
+		}
+
+		return improveLabel(node.toString(), node);
+	}
+
+	/**
+	 * Returns a meaningful label for a {@link VisualizationEdge}.
+	 *
+	 * Uses the edge's {@code toString()} (which delegates to the backing object). If the result looks like a default
+	 * {@link Object#toString()} (i.e., {@code ClassName@hexhash}), the simple class name of the backing is used
+	 * instead.
+	 *
+	 * @param edge
+	 *            The visualization edge.
+	 * @return A human-readable label for the edge.
+	 */
+	private static String getEdgeLabel(final VisualizationEdge edge) {
+		final String rawLabel = edge.toString();
+		final Object backing = edge.getBacking();
+		return improveLabel(rawLabel, backing);
+	}
+
+	/**
+	 * Improves a label by checking if it looks like a default {@link Object#toString()} output (pattern
+	 * {@code ClassName@hexhash}). If so, the simple class name of the backing object is used instead.
+	 *
+	 * @param rawLabel
+	 *            The original label string.
+	 * @param backing
+	 *            The backing object, used to determine the simple class name. May be {@code null}.
+	 * @return An improved label, or the original if it does not look like a default toString.
+	 */
+	private static String improveLabel(final String rawLabel, final Object backing) {
+		if (rawLabel == null || rawLabel.isEmpty()) {
+			return backing != null ? backing.getClass().getSimpleName() : "";
+		}
+
+		// Check for default Object.toString() pattern: ClassName@hexhash
+		if (rawLabel.matches("^[^@]+@[0-9a-fA-F]+$")) {
+			return backing != null ? backing.getClass().getSimpleName() : rawLabel;
+		}
+
+		return rawLabel;
+	}
+
+	private static String getGraphName(final ModelType graphType) {
+		if (graphType == null) {
+			return "graph";
+		}
+
+		final StringBuilder sb = new StringBuilder();
+		final String[] parts = graphType.getCreator().split("\\.");
+
+		if (parts.length - 1 > 0) {
+			sb.append(parts[parts.length - 1]);
+		} else {
+			sb.append(graphType.getCreator());
+		}
+
+		return sb.toString();
+	}
+
+	private static String getModelTypeSuffix(final ModelType graphType) {
+		if (graphType == null || graphType.getType() == null) {
+			return "graph";
+		}
+
+		return graphType.getType().name();
+	}
+
+	@Override
+	public boolean performedChanges() {
+		return false;
+	}
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/NodeInfoExtractor.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/NodeInfoExtractor.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import de.uni_freiburg.informatik.ultimate.core.lib.models.VisualizationEdge;
+import de.uni_freiburg.informatik.ultimate.core.lib.models.VisualizationNode;
+import de.uni_freiburg.informatik.ultimate.core.model.models.ILocation;
+import de.uni_freiburg.informatik.ultimate.core.model.models.IPayload;
+import de.uni_freiburg.informatik.ultimate.core.model.models.annotation.IAnnotations;
+import de.uni_freiburg.informatik.ultimate.lib.icfg.BoogieIcfgContainer;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.NodeInfo;
+
+/**
+ * Extracts metadata from {@link VisualizationNode}s and {@link VisualizationEdge}s into a tree of {@link NodeInfo}s.
+ *
+ * <p>
+ * The extracted tree contains all payload annotations from {@link IPayload#getAnnotations()}, with each
+ * {@link IAnnotations} expanded into its {@code toString()} representation. Special rendering is applied to known types
+ * such as {@link ILocation} (showing line and column numbers).
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public final class NodeInfoExtractor {
+
+	private NodeInfoExtractor() {
+	}
+
+	/**
+	 * Extracts metadata from a {@link VisualizationNode}.
+	 *
+	 * @param node
+	 *            The visualization node.
+	 * @return An {@link NodeInfo} tree, or {@code null} if no metadata is available.
+	 */
+	public static NodeInfo extractNodeInfo(final VisualizationNode node) {
+		if (node == null) {
+			return null;
+		}
+
+		final List<NodeInfo> sections = new ArrayList<>();
+
+		if (node.hasPayload()) {
+			final NodeInfo annotationSection = createAnnotationSection(node.getPayload());
+			if (annotationSection != null) {
+				sections.add(annotationSection);
+			}
+		}
+
+		return new NodeInfo("info", sections);
+	}
+
+	/**
+	 * Extracts metadata from a {@link VisualizationEdge}.
+	 *
+	 * @param edge
+	 *            The visualization edge.
+	 * @return An {@link NodeInfo} tree, or {@code null} if no metadata is available.
+	 */
+	public static NodeInfo extractEdgeInfo(final VisualizationEdge edge) {
+		if (edge == null) {
+			return null;
+		}
+
+		final List<NodeInfo> sections = new ArrayList<>();
+
+		if (edge.hasPayload()) {
+			final NodeInfo annotationSection = createAnnotationSection(edge.getPayload());
+			if (annotationSection != null) {
+				sections.add(annotationSection);
+			}
+		}
+
+		return new NodeInfo("info", sections);
+	}
+
+	private static NodeInfo createAnnotationSection(final IPayload payload) {
+		if (payload == null || !payload.hasAnnotation()) {
+			return null;
+		}
+
+		final List<NodeInfo> children = new ArrayList<>();
+		for (final Map.Entry<String, IAnnotations> entry : payload.getAnnotations().entrySet()) {
+			final IAnnotations annotation = entry.getValue();
+			if (annotation == null) {
+				continue;
+			}
+
+			if (annotation instanceof BoogieIcfgContainer) {
+				continue;
+			}
+
+			children.add(convertValue(getShortClassName(entry.getKey()), annotation));
+		}
+
+		return children.isEmpty() ? null : new NodeInfo("Annotations", children);
+	}
+
+	private static String getShortClassName(final String name) {
+		final String[] parts = name.split("\\.");
+
+		if (parts.length - 1 > 0) {
+			return parts[parts.length - 1];
+		}
+
+		return new String();
+	}
+
+	private static NodeInfo convertValue(final String name, final Object value) {
+		if (value == null) {
+			return new NodeInfo(name, "null");
+		}
+
+		if (value instanceof final ILocation loc) {
+			return convertLocation(name, loc);
+		}
+
+		return new NodeInfo(name, String.valueOf(value));
+	}
+
+	private static NodeInfo convertLocation(final String name, final ILocation loc) {
+		return new NodeInfo(name, String.format("L%d:%d – L%d:%d", loc.getStartLine(), loc.getStartColumn(),
+				loc.getEndLine(), loc.getEndColumn()));
+	}
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/IGraphFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/IGraphFormatter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot.DotFormatter;
+
+/**
+ * Interface for graph formatters that can build a graph representation from nodes and edges and write it to a file.
+ *
+ * Implementations include {@link DotFormatter} for the DOT (Graphviz) format. Other implementations could support
+ * GraphML, JSON, or other graph serialization formats.
+ *
+ * @author Manuel Bentele
+ */
+public interface IGraphFormatter {
+
+	/**
+	 * Sets the name of the graph.
+	 *
+	 * @param name
+	 *            The graph name.
+	 */
+	void setGraphName(String name);
+
+	/**
+	 * Adds a node to the graph representation.
+	 *
+	 * @param id
+	 *            The unique identifier of the node.
+	 * @param label
+	 *            The human-readable label of the node.
+	 */
+	void addNode(String id, String label);
+
+	/**
+	 * Adds a node with metadata to the graph representation.
+	 *
+	 * @param id
+	 *            The unique identifier of the node.
+	 * @param label
+	 *            The human-readable label of the node.
+	 * @param info
+	 *            A tree of metadata extracted from the node, or {@code null} if no metadata is available.
+	 */
+	void addNode(String id, String label, NodeInfo info);
+
+	/**
+	 * Adds a directed edge to the graph representation.
+	 *
+	 * @param sourceId
+	 *            The identifier of the source node.
+	 * @param targetId
+	 *            The identifier of the target node.
+	 * @param label
+	 *            The human-readable label of the edge, or {@code null} if the edge has no label.
+	 */
+	void addEdge(String sourceId, String targetId, String label);
+
+	/**
+	 * Adds a directed edge with metadata to the graph representation.
+	 *
+	 * @param sourceId
+	 *            The identifier of the source node.
+	 * @param targetId
+	 *            The identifier of the target node.
+	 * @param label
+	 *            The human-readable label of the edge, or {@code null} if the edge has no label.
+	 * @param info
+	 *            A tree of metadata extracted from the edge, or {@code null} if no metadata is available.
+	 */
+	void addEdge(String sourceId, String targetId, String label, NodeInfo info);
+
+	/**
+	 * Returns the file ending (including the leading dot) used by this formatter for output files.
+	 *
+	 * @return The file ending, e.g. {@code ".dot"}.
+	 */
+	String getFileEnding();
+
+	/**
+	 * Returns the string representation of the graph in the formatter's format.
+	 *
+	 * @return The formatted graph string.
+	 */
+	String getString();
+
+	/**
+	 * Writes the graph representation to a file at the given path.
+	 *
+	 * @param path
+	 *            The path where the file should be written.
+	 * @throws IOException
+	 *             If writing the file fails.
+	 */
+	void writeFile(Path path) throws IOException;
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/LabelFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/LabelFormatter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * Strategy interface for formatting node and edge labels in DOT output.
+ *
+ * <p>
+ * Each {@link AnnotationMode} has a corresponding {@link LabelFormatter} implementation that controls how labels and
+ * metadata ({@link NodeInfo}) are rendered in the DOT file.
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public interface LabelFormatter {
+
+	/**
+	 * Formats a node label, optionally enriched with metadata.
+	 *
+	 * @param label
+	 *            The primary label text.
+	 * @param info
+	 *            The metadata tree, or {@code null} if no metadata is available.
+	 * @return The DOT attribute value for the node label (without surrounding brackets or {@code label=} prefix).
+	 */
+	String formatNodeLabel(String label, NodeInfo info);
+
+	/**
+	 * Formats an edge label, optionally enriched with metadata.
+	 *
+	 * @param label
+	 *            The primary label text, or {@code null}/{@code ""} if the edge has no label.
+	 * @param info
+	 *            The metadata tree, or {@code null} if no metadata is available.
+	 * @return The DOT attribute value for the edge label (without surrounding brackets or {@code label=} prefix), or
+	 *         {@code null} if the edge should have no label attribute at all.
+	 */
+	String formatEdgeLabel(String label, NodeInfo info);
+
+	/**
+	 * Returns additional DOT node declarations (e.g. record nodes) that should be emitted alongside the main node.
+	 *
+	 * @param nodeId
+	 *            The DOT identifier of the node.
+	 * @param label
+	 *            The primary label text.
+	 * @param info
+	 *            The metadata tree, or {@code null}.
+	 * @return A list of additional DOT node declaration strings, or an empty list if none.
+	 */
+	default java.util.List<String> additionalNodeDeclarations(final String nodeId, final String label,
+			final NodeInfo info) {
+		return java.util.List.of();
+	}
+
+	/**
+	 * Returns additional DOT edge declarations (e.g. edges to record nodes) that should be emitted alongside the main
+	 * edge.
+	 *
+	 * @param sourceId
+	 *            The DOT identifier of the source node.
+	 * @param targetId
+	 *            The DOT identifier of the target node.
+	 * @param label
+	 *            The primary label text.
+	 * @param info
+	 *            The metadata tree, or {@code null}.
+	 * @return A list of additional DOT edge declaration strings, or an empty list if none.
+	 */
+	default java.util.List<String> additionalEdgeDeclarations(final String sourceId, final String targetId,
+			final String label, final NodeInfo info) {
+		return java.util.List.of();
+	}
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/NodeInfo.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/NodeInfo.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter;
+
+import java.util.List;
+
+/**
+ * A recursive tree data structure representing metadata extracted from graph nodes and edges.
+ *
+ * <p>
+ * An {@link #NodeInfo} is either a <em>leaf</em> node with a name and a string value, or a <em>group</em> node with a
+ * name and a list of child {@link #NodeInfo}s. This structure mirrors the tree shown in the Eclipse NodeView by
+ * {@link AnnotationTreeProvider}, with sections like "IElement" (containing class name, hash code, and
+ * {@code @Visualizable} fields/methods) and "Annotations" (containing payload annotations).
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public final class NodeInfo {
+
+	private final String mName;
+	private final String mValue;
+	private final List<NodeInfo> mChildren;
+
+	/**
+	 * Creates a leaf node with a name and a value.
+	 *
+	 * @param name
+	 *            The name of this entry.
+	 * @param value
+	 *            The string value of this entry, may be {@code null}.
+	 */
+	public NodeInfo(final String name, final String value) {
+		mName = name;
+		mValue = value;
+		mChildren = List.of();
+	}
+
+	/**
+	 * Creates a group node with a name and children.
+	 *
+	 * @param name
+	 *            The name of this group.
+	 * @param children
+	 *            The child nodes of this group.
+	 */
+	public NodeInfo(final String name, final List<NodeInfo> children) {
+		mName = name;
+		mValue = null;
+		mChildren = children != null ? List.copyOf(children) : List.of();
+	}
+
+	/**
+	 * @return The name of this node.
+	 */
+	public String getName() {
+		return mName;
+	}
+
+	/**
+	 * @return The string value of this leaf node, or {@code null} if this is a group node.
+	 */
+	public String getValue() {
+		return mValue;
+	}
+
+	/**
+	 * @return The children of this group node, or an empty list if this is a leaf node.
+	 */
+	public List<NodeInfo> getChildren() {
+		return mChildren;
+	}
+
+	/**
+	 * @return {@code true} if this node has no children (i.e., is a leaf node).
+	 */
+	public boolean isLeaf() {
+		return mChildren.isEmpty();
+	}
+
+	/**
+	 * @return {@code true} if this node has children (i.e., is a group node).
+	 */
+	public boolean isGroup() {
+		return !mChildren.isEmpty();
+	}
+
+	/**
+	 * @return {@code true} if this node has a non-{@code null} value.
+	 */
+	public boolean hasValue() {
+		return mValue != null;
+	}
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotFormatter.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.IGraphFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.LabelFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.NodeInfo;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * A standalone {@link IGraphFormatter} implementation that produces DOT (Graphviz) format output.
+ *
+ * <p>
+ * Supports three annotation output modes via {@link AnnotationMode}, each backed by a dedicated {@link LabelFormatter}:
+ * </p>
+ * <ul>
+ * <li>{@link AnnotationMode#NONE}: no annotations in the output ({@link DotPlainLabelFormatter})</li>
+ * <li>{@link AnnotationMode#HTML_LABELS}: annotations are embedded as HTML labels ({@link DotHtmlLabelFormatter})</li>
+ * <li>{@link AnnotationMode#RECORD_NODES}: annotations are rendered as separate record nodes
+ * ({@link DotRecordLabelFormatter})</li>
+ * </ul>
+ *
+ * <p>
+ * All plain-text labels are escaped for DOT compatibility: backslashes, double quotes, newlines, and carriage returns
+ * are escaped. HTML labels use DOT HTML-like string formatting and are not escaped the same way.
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public class DotFormatter implements IGraphFormatter {
+
+	private static final String NODE_FILL_COLOR = "#E8F0FE";
+	static final String RECORD_FILL_COLOR = "#F0F0F0";
+
+	private String mGraphName;
+	private final List<String> mNodeDeclarations;
+	private final List<String> mEdgeDeclarations;
+	private LabelFormatter mLabelFormatter;
+
+	public DotFormatter() {
+		this(AnnotationMode.NONE);
+	}
+
+	public DotFormatter(final AnnotationMode annotationMode) {
+		mGraphName = "graph";
+		mNodeDeclarations = new ArrayList<>();
+		mEdgeDeclarations = new ArrayList<>();
+		setAnnotationMode(Objects.requireNonNull(annotationMode));
+	}
+
+	/**
+	 * Sets the annotation output mode and selects the corresponding {@link LabelFormatter}.
+	 *
+	 * @param annotationMode
+	 *            The mode, must not be {@code null}.
+	 */
+	public void setAnnotationMode(final AnnotationMode annotationMode) {
+		mLabelFormatter = switch (Objects.requireNonNull(annotationMode)) {
+		case NONE -> new DotPlainLabelFormatter();
+		case HTML_LABELS -> new DotHtmlLabelFormatter();
+		case RECORD_NODES -> new DotRecordLabelFormatter();
+		};
+	}
+
+	@Override
+	public void setGraphName(final String name) {
+		mGraphName = Objects.requireNonNullElse(name, "graph");
+	}
+
+	@Override
+	public void addNode(final String id, final String label) {
+		addNode(id, label, null);
+	}
+
+	@Override
+	public void addNode(final String id, final String label, final NodeInfo info) {
+		final String formattedLabel = mLabelFormatter.formatNodeLabel(label, info);
+		final boolean isHtml = mLabelFormatter instanceof DotHtmlLabelFormatter && info != null && info.isGroup();
+		mNodeDeclarations.add(id + " [" + nodeAttributes(formattedLabel, !isHtml, NODE_FILL_COLOR) + "];");
+		mNodeDeclarations.addAll(mLabelFormatter.additionalNodeDeclarations(id, label, info));
+	}
+
+	@Override
+	public void addEdge(final String sourceId, final String targetId, final String label) {
+		addEdge(sourceId, targetId, label, (NodeInfo) null);
+	}
+
+	@Override
+	public void addEdge(final String sourceId, final String targetId, final String label, final NodeInfo info) {
+		final String formattedLabel = mLabelFormatter.formatEdgeLabel(label, info);
+		if (formattedLabel == null) {
+			mEdgeDeclarations.add(sourceId + " -> " + targetId + ";");
+		} else {
+			final boolean isHtml = mLabelFormatter instanceof DotHtmlLabelFormatter && info != null && info.isGroup();
+			mEdgeDeclarations.add(sourceId + " -> " + targetId + " [" + labelAttribute(formattedLabel, !isHtml) + "];");
+		}
+
+		mEdgeDeclarations.addAll(mLabelFormatter.additionalEdgeDeclarations(sourceId, targetId, label, info));
+	}
+
+	@Override
+	public String getFileEnding() {
+		return ".dot";
+	}
+
+	@Override
+	public String getString() {
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append("digraph \"").append(escapeDotString(mGraphName)).append("\" {\n");
+		sb.append("    node [shape=box];\n");
+		for (final String nodeDecl : mNodeDeclarations) {
+			sb.append("    ").append(nodeDecl).append("\n");
+		}
+		for (final String edgeDecl : mEdgeDeclarations) {
+			sb.append("    ").append(edgeDecl).append("\n");
+		}
+		sb.append("}\n");
+
+		return sb.toString();
+	}
+
+	@Override
+	public void writeFile(final Path path) throws IOException {
+		Files.createDirectories(path.getParent());
+		Files.write(path, getString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Builds a DOT label attribute string.
+	 *
+	 * @param label
+	 *            The formatted label text.
+	 * @param quote
+	 *            Whether to wrap the label in double quotes. Use {@code false} for HTML labels.
+	 * @return The DOT attribute string.
+	 */
+	static String labelAttribute(final String label, final boolean quote) {
+		return quote ? "label=\"" + label + "\"" : "label=" + label;
+	}
+
+	/**
+	 * Builds DOT node attributes with label, fill style, and fill color.
+	 *
+	 * @param label
+	 *            The formatted label text.
+	 * @param quote
+	 *            Whether to wrap the label in double quotes. Use {@code false} for HTML labels.
+	 * @param fillColor
+	 *            The fill color (e.g. {@code #E8F0FE}).
+	 * @return The DOT attribute string.
+	 */
+	static String nodeAttributes(final String label, final boolean quote, final String fillColor) {
+		return labelAttribute(label, quote) + ", style=filled, fillcolor=\"" + fillColor + "\"";
+	}
+
+	/**
+	 * Escapes a string for safe use inside DOT double-quoted labels.
+	 *
+	 * @param input
+	 *            The raw string to escape.
+	 * @return The escaped string, or an empty string if {@code input} is {@code null}.
+	 */
+	static String escapeDotString(final String input) {
+		if (input == null) {
+			return "";
+		}
+
+		return input.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+	}
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotHtmlLabelFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotHtmlLabelFormatter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot;
+
+import java.util.List;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.LabelFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.NodeInfo;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * {@link LabelFormatter} for {@link AnnotationMode#HTML_LABELS}.
+ *
+ * <p>
+ * Embeds metadata as DOT HTML-like labels on nodes and edges, using nested HTML tables with section headers, group
+ * headers, and key-value leaf entries.
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public final class DotHtmlLabelFormatter implements LabelFormatter {
+
+	@Override
+	public String formatNodeLabel(final String label, final NodeInfo info) {
+		if (info == null || !info.isGroup()) {
+			return DotFormatter.escapeDotString(label);
+		}
+
+		return buildHtmlLabel(label, info, false);
+	}
+
+	@Override
+	public String formatEdgeLabel(final String label, final NodeInfo info) {
+		if (info == null || !info.isGroup()) {
+			if (label == null || label.isEmpty()) {
+				return null;
+			}
+			return DotFormatter.escapeDotString(label);
+		}
+
+		return buildHtmlLabel(label, info, true);
+	}
+
+	private static String buildHtmlLabel(final String label, final NodeInfo info, final boolean bordered) {
+		final String innerBorder = bordered ? "1" : "0";
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append("<");
+		sb.append("<table border=\"0\" cellborder=\"0\" cellspacing=\"0\">");
+		sb.append("<tr><td align=\"left\"><b>").append(escapeHtml(label)).append("</b></td></tr>");
+		sb.append("<tr><td>");
+		sb.append("<table border=\"").append(innerBorder).append("\" cellborder=\"0\" cellspacing=\"0\">");
+		for (final NodeInfo section : info.getChildren()) {
+			sb.append("<tr><td align=\"left\" colspan=\"2\"><b>").append(escapeHtml(section.getName()))
+					.append("</b></td></tr>");
+
+			renderHtmlChildren(sb, section.getChildren(), 1);
+		}
+		sb.append("</table>");
+		sb.append("</td></tr>");
+		sb.append("</table>>");
+
+		return sb.toString();
+	}
+
+	private static void renderHtmlChildren(final StringBuilder sb, final List<NodeInfo> children, final int depth) {
+		for (final NodeInfo child : children) {
+			if (child.isLeaf()) {
+				sb.append("<tr>");
+				sb.append("<td align=\"left\">").append(escapeHtml(child.getName())).append("</td>");
+				sb.append("<td align=\"left\">").append(escapeHtml(child.getValue())).append("</td>");
+				sb.append("</tr>");
+			} else {
+				final String indent = "&nbsp;".repeat(Math.max(0, depth) * 2);
+
+				sb.append("<tr>");
+				sb.append("<td align=\"left\" colspan=\"2\"><i>").append(indent).append(escapeHtml(child.getName()))
+						.append("</i></td>");
+				sb.append("</tr>");
+
+				renderHtmlChildren(sb, child.getChildren(), depth + 1);
+			}
+		}
+	}
+
+	private static String escapeHtml(final String input) {
+		if (input == null) {
+			return "";
+		}
+
+		return input.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br/>")
+				.replace("\r", "");
+	}
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotPlainLabelFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotPlainLabelFormatter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.LabelFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.NodeInfo;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * {@link LabelFormatter} for {@link AnnotationMode#NONE}.
+ *
+ * <p>
+ * Ignores all metadata and produces plain quoted DOT labels.
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public final class DotPlainLabelFormatter implements LabelFormatter {
+
+	@Override
+	public String formatNodeLabel(final String label, final NodeInfo info) {
+		return DotFormatter.escapeDotString(label);
+	}
+
+	@Override
+	public String formatEdgeLabel(final String label, final NodeInfo info) {
+		if (label == null || label.isEmpty()) {
+			return null;
+		}
+
+		return DotFormatter.escapeDotString(label);
+	}
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotRecordLabelFormatter.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/formatter/dot/DotRecordLabelFormatter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.dot;
+
+import java.util.List;
+
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.LabelFormatter;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.formatter.NodeInfo;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * {@link LabelFormatter} for {@link AnnotationMode#RECORD_NODES}.
+ *
+ * <p>
+ * Renders metadata as separate DOT record nodes connected to the parent node/edge via dashed edges. The primary node
+ * keeps a plain label; the record node contains the flattened metadata tree.
+ * </p>
+ *
+ * @author Manuel Bentele
+ */
+public final class DotRecordLabelFormatter implements LabelFormatter {
+
+	@Override
+	public String formatNodeLabel(final String label, final NodeInfo info) {
+		return DotFormatter.escapeDotString(label);
+	}
+
+	@Override
+	public String formatEdgeLabel(final String label, final NodeInfo info) {
+		if (label == null || label.isEmpty()) {
+			return null;
+		}
+
+		return DotFormatter.escapeDotString(label);
+	}
+
+	@Override
+	public List<String> additionalNodeDeclarations(final String nodeId, final String label, final NodeInfo info) {
+		if (info == null || !info.isGroup()) {
+			return List.of();
+		}
+
+		final String recordId = nodeId + "_info";
+		final String recordAttrs = DotFormatter.nodeAttributes(
+				"{" + DotFormatter.escapeDotString(label) + " information|" + buildRecordFields(info) + "}", true,
+				DotFormatter.RECORD_FILL_COLOR);
+		final String recordNode = recordId + " [shape=record, " + recordAttrs + "];";
+		final String recordEdge = nodeId + " -> " + recordId + " [style=dashed, color=gray, dir=none];";
+
+		return List.of(recordNode, recordEdge);
+	}
+
+	@Override
+	public List<String> additionalEdgeDeclarations(final String sourceId, final String targetId, final String label,
+			final NodeInfo info) {
+		if (info == null || !info.isGroup()) {
+			return List.of();
+		}
+
+		final String recordId = sourceId + "_" + targetId + "_info";
+		final String recordAttrs = DotFormatter.nodeAttributes("{Edge information|" + buildRecordFields(info) + "}",
+				true, DotFormatter.RECORD_FILL_COLOR);
+		final String recordNode = recordId + " [shape=record, " + recordAttrs + "];";
+		final String recordEdge = sourceId + " -> " + recordId + " [style=dashed, color=gray, dir=none];";
+
+		return List.of(recordNode, recordEdge);
+	}
+
+	private static String buildRecordFields(final NodeInfo info) {
+		final StringBuilder sb = new StringBuilder();
+		boolean first = true;
+
+		for (final NodeInfo section : info.getChildren()) {
+			if (!first) {
+				sb.append("|");
+			}
+
+			first = false;
+
+			sb.append("{").append(DotFormatter.escapeDotString(section.getName())).append("|{");
+			flattenRecordFields(sb, section.getChildren());
+			sb.append("}}");
+		}
+
+		return sb.toString();
+	}
+
+	private static void flattenRecordFields(final StringBuilder sb, final List<NodeInfo> children) {
+		boolean first = true;
+
+		for (final NodeInfo child : children) {
+			if (child.isLeaf()) {
+				if (!first) {
+					sb.append("|");
+				}
+
+				first = false;
+
+				sb.append(DotFormatter.escapeDotString(child.getName())).append(": ")
+						.append(DotFormatter.escapeDotString(child.getValue()));
+			} else {
+				if (!first) {
+					sb.append("|");
+				}
+
+				first = false;
+
+				sb.append("{").append(DotFormatter.escapeDotString(child.getName())).append("|{");
+				flattenRecordFields(sb, child.getChildren());
+				sb.append("}}");
+			}
+		}
+	}
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/preferences/GraphPrinterPreferenceInitializer.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/preferences/GraphPrinterPreferenceInitializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences;
+
+import de.uni_freiburg.informatik.ultimate.core.lib.preferences.UltimatePreferenceInitializer;
+import de.uni_freiburg.informatik.ultimate.core.model.ITool.ModelQuery;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.PreferenceType;
+import de.uni_freiburg.informatik.ultimate.core.model.preferences.UltimatePreferenceItem;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.Activator;
+import de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences.GraphPrinterPreferenceValues.AnnotationMode;
+
+/**
+ * Preference initializer for the GraphPrinter plug-in.
+ *
+ * @author Manuel Bentele
+ */
+public class GraphPrinterPreferenceInitializer extends UltimatePreferenceInitializer {
+
+	public GraphPrinterPreferenceInitializer() {
+		super(Activator.PLUGIN_ID, Activator.PLUGIN_NAME);
+	}
+
+	@Override
+	protected UltimatePreferenceItem<?>[] initDefaultPreferences() {
+		return new UltimatePreferenceItem<?>[] {
+				new UltimatePreferenceItem<>(GraphPrinterPreferenceValues.LABEL_GRAPH_DIRECTORY,
+						GraphPrinterPreferenceValues.DEF_GRAPH_DIRECTORY,
+						GraphPrinterPreferenceValues.DESC_GRAPH_DIRECTORY, PreferenceType.Directory),
+				new UltimatePreferenceItem<>(GraphPrinterPreferenceValues.LABEL_GRAPH_FILENAME,
+						GraphPrinterPreferenceValues.DEF_GRAPH_FILENAME,
+						GraphPrinterPreferenceValues.DESC_GRAPH_FILENAME, PreferenceType.String),
+				new UltimatePreferenceItem<>(GraphPrinterPreferenceValues.LABEL_GRAPH_BESIDES_INPUT_FILE,
+						GraphPrinterPreferenceValues.DEF_GRAPH_BESIDES_INPUT_FILE,
+						GraphPrinterPreferenceValues.DESC_GRAPH_BESIDES_INPUT_FILE, PreferenceType.Boolean),
+				new UltimatePreferenceItem<>(GraphPrinterPreferenceValues.LABEL_GRAPH_MODEL,
+						GraphPrinterPreferenceValues.DEF_GRAPH_MODEL, GraphPrinterPreferenceValues.DESC_GRAPH_MODEL,
+						PreferenceType.Combo, ModelQuery.values()),
+				new UltimatePreferenceItem<>(GraphPrinterPreferenceValues.LABEL_GRAPH_ANNOTATION_MODE,
+						GraphPrinterPreferenceValues.DEF_GRAPH_ANNOTATION_MODE,
+						GraphPrinterPreferenceValues.DESC_GRAPH_ANNOTATION_MODE, PreferenceType.Combo,
+						AnnotationMode.values()) };
+	}
+
+}

--- a/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/preferences/GraphPrinterPreferenceValues.java
+++ b/trunk/source/GraphPrinter/src/de/uni_freiburg/informatik/ultimate/plugins/output/graphprinter/preferences/GraphPrinterPreferenceValues.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 Manuel Bentele
+ *
+ * This file is part of the ULTIMATE GraphPrinter plug-in.
+ *
+ * The ULTIMATE GraphPrinter plug-in is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ULTIMATE GraphPrinter plug-in is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with the ULTIMATE GraphPrinter
+ * plug-in. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Additional permission under GNU GPL version 3 section 7: If you modify the ULTIMATE GraphPrinter plug-in, or any
+ * covered work, by linking or combining it with Eclipse RCP (or a modified version of Eclipse RCP), containing parts
+ * covered by the terms of the Eclipse Public License, the licensors of the ULTIMATE GraphPrinter plug-in grant you
+ * additional permission to convey the resulting work.
+ */
+
+package de.uni_freiburg.informatik.ultimate.plugins.output.graphprinter.preferences;
+
+import de.uni_freiburg.informatik.ultimate.core.model.ITool.ModelQuery;
+
+/**
+ * Contains labels and default values for the GraphPrinter preference page.
+ *
+ * @author Manuel Bentele
+ */
+public class GraphPrinterPreferenceValues {
+
+	/**
+	 * Annotation output mode for the graph.
+	 */
+	public enum AnnotationMode {
+		/**
+		 * No annotations are included in the formatted graph output.
+		 */
+		NONE,
+
+		/**
+		 * Annotations are included as HTML labels on nodes and edges.
+		 */
+		HTML_LABELS,
+
+		/**
+		 * Annotations are included as separate record nodes connected to their parent.
+		 */
+		RECORD_NODES
+	}
+
+	public static final String LABEL_GRAPH_DIRECTORY = "Graph directory";
+	public static final String DEF_GRAPH_DIRECTORY = ".";
+	public static final String DESC_GRAPH_DIRECTORY = "Write graph to the specified directory.";
+
+	public static final String LABEL_GRAPH_FILENAME = "Graph filename";
+	public static final String DEF_GRAPH_FILENAME = "graph";
+	public static final String DESC_GRAPH_FILENAME = "The filename of the generated graph (without file-ending).";
+
+	public static final String LABEL_GRAPH_BESIDES_INPUT_FILE = "Write graph besides input file";
+	public static final boolean DEF_GRAPH_BESIDES_INPUT_FILE = true;
+	public static final String DESC_GRAPH_BESIDES_INPUT_FILE = "Write graph as \"<inputfilename>_<modeltype>.dot\" "
+			+ "in the same directory as the input file. If disabled, the graph is written to the specified graph "
+			+ "directory.";
+
+	public static final String LABEL_GRAPH_MODEL = "Graph model to be printed";
+	public static final ModelQuery DEF_GRAPH_MODEL = ModelQuery.LAST;
+	public static final String DESC_GRAPH_MODEL = "Selects which models are printed by this plugin. "
+			+ "ALL prints every model, LAST only the last modified one.";
+
+	public static final String LABEL_GRAPH_ANNOTATION_MODE = "Graph annotation mode";
+	public static final AnnotationMode DEF_GRAPH_ANNOTATION_MODE = AnnotationMode.HTML_LABELS;
+	public static final String DESC_GRAPH_ANNOTATION_MODE = "Controls how annotations from nodes and edges are "
+			+ "included in the graph output. NONE omits annotations, HTML_LABELS embeds them as HTML labels, "
+			+ "RECORD_NODES creates separate record nodes connected to each node/edge.";
+
+}


### PR DESCRIPTION
Create a new **GraphPrinter** plugin that prints `IElement` data structures (AST, CFG, interpolant automata, etc.) in DOT (Graphviz) format to files. The plugin works like `JungVisualization` but is headless (`isGuiRequired()` returns false), making it usable in both GUI and CLI modes.

The plugin uses the same `IVisualizable` -> `VisualizationNode` -> `DFS traversal` pattern as `JungVisualization`, but writes DOT output to a file instead of displaying in a JUNG viewer. Node labels use the full object's `toString()` without truncation.

Preferences follow Ultimate's well-known dump pattern:

  - Graph directory (default: current directory)
  - Graph filename (default: "graph")
  - Write graph besides input file (default: true)
  - Which models to print (default: `LAST`, configurable like `JungVisualization`)

An annotation output mode controls how metadata and annotations from `VisualizationNode` and `VisualizationEdge` payloads are included in the DOT output:

  - `NONE`: no annotations in the output (like before)
  - `HTML_LABELS`:  annotations are embedded as DOT HTML-like labels on nodes and edges, showing the label followed by an HTML table of all annotation key-value pairs (default mode)
  - `RECORD_NODES`: annotations are rendered as separate record nodes connected to their parent node/edge with dashed edges